### PR TITLE
Add basic saving of form object and validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'fuubar'
+  gem 'rails-controller-testing'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
   gem 'shoulda'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -351,6 +355,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   rails_12factor
   rspec-rails
   rubocop

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -8,4 +8,15 @@ class StepController < ApplicationController
   def current_tribunal_case
     @current_tribunal_case ||= TribunalCase.find_by_id(session[:tribunal_case_id])
   end
+
+  def update_and_advance(attr, form_class, opts={})
+    hash = params.fetch(form_class.name.underscore, {})
+    @form_object = form_class.new(hash.merge(tribunal_case: current_tribunal_case))
+
+    if @form_object.save
+      redirect_to root_path
+    else
+      render opts.fetch(:render, :edit)
+    end
+  end
 end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -9,7 +9,7 @@ class StepController < ApplicationController
     @current_tribunal_case ||= TribunalCase.find_by_id(session[:tribunal_case_id])
   end
 
-  def update_and_advance(attr, form_class, opts={})
+  def update_and_advance(form_class, opts={})
     hash = params.fetch(form_class.name.underscore, {})
     @form_object = form_class.new(hash.merge(tribunal_case: current_tribunal_case))
 

--- a/app/controllers/steps/did_challenge_hmrc_controller.rb
+++ b/app/controllers/steps/did_challenge_hmrc_controller.rb
@@ -8,7 +8,7 @@ class Steps::DidChallengeHmrcController < StepController
   end
 
   def update
-    update_and_advance(:did_challenge_hmrc, DidChallengeHmrcForm)
+    update_and_advance(DidChallengeHmrcForm)
   end
 
   private

--- a/app/controllers/steps/did_challenge_hmrc_controller.rb
+++ b/app/controllers/steps/did_challenge_hmrc_controller.rb
@@ -1,10 +1,14 @@
 class Steps::DidChallengeHmrcController < StepController
   def edit
     super
-    @form_object = DidChallengeHmrcForm.new(current_tribunal_case)
+    @form_object = DidChallengeHmrcForm.new(
+      tribunal_case: current_tribunal_case,
+      did_challenge_hmrc: current_tribunal_case.did_challenge_hmrc
+    )
   end
 
   def update
+    update_and_advance(:did_challenge_hmrc, DidChallengeHmrcForm)
   end
 
   private

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -2,10 +2,15 @@ class BaseForm
   include Virtus.model
   include ActiveModel::Validations
 
-  attr_reader :tribunal_case
+  attr_accessor :tribunal_case
 
-  def initialize(tribunal_case)
-    @tribunal_case = tribunal_case
+  def save
+    if valid?
+      persist!
+      true
+    else
+      false
+    end
   end
 
   def to_key
@@ -17,4 +22,12 @@ class BaseForm
   def persisted?
     false
   end
+
+  private
+
+  # :nocov:
+  def persist!
+    raise 'Subclasses of BaseForm need to implement #persist!'
+  end
+  # :nocov:
 end

--- a/app/forms/did_challenge_hmrc_form.rb
+++ b/app/forms/did_challenge_hmrc_form.rb
@@ -1,3 +1,12 @@
 class DidChallengeHmrcForm < BaseForm
   attribute :did_challenge_hmrc, Boolean
+
+  validates_inclusion_of :did_challenge_hmrc, in: [true, false]
+
+  private
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    tribunal_case.update(did_challenge_hmrc: did_challenge_hmrc)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,18 @@ en:
               <li>appeal to an independent tax tribunal within 30 days</li>
             </ul>
             <p>See the <a href="https://www.gov.uk/tax-appeals">guidance from HMRC on how to appeal</a> against a tax decision.</p>
+
+  errors:
+    # WARNING: This means every possible error message must be a full
+    #  English sentence because the attribute name won't be prepended!
+    format: "%{message}"
+  activemodel:
+    errors:
+      models:
+        did_challenge_hmrc_form:
+          attributes:
+            did_challenge_hmrc:
+              inclusion: Select whether you have challenged the decision with HMRC first
   helpers:
     fieldset:
       did_challenge_hmrc_form:

--- a/spec/controllers/steps/did_challenge_hmrc_controller_spec.rb
+++ b/spec/controllers/steps/did_challenge_hmrc_controller_spec.rb
@@ -38,4 +38,34 @@ RSpec.describe Steps::DidChallengeHmrcController, type: :controller do
       end
     end
   end
+
+  describe 'PUT /update' do
+    let(:did_challenge_hmrc_form) { instance_double(DidChallengeHmrcForm) }
+
+    before do
+      expect(DidChallengeHmrcForm).to receive(:new).and_return(did_challenge_hmrc_form)
+    end
+
+    context 'when the form saves successfully' do
+      before do
+        expect(did_challenge_hmrc_form).to receive(:save).and_return(true)
+      end
+
+      it 'redirects to the start page' do
+        put :update
+        expect(subject).to redirect_to(root_path)
+      end
+    end
+
+    context 'when the form fails to save' do
+      before do
+        expect(did_challenge_hmrc_form).to receive(:save).and_return(false)
+      end
+
+      it 'renders the question page again' do
+        put :update
+        expect(subject).to render_template(:edit)
+      end
+    end
+  end
 end

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe BaseForm do
-  let(:tribunal_case) { double('Tribunal Case') }
-  subject { described_class.new(tribunal_case) }
-
   describe '#persisted?' do
     it 'always returns false' do
       expect(subject.persisted?).to eq(false)

--- a/spec/forms/did_challenge_hmrc_form_spec.rb
+++ b/spec/forms/did_challenge_hmrc_form_spec.rb
@@ -1,4 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe DidChallengeHmrcForm do
+  let(:arguments) { {
+    tribunal_case:      tribunal_case,
+    did_challenge_hmrc: did_challenge_hmrc
+  } }
+  let(:tribunal_case)      { instance_double(TribunalCase, did_challenge_hmrc: nil) }
+  let(:did_challenge_hmrc) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case) { nil }
+      let(:did_challenge_hmrc) { true }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when did_challenge_hmrc is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:did_challenge_hmrc]).to_not be_empty
+      end
+    end
+
+    context 'when did_challenge_hmrc is not valid' do
+      let(:did_challenge_hmrc) { 'wibble' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:did_challenge_hmrc]).to_not be_empty
+      end
+    end
+
+    context 'when did_challenge_hmrc is valid' do
+      let(:did_challenge_hmrc) { true }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with( did_challenge_hmrc: true)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Allow the form object to be saved and to persist its value to the case model instance
- Validate user input for the HMRC challenge form
- Change validation I18n to exclude attribute names because otherwise we can't provide sensible English error messages
- Include semi-deprecated 'rails-controller-testing' gem to allow testing of controllers in a Rails 4 style way until we figure out a way of controller testing more in line with the New Way(tm)