### PR TITLE
alphabetise gems, remove tzinfo & add dotenv-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,39 +1,35 @@
 source 'https://rubygems.org'
-gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
+gem 'coffee-rails', '~> 4.2'
+gem 'govuk_elements_rails'
+gem 'govuk_frontend_toolkit'
+gem 'govuk_template'
+gem 'high_voltage'
+gem 'jbuilder', '~> 2.5'
+gem 'jquery-rails'
+gem 'lograge'
 gem 'pg', '~> 0.18'
+gem 'pry-rails'
 gem 'puma', '~> 3.0'
+gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
-gem 'coffee-rails', '~> 4.2'
-
-gem 'jquery-rails'
-gem 'jbuilder', '~> 2.5'
-group :development, :test do
-  gem 'byebug', platform: :mri
-end
 
 group :development do
   gem 'web-console'
   gem 'listen', '~> 3.0.5'
 end
 
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem 'govuk_elements_rails'
-gem 'govuk_frontend_toolkit'
-gem 'govuk_template'
-gem 'high_voltage'
-gem 'lograge'
-gem 'pry-rails'
-group :production do
-  gem 'rails_12factor'
-end
-
 group :development, :test do
+  gem 'byebug', platform: :mri
+  gem 'dotenv-rails'
   gem 'launchy'
   gem 'mutant-rspec'
   gem 'pry-byebug'
   gem 'rspec-rails'
+end
+
+group :production do
+  gem 'rails_12factor'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,10 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     equalizer (0.0.11)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -305,6 +309,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   database_cleaner
+  dotenv-rails
   factory_girl_rails
   fuubar
   govuk_elements_rails
@@ -330,7 +335,6 @@ DEPENDENCIES
   shoulda
   simplecov
   simplecov-rcov
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console
 


### PR DESCRIPTION
This fixes tests refusing to run because there is
no config/database.yml file

tzinfo is not necessary