### PR TITLE
Basic endpoint support for decision tree

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
   AllCops:
+    TargetRubyVersion: 2.3
     DisabledByDefault: true
   Lint/AmbiguousOperator:
     Description: >-

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -1,0 +1,5 @@
+class DecisionsController < ApplicationController
+  def show
+    @decision = params[:id]
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < ApplicationController
+  def destroy
+    reset_session
+    redirect_to root_path
+  end
+end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -12,9 +12,14 @@ class StepController < ApplicationController
   def update_and_advance(form_class, opts={})
     hash = params.fetch(form_class.name.underscore, {})
     @form_object = form_class.new(hash.merge(tribunal_case: current_tribunal_case))
+    @next_step = params[:next_step].blank? ? nil : params[:next_step]
 
     if @form_object.save
-      redirect_to root_path
+      redirect_to DecisionTree.new(
+        object:    current_tribunal_case,
+        step:      hash,
+        next_step: @next_step
+      ).destination
     else
       render opts.fetch(:render, :edit)
     end

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -1,0 +1,47 @@
+class DecisionTree
+  include ApplicationHelper
+
+  def initialize(object:, step:, next_step: nil)
+    @object    = object
+    @step      = step
+    @next_step = next_step
+  end
+
+  def destination
+    return @next_step if @next_step
+
+    case step.to_sym
+    when :did_challenge_hmrc
+      after_did_challenge_hmrc_step
+    else
+      raise "Invalid step '#{step}'"
+    end
+  end
+
+  private
+
+  def after_did_challenge_hmrc_step
+    a = ANSWERS.fetch(:did_challenge_hmrc)
+
+    case answer
+    when a.fetch(:yes)
+      endpoint "appeal_cost"
+    when a.fetch(:no)
+      endpoint "must_challenge_hmrc"
+    end
+  end
+
+  #----------------------
+
+  def endpoint(str)
+    Rails.application.routes.url_helpers.decision_path str
+  end
+
+  def step
+    @step.keys.first
+  end
+
+  def answer
+    @step.values.first
+  end
+end

--- a/app/views/decisions/show.html.erb
+++ b/app/views/decisions/show.html.erb
@@ -1,0 +1,7 @@
+<h1 class="heading-large">Your Decision</h1>
+<p class="lede">
+  Your decision is <em><%= @decision %></em>.
+</p>
+<p>
+  <%= link_to "Start again", session_path, method: :delete, class: 'link-back' %>
+</p>

--- a/config/initializers/answers.rb
+++ b/config/initializers/answers.rb
@@ -1,0 +1,6 @@
+ANSWERS = {
+  did_challenge_hmrc: {
+    yes: 'yes',
+    no:  'no'
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,7 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :decisions, only: [:show]
+  resource :session, only: [:destroy]
   root to: 'start#index'
 end

--- a/spec/controllers/decisions_controller_spec.rb
+++ b/spec/controllers/decisions_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe DecisionsController, type: :controller do
+  describe '#show' do
+    it 'is successful' do
+      get :show, params: { id: 1 }
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SessionsController, type: :controller do
+  describe '#destroy' do
+    it 'resets the session' do
+      get :destroy, session: { foo: 'BAR' }
+      expect(session).to be_empty
+    end
+
+    it 'redirects to the start page' do
+      get :destroy
+      expect(subject).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/controllers/steps/did_challenge_hmrc_controller_spec.rb
+++ b/spec/controllers/steps/did_challenge_hmrc_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Steps::DidChallengeHmrcController, type: :controller do
-  describe 'GET /edit' do
+  describe '#edit' do
     context 'when no case exists in the session yet' do
       it 'creates a new case' do
         expect { get :edit }.to change { TribunalCase.count }.by(1)
@@ -39,7 +39,7 @@ RSpec.describe Steps::DidChallengeHmrcController, type: :controller do
     end
   end
 
-  describe 'PUT /update' do
+  describe '#update' do
     let(:did_challenge_hmrc_form) { instance_double(DidChallengeHmrcForm) }
 
     before do
@@ -51,9 +51,12 @@ RSpec.describe Steps::DidChallengeHmrcController, type: :controller do
         expect(did_challenge_hmrc_form).to receive(:save).and_return(true)
       end
 
-      it 'redirects to the start page' do
+      let(:decision_tree) { instance_double(DecisionTree, destination: '/expected_destination') }
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(DecisionTree).to receive(:new).and_return(decision_tree)
         put :update
-        expect(subject).to redirect_to(root_path)
+        expect(subject).to redirect_to('/expected_destination')
       end
     end
 

--- a/spec/services/decision_tree_spec.rb
+++ b/spec/services/decision_tree_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe DecisionTree do
+  let(:object)    { double('Object') }
+  let(:step)      { double('Step') }
+  let(:next_step) { nil }
+  subject { described_class.new(object: object, step: step, next_step: next_step) }
+
+  describe '#destination' do
+    context 'when the step is `did_challenge_hmrc`' do
+      context 'and the answer is yes' do
+        let(:step) { { did_challenge_hmrc: 'yes' } }
+
+        it 'sends the user to the `appeal_cost` endpoint' do
+          expect(Rails.application).to receive_message_chain(:routes, :url_helpers, :decision_path).with('appeal_cost').and_return('/expected_endpoint')
+          expect(subject.destination).to eq('/expected_endpoint')
+        end
+      end
+
+      context 'and the answer is no' do
+        let(:step) { { did_challenge_hmrc: 'no' } }
+
+        it 'sends the user to the `must_challenge_hmrc` endpoint' do
+          expect(Rails.application).to receive_message_chain(:routes, :url_helpers, :decision_path).with('must_challenge_hmrc').and_return('/expected_endpoint')
+          expect(subject.destination).to eq('/expected_endpoint')
+        end
+      end
+    end
+
+    context 'when the step is invalid' do
+      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+
+      it 'raises an error' do
+        expect { subject.destination }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This ports more logic from the decision tree prototype over to
the app.

- Create a trivial `DecisionsController` to serve as an endpoint and simply show the chosen endpoint name
- Add `DecisionTree` service object that determines which endpoint to choose
- Use that service object to determine the redirect target in the `DidChallengeHmrcController`
- Add the ability to reset the session via a `SessionsController`