### PR TITLE
Add trivial case model & start page

### DIFF
--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -1,0 +1,4 @@
+class StartController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -1,4 +1,11 @@
 class StepController < ApplicationController
   def edit
+    raise 'No tribunal case in session' unless current_tribunal_case
+  end
+
+  private
+
+  def current_tribunal_case
+    @current_tribunal_case ||= TribunalCase.find_by_id(session[:tribunal_case_id])
   end
 end

--- a/app/controllers/steps/did_challenge_hmrc_controller.rb
+++ b/app/controllers/steps/did_challenge_hmrc_controller.rb
@@ -1,9 +1,19 @@
 class Steps::DidChallengeHmrcController < StepController
   def edit
     super
-    @form_object = DidChallengeHmrcForm.new
+    @form_object = DidChallengeHmrcForm.new(current_tribunal_case)
   end
 
   def update
+  end
+
+  private
+
+  def current_tribunal_case
+    # This step, and only this step, should create a tribunal case if
+    # there isn't one in the session - because it's the first
+    super || TribunalCase.create.tap do |tribunal_case|
+      session[:tribunal_case_id] = tribunal_case.id
+    end
   end
 end

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -2,6 +2,12 @@ class BaseForm
   include Virtus.model
   include ActiveModel::Validations
 
+  attr_reader :tribunal_case
+
+  def initialize(tribunal_case)
+    @tribunal_case = tribunal_case
+  end
+
   def to_key
     # Intentionally returns nil so the form builder picks up _only_
     # the class name to generate the HTML attributes.

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,0 +1,2 @@
+class TribunalCase < ApplicationRecord
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,4 +34,20 @@
   </main>
 <% end %>
 
+<% if Rails.env.development? %>
+  <% content_for(:footer_top) do %>
+    <details>
+      <summary><span class="summary">Debug Information</span></summary>
+      <div class="panel panel-border-narrow">
+        <% if @form_object&.tribunal_case %>
+          <h4 class="heading-small">Current Case ID</h4>
+          <p>
+            <%= @form_object.tribunal_case.id %>
+          </p>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
+<% end %>
+
 <%= render template: "layouts/govuk_template" %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -1,0 +1,15 @@
+<h1 class="heading-large">
+  <%=t '.heading' %>
+</h1>
+
+<p class="lede">
+  <%=t '.lead_text' %>
+</p>
+
+<%=t '.description_html' %>
+
+<p>
+  <%= link_to t('.start_now'), edit_steps_did_challenge_hmrc_path, class: 'button button-start', role: 'button' %>
+</p>
+
+<%=t '.further_html' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,152 @@
 en:
