### PR TITLE
Fix issue with ActionControler::Parameters

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -10,7 +10,7 @@ class StepController < ApplicationController
   end
 
   def update_and_advance(attr, form_class, opts={})
-    hash = params.fetch(form_class.name.underscore, {})
+    hash = permitted_params(form_class).to_h
 
     @next_step   = params[:next_step].presence
     @form_object = form_class.new(
@@ -37,5 +37,11 @@ class StepController < ApplicationController
     else
       render opts.fetch(:render, :edit)
     end
+  end
+
+  def permitted_params(form_class)
+    params
+      .require(form_class.name.underscore)
+      .permit(form_class.new.attributes.keys)
   end
 end

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -2,10 +2,18 @@ require 'rails_helper'
 
 RSpec.shared_examples 'a generic step controller' do |form_class|
   describe '#update' do
-    let(:form_object) { instance_double(form_class) }
+    let(:form_object) { instance_double(form_class, attributes: { foo: double }) }
+    let(:form_class_params_name) { form_class.name.underscore }
+    let(:expected_params) { { form_class_params_name => { foo: 'bar' } } }
 
     before do
-      expect(form_class).to receive(:new).and_return(form_object)
+      allow(form_class).to receive(:new).and_return(form_object)
+    end
+
+    context 'when the required form parameters are missing' do
+      it 'raises an error' do
+        expect { put :update }.to raise_error(ActionController::ParameterMissing)
+      end
     end
 
     context 'when the form saves successfully' do
@@ -17,7 +25,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class|
 
       it 'asks the decision tree for the next destination and redirects there' do
         expect(DecisionTree).to receive(:new).and_return(decision_tree)
-        put :update
+        put :update, params: expected_params
         expect(subject).to redirect_to('/expected_destination')
       end
     end
@@ -28,7 +36,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class|
       end
 
       it 'renders the question page again' do
-        put :update
+        put :update, params: expected_params
         expect(subject).to render_template(:edit)
       end
     end


### PR DESCRIPTION
Our way of parsing form input data implicitly uses the deprecated `ActionController::Parameters#to_hash`. We should actually check whether the incoming data is permissible, and do it in a flexible enough way to allow us to get that info from the form object.