### PR TITLE
Add WhatIsYourAppealAboutChallenged form

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -9,12 +9,18 @@ class StepController < ApplicationController
     @current_tribunal_case ||= TribunalCase.find_by_id(session[:tribunal_case_id])
   end
 
-  def update_and_advance(form_class, opts={})
+  def update_and_advance(attr, form_class, opts={})
     hash = params.fetch(form_class.name.underscore, {})
     @form_object = form_class.new(hash.merge(tribunal_case: current_tribunal_case))
     @next_step = params[:next_step].blank? ? nil : params[:next_step]
 
     if @form_object.save
+      # if we are reusing a step (e.g. income, income2, income3)
+      # we need to rename the 'income' attribute to 'income2' (or whatever) for the
+      # DecisionTree#destination call
+      # i.e. { income: "high" } -> { income2: "high" }
+      hash = opts[:as] ? { opts[:as] => hash[attr] } : hash
+
       destination = DecisionTree.new(
         object:    current_tribunal_case,
         step:      hash,

--- a/app/controllers/steps/did_challenge_hmrc_controller.rb
+++ b/app/controllers/steps/did_challenge_hmrc_controller.rb
@@ -8,7 +8,7 @@ class Steps::DidChallengeHmrcController < StepController
   end
 
   def update
-    update_and_advance(DidChallengeHmrcForm)
+    update_and_advance(:did_challenge_hmrc, DidChallengeHmrcForm)
   end
 
   private

--- a/app/controllers/steps/what_is_appeal_about_challenged_controller.rb
+++ b/app/controllers/steps/what_is_appeal_about_challenged_controller.rb
@@ -1,0 +1,13 @@
+class Steps::WhatIsAppealAboutChallengedController < StepController
+  def edit
+    super
+    @form_object = WhatIsAppealAboutChallengedForm.new(
+      tribunal_case: current_tribunal_case,
+      what_is_appeal_about: current_tribunal_case.what_is_appeal_about
+    )
+  end
+
+  def update
+    update_and_advance(:what_is_appeal_about, WhatIsAppealAboutChallengedForm, as: :what_is_appeal_about_challenged)
+  end
+end

--- a/app/forms/what_is_appeal_about_challenged_form.rb
+++ b/app/forms/what_is_appeal_about_challenged_form.rb
@@ -1,0 +1,16 @@
+class WhatIsAppealAboutChallengedForm < BaseForm
+  attribute :what_is_appeal_about, Boolean
+
+  def self.choices
+    TribunalCase.what_is_appeal_about_values
+  end
+
+  validates_inclusion_of :what_is_appeal_about, in: choices
+
+  private
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    tribunal_case.update(what_is_appeal_about: what_is_appeal_about)
+  end
+end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,2 +1,14 @@
 class TribunalCase < ApplicationRecord
+  def self.what_is_appeal_about_values
+    %w(
+      income_tax
+      vat
+      apn_penalty
+      inaccurate_return
+      closure_notice
+      information_notice
+      request_permission_for_review
+      other
+    )
+  end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,14 +1,16 @@
 class TribunalCase < ApplicationRecord
+  WHAT_IS_APPEAL_ABOUT_VALUES = %w(
+    income_tax
+    vat
+    apn_penalty
+    inaccurate_return
+    closure_notice
+    information_notice
+    request_permission_for_review
+    other
+  )
+
   def self.what_is_appeal_about_values
-    %w(
-      income_tax
-      vat
-      apn_penalty
-      inaccurate_return
-      closure_notice
-      information_notice
-      request_permission_for_review
-      other
-    )
+    WHAT_IS_APPEAL_ABOUT_VALUES
   end
 end

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -13,6 +13,8 @@ class DecisionTree
     case step.to_sym
     when :did_challenge_hmrc
       after_did_challenge_hmrc_step
+    when :what_is_appeal_about_challenged
+      after_what_is_appeal_about_challenged_step
     else
       raise "Invalid step '#{step}'"
     end
@@ -25,10 +27,14 @@ class DecisionTree
 
     case answer
     when a.fetch(:yes)
-      { controller: :determine_cost, action: :show }
+      { controller: :what_is_appeal_about_challenged, action: :edit }
     when a.fetch(:no)
       { controller: :determine_cost, action: :show }
     end
+  end
+
+  def after_what_is_appeal_about_challenged_step
+    { controller: :determine_cost, action: :show }
   end
 
   def step

--- a/app/views/steps/what_is_appeal_about_challenged/edit.html.erb
+++ b/app/views/steps/what_is_appeal_about_challenged/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%=t '.description_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :what_is_appeal_about,
+        choices: WhatIsAppealAboutChallengedForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,7 +167,11 @@ en:
               <li>appeal to an independent tax tribunal within 30 days</li>
             </ul>
             <p>See the <a href="https://www.gov.uk/tax-appeals">guidance from HMRC on how to appeal</a> against a tax decision.</p>
-
+    what_is_appeal_about_challenged:
+      edit:
+        heading: What is your appeal about?
+        lead_text: The type of tax or issue you're disputing is usually shown on the original notice letter from HMRC, or review conclusion letter (if you challenged the decision directly with HMRC).
+        description_text: If the tax or issue is not listed below or you’re making a different type of appeal or application, please select ‘other’.
   errors:
     # WARNING: This means every possible error message must be a full
     #  English sentence because the attribute name won't be prepended!
@@ -179,10 +183,27 @@ en:
           attributes:
             did_challenge_hmrc:
               inclusion: Select whether you have challenged the decision with HMRC first
+        what_is_appeal_about_challenged_form:
+          attributes:
+            what_is_appeal_about:
+              inclusion: Select what your appeal is about
   helpers:
     fieldset:
       did_challenge_hmrc_form:
         did_challenge_hmrc: Did you challenge the decision with HMRC first?
+      what_is_appeal_about_challenged_form:
+        what_is_appeal_about: What is your appeal about?
+    label:
+      what_is_appeal_about_challenged_form:
+        what_is_appeal_about:
+          income_tax: Income Tax
+          vat: Value Added Tax (VAT)
+          apn_penalty: Advance Payment Notice (APN) penalty
+          inaccurate_return: Inaccurate return
+          closure_notice: Closure notice
+          information_notice: Information notices (Schedule 36)
+          request_permission_for_review: Request permission for a review
+          other: Other
     submit:
       # These are defaults applicable to most steps, override them for
       # forms that should have different nomenclature.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
-STEPS = [
-  :did_challenge_hmrc
-]
+STEPS = %i(
+  did_challenge_hmrc
+  what_is_appeal_about_challenged
+)
 
 Rails.application.routes.draw do
   namespace :steps do

--- a/db/migrate/20161026161756_add_what_is_appeal_about_to_tribunal_case.rb
+++ b/db/migrate/20161026161756_add_what_is_appeal_about_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddWhatIsAppealAboutToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :what_is_appeal_about, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161025094827) do
+ActiveRecord::Schema.define(version: 20161026161756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,8 +18,9 @@ ActiveRecord::Schema.define(version: 20161025094827) do
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.boolean  "did_challenge_hmrc"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.string   "what_is_appeal_about"
   end
 
 end

--- a/spec/controllers/steps/what_is_appeal_about_challenged_controller_spec.rb
+++ b/spec/controllers/steps/what_is_appeal_about_challenged_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Steps::WhatIsAppealAboutChallengedController, type: :controller do
+  describe '#edit' do
+    context 'when no case exists in the session yet' do
+      it 'raises an exception' do
+        expect { get :edit }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when a case exists in the session' do
+      let!(:existing_case) { TribunalCase.create }
+
+      it 'responds with HTTP success' do
+        get :edit, session: { tribunal_case_id: existing_case.id }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:what_is_appeal_about_challenged_form) { instance_double(WhatIsAppealAboutChallengedForm) }
+
+    before do
+      expect(WhatIsAppealAboutChallengedForm).to receive(:new).and_return(what_is_appeal_about_challenged_form)
+    end
+
+    context 'when the form saves successfully' do
+      before do
+        expect(what_is_appeal_about_challenged_form).to receive(:save).and_return(true)
+      end
+
+      let(:decision_tree) { instance_double(DecisionTree, destination: '/expected_destination') }
+
+      it 'asks the decision tree for the next destination and redirects there' do
+        expect(DecisionTree).to receive(:new).and_return(decision_tree)
+        put :update
+        expect(subject).to redirect_to('/expected_destination')
+      end
+    end
+
+    context 'when the form fails to save' do
+      before do
+        expect(what_is_appeal_about_challenged_form).to receive(:save).and_return(false)
+      end
+
+      it 'renders the question page again' do
+        put :update
+        expect(subject).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/forms/what_is_appeal_about_challenged_form_spec.rb
+++ b/spec/forms/what_is_appeal_about_challenged_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe WhatIsAppealAboutChallengedForm do
+  let(:arguments) { {
+    tribunal_case:        tribunal_case,
+    what_is_appeal_about: what_is_appeal_about
+  } }
+  let(:tribunal_case)        { instance_double(TribunalCase, what_is_appeal_about: nil) }
+  let(:what_is_appeal_about) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)        { nil }
+      let(:what_is_appeal_about) { 'vat' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when what_is_appeal_about is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_appeal_about]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_appeal_about is not valid' do
+      let(:what_is_appeal_about) { 'lave-linge-pas-cher' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_appeal_about]).to_not be_empty
+      end
+    end
+
+    context 'when did_challenge_hmrc is valid' do
+      let(:what_is_appeal_about) { 'income_tax' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with( what_is_appeal_about: 'income_tax')
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -1,4 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe TribunalCase, type: :model do
+  describe '.what_is_appeal_about_values' do
+    it 'matches TribunalCase::WHAT_IS_APPEAL_ABOUT_VALUES' do
+      expect(described_class.what_is_appeal_about_values).to eq(described_class::WHAT_IS_APPEAL_ABOUT_VALUES)
+    end
+  end
 end

--- a/spec/services/decision_tree_spec.rb
+++ b/spec/services/decision_tree_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe DecisionTree do
       context 'and the answer is yes' do
         let(:step) { { did_challenge_hmrc: 'yes' } }
 
-        it 'sends the user to the endpoint' do
+        it 'sends the user to the what_is_appeal_about_challenged step' do
           expect(subject.destination).to eq({
-            controller: :determine_cost,
-            action:     :show
+            controller: :what_is_appeal_about_challenged,
+            action:     :edit
           })
         end
       end
@@ -28,6 +28,17 @@ RSpec.describe DecisionTree do
             action:     :show
           })
         end
+      end
+    end
+
+    context 'when the step is `did_challenge_hmrc`' do
+      let(:step) { { what_is_appeal_about_challenged: 'anything_for_now' } }
+
+      it 'sends the user to the endpoint' do
+        expect(subject.destination).to eq({
+          controller: :determine_cost,
+          action:     :show
+        })
       end
     end
 


### PR DESCRIPTION
Adds one of the two "What is your appeal about?" forms (when the user has challenged HMRC) and update I18n and `DecisionTree` accordingly.

- Make `StepController#update_and_advance` able to handle multiple questions for the same attribute like in the prototype