+  start:
+    index:
+      heading: Appeal to an independent tax tribunal
+      lead_text: Use this service to settle a tax dispute with HM Revenue and Customs (HMRC).
+      description_html: >
+        <p>The tribunal is <strong>independent of government</strong> and will listen to both sides of the argument before making a decision.</p>
+        <p>For more information see the <a href="https://www.gov.uk/tax-tribunal/overview">guide to tax tribunals and fees</a>.</p>
+        <p>You can make an appeal to the tax tribunal by following each step below.</p>
+
+        <ol class="list list-number util_mt-large">
+          <li>
+            <p><strong>Find out how much your appeal costs</strong> (about 5 minutes to complete)</p>
+            <details role="group">
+              <summary role="button" aria-controls="details-content-0" aria-expanded="false">You will need to pay a fee of £20, £50 or £200 to submit an appeal unless you're eligible for <a href="https://www.gov.uk/get-help-with-court-fees">help with fees</a>.</summary>
+
+              <div class="panel" id="details-content-0" aria-hidden="true">
+                <p>The initial fee to submit your appeal depends on your type of case.</p>
+                <p>You may also have to pay a further fee if your case needs further documents, correspondence and a hearing in person with a judge.</p>
+                <p>The judge has the power to decide whether HMRC should reimburse your fees when they look at your case. The tribunal itself does not have the power to enforce or award costs.</p>
+                <p>Check if you're able to <a href="https://www.gov.uk/get-help-with-court-fees">get help paying your fees</a> if you’re on a low income or receiving certain benefits.</p>
+
+                <table class="expandable-demo">
+                  <caption>Table explaining the fees for different types of appeals or applications</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Type of appeal or application</th>
+                      <th scope="col">Initial fee</th>
+                      <th scope="col">Further fee</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <ul class="list list-bullet">
+                          <li>Penalty of £100 or less
+                            (e.g. for late self-assessment)</li>
+                        </ul>
+                      </td>
+                      <td>£20</td>
+                      <td>—</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <ul class="list list-bullet">
+                          <li>Penalty of £101 to £2,000
+                            (e.g. for late filing or payment)</li>
+                        </ul>
+                      </td>
+                      <td>£50</td>
+                      <td>—</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <ul class="list list-bullet">
+                          <li>Penalty of £2,001 to £20,000</li>
+                          <li>Inaccurate return (careless)</li>
+                          <li>Information notice</li>
+                          <li>Closure notice</li>
+                          <li>Pay As You Earn (PAYE) coding notice</li>
+                          <li>Apply for a late review with HMRC</li>
+                        </ul>
+                      </td>
+                      <td>£50</td>
+                      <td>£200</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <ul class="list list-bullet">
+                          <li>All other types of appeal or application</li>
+                        </ul>
+                      </td>
+                      <td>£200</td>
+                      <td>£500</td>
+                    </tr>
+                      <tr>
+                      <td>
+                        <ul class="list list-bullet">
+                          <li>Appeals over £1 million or principles of law</li>
+                        </ul>
+                      </td>
+                      <td>£200</td>
+                      <td>£1,000</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          </li>
+
+          <li>
+            <p><strong>Check the deadline to appeal to the tribunal</strong> (5 minutes)</p>
+            <details role="group">
+              <summary role="button" aria-controls="details-content-1" aria-expanded="false">You must appeal within the time stated on your last letter from HMRC. This is usually 30 days.</summary>
+
+              <div class="panel" id="details-content-1" aria-hidden="true">
+                <p>If you haven't challenged HMRC about your dispute you may wish to <a href="https://www.gov.uk/tax-appeals">resolve the matter directly with HMRC</a> at no extra cost before you appeal to the tribunal.</p>
+                <p>For certain types of tax, you must first ask HMRC to look into your case before you can appeal to the tax tribunal.</p>
+                <p><strong>What you will need</strong></p>
+                <ul class="list list-bullet">
+                  <li>date you received your last letter from HMRC</li>
+                  <li>reasons why you're outside the time limit if you want to submit an appeal late</li>
+                </ul>
+              </div>
+            </details>
+          </li>
+          <li>
+            <p><strong>Enter your appeal or application details</strong> (20 minutes)</p>
+            <details role="group">
+              <summary role="button" aria-controls="details-content-2" aria-expanded="false">You will need to include grounds for your appeal and upload a scan or photo of the letters from HMRC.</summary>
+              <div class="panel" id="details-content-2" aria-hidden="true">
+                <p>You will need to provide:</p>
+                <ul class="list list-bullet">
+                  <li>a scan or photo of the original decision letter or review conclusion letter from HMRC</li>
+                  <li>HMRC reference number shown on the letters</li>
+                  <li>details of your representative if you have one</li>
+                  <li>a National Insurance number or VAT registration number depending on your type of appeal</li>
+                </ul>
+              </div>
+            </details>
+          </li>
+          <li>
+            <p><strong>Pay the fee to submit your appeal</strong> (5 minutes)</p>
+            <details role="group">
+              <summary role="button" aria-controls="details-content-3" aria-expanded="false">Your appeal will only be valid once you have paid the initial processing fee.</summary>
+              <div class="panel" id="details-content-3" aria-hidden="true">
+                <p>You can pay:</p>
+                <ul class="list list-bullet">
+                    <li>online using a debit or credit card</li>
+                    <li>enter a <a href="https://www.gov.uk/get-help-with-court-fees">help with fees</a> reference number</li>
+                    <li>send a cheque</li>
+                </ul>
+                <p><strong>What happens next</strong></p>
+                <p>The tax tribunal will process your appeal and decide how your case will proceed. You will usually hear within 14 days about what will happen next and whether you need to appear at a hearing with a judge.</p>
+              </div>
+            </details>
+          </li>
+        </ol>
+      further_html: >
+        <h2 class="heading-medium">Paying for an existing appeal</h2>
+        <p>If you have received a reference number and a confirmation code by email but still need to pay your fee, <a href="/payment_tool/case_requests">you can do that now</a>.</p>
+        <h2 class="heading-medium">Other ways to submit an appeal</h2>
+        <ul class="list list-bullet">
+          <li>You can submit an appeal or application by <a class="external" rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForms.do?court_forms_category=Tax%20(First-tier%20Tribunal)">paper form</a></li>
+          <li>
+            Send your form by post to First-tier Tribunal (Tax Chamber), PO Box 16972, Birmingham, B16 6TZ
+          </li>
+        </ul>
+      start_now: Start now
   steps:
     did_challenge_hmrc:
       edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
         path_names: { edit: '' }
     end
   end
+
+  root to: 'start#index'
 end

--- a/db/migrate/20161025094707_enable_uuid_extension.rb
+++ b/db/migrate/20161025094707_enable_uuid_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidExtension < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end

--- a/db/migrate/20161025094827_create_tribunal_cases.rb
+++ b/db/migrate/20161025094827_create_tribunal_cases.rb
@@ -1,0 +1,9 @@
+class CreateTribunalCases < ActiveRecord::Migration[5.0]
+  def change
+    create_table :tribunal_cases, id: :uuid do |t|
+      t.boolean :did_challenge_hmrc
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20161025094827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
+
+  create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.boolean  "did_challenge_hmrc"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
 
 end

--- a/spec/controllers/steps/did_challenge_hmrc_controller_spec.rb
+++ b/spec/controllers/steps/did_challenge_hmrc_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Steps::DidChallengeHmrcController, type: :controller do
+  describe 'GET /edit' do
+    context 'when no case exists in the session yet' do
+      it 'creates a case and shows the question to the user' do
+        get :edit
+
+        expect(response).to have_http_status(:success)
+        expect(TribunalCase.count).to be(1)
+        expect(session[:tribunal_case_id]).to eq(TribunalCase.first.id)
+      end
+    end
+
+    context 'when a case exists in the session' do
+      it 'uses the existing case and shows the question to the user' do
+        existing_case = TribunalCase.create
+        get :edit, session: { tribunal_case_id: existing_case.id }
+
+        expect(response).to have_http_status(:success)
+        expect(TribunalCase.count).to be(1)
+        expect(session[:tribunal_case_id]).to eq(TribunalCase.first.id)
+      end
+    end
+  end
+end

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe BaseForm do
+  let(:tribunal_case) { double('Tribunal Case') }
+  subject { described_class.new(tribunal_case) }
+
   describe '#persisted?' do
     it 'always returns false' do
       expect(subject.persisted?).to eq(false)

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe TribunalCase, type: :model do
+end


### PR DESCRIPTION
- Add TribunalCase model to represent the progress the user is making through the app while building up their case
- Create a new TribunalCase when the user first navigates to the first step, or reuse it if they already have one
- Add a basic start page copied from the prototype