### PR TITLE
Use appeal.valid_for_costing? in CostDeterminer

### DIFF
--- a/app/services/cost_determiner.rb
+++ b/app/services/cost_determiner.rb
@@ -8,7 +8,7 @@ class CostDeterminer
   end
 
   def run
-    raise InvalidAppealError unless appeal.valid?
+    raise InvalidAppealError unless appeal.valid_for_costing?
 
     case appeal.appeal_about
     when :income_tax

--- a/spec/services/cost_determiner_spec.rb
+++ b/spec/services/cost_determiner_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe CostDeterminer do
-  let(:appeal_attrs) { { valid?: true } }
+  let(:appeal_attrs) { { valid_for_costing?: true } }
   let(:appeal) { double(appeal_attrs) }
 
   subject { described_class.new(appeal) }
 
   context "when appeal is invalid" do
-    let(:appeal_attrs) { super().merge(valid?: false) }
+    let(:appeal_attrs) { super().merge(valid_for_costing?: false) }
 
     it "raises bad appeal error" do
       expect{ subject.run }.to raise_error(InvalidAppealError)


### PR DESCRIPTION
The appeal will *always* be 'invalid' when we are
determining its cost, because it won't have
contact details, etc. 
So, we need a more specific property that returns
true if the appeal is in a state where we are able
to figure out how much it will cost.