### PR TITLE
Modify routes to be more human-readable

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,14 @@
+STEPS = [
+  :did_challenge_hmrc
+]
+
 Rails.application.routes.draw do
   namespace :steps do
-    [
-      :did_challenge_hmrc
-    ].each do |ctrlr|
-      resources ctrlr, only: [:edit, :update]
+    STEPS.each do |step_resource|
+      resource step_resource,
+        only:       [:edit, :update],
+        controller: step_resource,
+        path_names: { edit: '' }
     end
   end
 end


### PR DESCRIPTION
This changes the routes from plural resources to a singular resource per step - which makes more sense semantically. It also changes the path name for 'edit' to a blank string and cleans up the routes file a bit.

So we go from:
`/steps/did_challenge_hmrc/1/edit`

to:
`/steps/did_challenge_hmrc`