### PR TITLE
Complete decision logic for VAT appeals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,6 +224,7 @@
                    A complexity metric that is strongly correlated to the number
                    of test cases needed to validate a method.
     Enabled: true
+    Max: 10
 
   Metrics/LineLength:
     Description: 'Limit lines to 80 characters.'

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -41,7 +41,7 @@ class StepController < ApplicationController
 
   def permitted_params(form_class)
     params
-      .require(form_class.name.underscore)
+      .fetch(form_class.name.underscore, {})
       .permit(form_class.new.attributes.keys)
   end
 end

--- a/app/controllers/steps/what_is_dispute_about_vat_controller.rb
+++ b/app/controllers/steps/what_is_dispute_about_vat_controller.rb
@@ -1,0 +1,13 @@
+class Steps::WhatIsDisputeAboutVatController < StepController
+  def edit
+    super
+    @form_object = WhatIsDisputeAboutVatForm.new(
+      tribunal_case: current_tribunal_case,
+      what_is_dispute_about: current_tribunal_case.what_is_dispute_about
+    )
+  end
+
+  def update
+    update_and_advance(:what_is_dispute_about, WhatIsDisputeAboutVatForm, as: :what_is_dispute_about_vat)
+  end
+end

--- a/app/controllers/steps/what_is_late_penalty_or_surcharge_controller.rb
+++ b/app/controllers/steps/what_is_late_penalty_or_surcharge_controller.rb
@@ -1,0 +1,13 @@
+class Steps::WhatIsLatePenaltyOrSurchargeController < StepController
+  def edit
+    super
+    @form_object = WhatIsLatePenaltyOrSurchargeForm.new(
+      tribunal_case: current_tribunal_case,
+      what_is_penalty_or_surcharge_amount: current_tribunal_case.what_is_penalty_or_surcharge_amount
+    )
+  end
+
+  def update
+    update_and_advance(:what_is_late_penalty_or_surcharge, WhatIsLatePenaltyOrSurchargeForm, as: :what_is_late_penalty_or_surcharge)
+  end
+end

--- a/app/forms/what_is_appeal_about_form.rb
+++ b/app/forms/what_is_appeal_about_form.rb
@@ -1,5 +1,5 @@
 class WhatIsAppealAboutForm < BaseForm
-  attribute :what_is_appeal_about, Boolean
+  attribute :what_is_appeal_about, String
 
   def self.choices
     TribunalCase.what_is_appeal_about_values

--- a/app/forms/what_is_dispute_about_vat_form.rb
+++ b/app/forms/what_is_dispute_about_vat_form.rb
@@ -1,0 +1,18 @@
+class WhatIsDisputeAboutVatForm < BaseForm
+  attribute :what_is_dispute_about, String
+
+  def self.choices
+    %w(
+      late_return_or_payment
+      amount_of_tax_owed
+    )
+  end
+  validates_inclusion_of :what_is_dispute_about, in: choices
+
+  private
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    tribunal_case.update(what_is_dispute_about: what_is_dispute_about)
+  end
+end

--- a/app/forms/what_is_late_penalty_or_surcharge_form.rb
+++ b/app/forms/what_is_late_penalty_or_surcharge_form.rb
@@ -1,0 +1,19 @@
+class WhatIsLatePenaltyOrSurchargeForm < BaseForm
+  attribute :what_is_penalty_or_surcharge_amount, String
+
+  def self.choices
+    %w(
+      100_or_less
+      101_to_20000
+      20001_or_more
+    )
+  end
+  validates_inclusion_of :what_is_penalty_or_surcharge_amount, in: choices
+
+  private
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    tribunal_case.update(what_is_penalty_or_surcharge_amount: what_is_penalty_or_surcharge_amount)
+  end
+end

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -17,6 +17,10 @@ class DecisionTree
       after_what_is_appeal_about_challenged_step
     when :what_is_appeal_about_unchallenged
       after_what_is_appeal_about_unchallenged_step
+    when :what_is_dispute_about_vat
+      after_what_is_dispute_about_vat_step
+    when :what_is_late_penalty_or_surcharge
+      after_what_is_late_penalty_or_surcharge_step
     else
       raise "Invalid step '#{step}'"
     end
@@ -34,16 +38,36 @@ class DecisionTree
   end
 
   def after_what_is_appeal_about_challenged_step
-    { controller: :determine_cost, action: :show }
+    case answer
+    when :vat
+      { controller: :what_is_dispute_about_vat, action: :edit }
+    else
+      { controller: :determine_cost, action: :show }
+    end
   end
 
   def after_what_is_appeal_about_unchallenged_step
     case answer
     when :income_tax
       { controller: :must_challenge_hmrc, action: :show }
+    when :vat
+      { controller: :what_is_dispute_about_vat, action: :edit }
     else
       { controller: :determine_cost, action: :show }
     end
+  end
+
+  def after_what_is_dispute_about_vat_step
+    case answer
+    when :late_return_or_payment
+      { controller: :what_is_late_penalty_or_surcharge, action: :edit }
+    when :amount_of_tax_owed
+      { controller: :determine_cost, action: :show }
+    end
+  end
+
+  def after_what_is_late_penalty_or_surcharge_step
+    { controller: :determine_cost, action: :show }
   end
 
   def step

--- a/app/views/steps/determine_cost/show.html.erb
+++ b/app/views/steps/determine_cost/show.html.erb
@@ -1,7 +1,9 @@
 <h1 class="heading-large"><%=t '.heading' %></h1>
+
 <p class="lede">
 <%=t '.lead_text' %>
 </p>
+
 <p>
   <%= link_to t('.start_again'), session_path, method: :delete, class: 'link-back' %>
 </p>

--- a/app/views/steps/what_is_dispute_about_vat/edit.html.erb
+++ b/app/views/steps/what_is_dispute_about_vat/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%=t '.description_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :what_is_dispute_about,
+        choices: WhatIsDisputeAboutVatForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/what_is_late_penalty_or_surcharge/edit.html.erb
+++ b/app/views/steps/what_is_late_penalty_or_surcharge/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :what_is_penalty_or_surcharge_amount,
+        choices: WhatIsLatePenaltyOrSurchargeForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,15 @@ en:
         heading: What is your appeal about?
         lead_text: The type of tax or issue you're disputing is usually shown on the original notice letter from HMRC, or review conclusion letter (if you challenged the decision directly with HMRC).
         description_text: If the tax or issue is not listed below or you’re making a different type of appeal or application, please select ‘other’.
+    what_is_dispute_about_vat:
+      edit:
+        heading: What is your dispute about?
+        lead_text: Your dispute will be stated on either the original notice letter from HMRC, or the review conclusion letter if your case was reviewed.
+        description_text: You can't combine separate disputes on separate letters into one appeal.
+    what_is_late_penalty_or_surcharge:
+      edit:
+        heading: What is the penalty or surcharge amount?
+        lead_text: Select an option below based on the amount shown on the original notice letter or review conclusion letter you received from HMRC.
     determine_cost:
       show:
         heading: Your Appeal
@@ -212,6 +221,10 @@ en:
         did_challenge_hmrc: Did you challenge the decision with HMRC first?
       what_is_appeal_about_form:
         what_is_appeal_about: What is your appeal about?
+      what_is_dispute_about_vat_form:
+        what_is_dispute_about: What is your dispute about?
+      what_is_late_penalty_or_surcharge_form:
+        what_is_penalty_or_surcharge_amount: What is the penalty or surcharge amount?
     label:
       what_is_appeal_about_form:
         what_is_appeal_about:
@@ -223,6 +236,15 @@ en:
           information_notice: Information notices (Schedule 36)
           request_permission_for_review: Request permission for a review
           other: Other
+      what_is_dispute_about_vat_form:
+        what_is_dispute_about:
+          late_return_or_payment: Late return or payment
+          amount_of_tax_owed: Amount of tax owed
+      what_is_late_penalty_or_surcharge_form:
+        what_is_penalty_or_surcharge_amount:
+          100_or_less: £100 or less
+          101_to_20000: £101 – £20,000
+          20001_or_more: £20,001 or more
     submit:
       # These are defaults applicable to most steps, override them for
       # forms that should have different nomenclature.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ STEPS = %i(
   did_challenge_hmrc
   what_is_appeal_about_challenged
   what_is_appeal_about_unchallenged
+  what_is_dispute_about_vat
+  what_is_late_penalty_or_surcharge
 )
 
 ENDPOINTS = %i(

--- a/db/migrate/20161101102300_add_what_is_dispute_about_to_tribunal_case.rb
+++ b/db/migrate/20161101102300_add_what_is_dispute_about_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddWhatIsDisputeAboutToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :what_is_dispute_about, :string
+  end
+end

--- a/db/migrate/20161101154510_add_penalty_or_surcharge_amount_to_tribunal_case.rb
+++ b/db/migrate/20161101154510_add_penalty_or_surcharge_amount_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddPenaltyOrSurchargeAmountToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :what_is_penalty_or_surcharge_amount, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161026161756) do
+ActiveRecord::Schema.define(version: 20161101154510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,9 +18,11 @@ ActiveRecord::Schema.define(version: 20161026161756) do
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.boolean  "did_challenge_hmrc"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "what_is_appeal_about"
+    t.string   "what_is_dispute_about"
+    t.string   "what_is_penalty_or_surcharge_amount"
   end
 
 end

--- a/spec/controllers/steps/what_is_dispute_about_vat_controller_spec.rb
+++ b/spec/controllers/steps/what_is_dispute_about_vat_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::WhatIsDisputeAboutVatController, type: :controller do
+    it_behaves_like 'an intermediate step controller', WhatIsDisputeAboutVatForm
+end

--- a/spec/controllers/steps/what_is_late_penalty_or_surcharge_amount_controller_spec.rb
+++ b/spec/controllers/steps/what_is_late_penalty_or_surcharge_amount_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::WhatIsLatePenaltyOrSurchargeController, type: :controller do
+    it_behaves_like 'an intermediate step controller', WhatIsLatePenaltyOrSurchargeForm
+end

--- a/spec/features/cost_decisions_spec.rb
+++ b/spec/features/cost_decisions_spec.rb
@@ -10,10 +10,64 @@ RSpec.feature 'Cost decisions', :type => :feature do
     expect(page).to have_text('To submit an appeal you will have to pay')
   end
 
-  scenario 'Unchallenged income tax appeal' do
-    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
-    answer_question 'What is your appeal about?', with: 'Income Tax'
+  context 'unchallenged' do
+    before do
+      answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    end
 
-    expect(page).to have_text('You must challenge HMRC before you can appeal')
+    scenario 'income tax appeal' do
+      answer_question 'What is your appeal about?', with: 'Income Tax'
+
+      expect(page).to have_text('You must challenge HMRC before you can appeal')
+    end
+
+    context 'VAT appeal' do
+      before do
+        answer_question 'What is your appeal about?', with: 'Value Added Tax (VAT)'
+      end
+
+      scenario 'on the basis of amount of tax owed' do
+        answer_question 'What is your dispute about?', with: 'Amount of tax owed'
+
+        expect(page).to have_text('To submit an appeal you will have to pay')
+      end
+
+      scenario 'on the basis of late return/payment' do
+        answer_question 'What is your dispute about?', with: 'Late return or payment'
+        answer_question 'What is the penalty or surcharge amount?', with: '£100 or less'
+
+        expect(page).to have_text('To submit an appeal you will have to pay')
+      end
+    end
+
+    scenario 'closure notice appeal' do
+      answer_question 'What is your appeal about?', with: 'Closure notice'
+
+      expect(page).to have_text('To submit an appeal you will have to pay')
+    end
+
+    scenario 'information notice appeal' do
+      answer_question 'What is your appeal about?', with: 'Information notice'
+
+      expect(page).to have_text('To submit an appeal you will have to pay')
+    end
+
+    scenario 'request for permission to review' do
+      answer_question 'What is your appeal about?', with: 'Request permission for a review'
+
+      expect(page).to have_text('To submit an appeal you will have to pay')
+    end
+
+    scenario 'APN penalty appeal' do
+      answer_question 'What is your appeal about?', with: 'Advance Payment Notice (APN) penalty'
+
+      expect(page).to have_text('To submit an appeal you will have to pay')
+    end
+
+    scenario 'inaccurate return appeal' do
+      answer_question 'What is your appeal about?', with: 'Inaccurate return'
+
+      expect(page).to have_text('To submit an appeal you will have to pay')
+    end
   end
 end

--- a/spec/forms/what_is_dispute_about_vat_form_spec.rb
+++ b/spec/forms/what_is_dispute_about_vat_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe WhatIsDisputeAboutVatForm do
+  let(:arguments) { {
+    tribunal_case:         tribunal_case,
+    what_is_dispute_about: what_is_dispute_about
+  } }
+  let(:tribunal_case)         { instance_double(TribunalCase, what_is_dispute_about: nil) }
+  let(:what_is_dispute_about) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)         { nil }
+      let(:what_is_dispute_about) { 'amount_of_tax_owed' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when what_is_dispute_about is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_dispute_about]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_dispute_about is not valid' do
+      let(:what_is_dispute_about) { 'feliz-navidad' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_dispute_about]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_dispute_about is valid' do
+      let(:what_is_dispute_about) { 'late_return_or_payment' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with( what_is_dispute_about: 'late_return_or_payment')
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/decision_tree_spec.rb
+++ b/spec/services/decision_tree_spec.rb
@@ -32,22 +32,34 @@ RSpec.describe DecisionTree do
     end
 
     context 'when the step is `what_is_appeal_about_challenged`' do
-      let(:step) { { what_is_appeal_about_challenged: 'anything_for_now' } }
+      context 'and the answer is `vat`' do
+        let(:step) { { what_is_appeal_about_challenged: 'vat' } }
 
-      it 'sends the user to the endpoint' do
-        expect(subject.destination).to eq({
-          controller: :determine_cost,
-          action:     :show
-        })
+        it 'sends the user to the what_is_dispute_about_vat step' do
+          expect(subject.destination).to eq({
+            controller: :what_is_dispute_about_vat,
+            action:     :edit
+          })
+        end
+      end
+
+      context 'and the answer is anything else' do
+        let(:step) { { what_is_appeal_about_challenged: 'anything_for_now' } }
+
+        it 'sends the user to the endpoint' do
+          expect(subject.destination).to eq({
+            controller: :determine_cost,
+            action:     :show
+          })
+        end
       end
     end
 
     context 'when the step is `what_is_appeal_about_unchallenged`' do
-
-      context "and the answer is 'income_tax'" do
+      context 'and the answer is `income_tax`' do
         let(:step) { { what_is_appeal_about_unchallenged: 'income_tax' } }
 
-        it "sends the user to the 'must_challenge_hmrc' endpoint" do
+        it 'sends the user to the `must_challenge_hmrc` endpoint' do
           expect(subject.destination).to eq({
             controller: :must_challenge_hmrc,
             action:     :show
@@ -55,8 +67,18 @@ RSpec.describe DecisionTree do
         end
       end
 
+      context 'and the answer is `vat`' do
+        let(:step) { { what_is_appeal_about_unchallenged: 'vat' } }
+
+        it 'sends the user to the `what_is_dispute_about_vat` endpoint' do
+          expect(subject.destination).to eq({
+            controller: :what_is_dispute_about_vat,
+            action:     :edit
+          })
+        end
+      end
+
       %w(
-        vat
         apn_penalty
         inaccurate_return
         closure_notice
@@ -64,16 +86,51 @@ RSpec.describe DecisionTree do
         request_permission_for_review
         other
       ).each do |tax_type|
-        context "and the answer is '#{tax_type}'" do
+        context "and the answer is `#{tax_type}`" do
           let(:step) { { what_is_appeal_about_unchallenged: tax_type } }
 
-          it "sends the user to the 'determine_cost' endpoint" do
+          it 'sends the user to the `determine_cost` endpoint' do
             expect(subject.destination).to eq({
               controller: :determine_cost,
               action:     :show
             })
           end
         end
+      end
+    end
+
+    context 'when the step is `what_is_dispute_about_vat`' do
+      context 'and the answer is `amount_of_tax_owed`' do
+        let(:step) { { what_is_dispute_about_vat: 'amount_of_tax_owed' } }
+
+        it 'sends the user to the `determine_cost` endpoint' do
+          expect(subject.destination).to eq({
+            controller: :determine_cost,
+            action:     :show
+          })
+        end
+      end
+
+      context 'and the answer is `late_return_or_payment`' do
+        let(:step) { { what_is_dispute_about_vat: 'late_return_or_payment' } }
+
+        it 'sends the user to the `what_is_late_penalty_or_surcharge` step' do
+          expect(subject.destination).to eq({
+            controller: :what_is_late_penalty_or_surcharge,
+            action:     :edit
+          })
+        end
+      end
+    end
+
+    context 'when the step is `what_is_late_penalty_or_surcharge`' do
+      let(:step) { { what_is_late_penalty_or_surcharge: 'anything' } }
+
+      it 'sends the user to the endpoint' do
+        expect(subject.destination).to eq({
+          controller: :determine_cost,
+          action:     :show
+        })
       end
     end
 

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -10,12 +10,6 @@ RSpec.shared_examples 'a generic step controller' do |form_class|
       allow(form_class).to receive(:new).and_return(form_object)
     end
 
-    context 'when the required form parameters are missing' do
-      it 'raises an error' do
-        expect { put :update }.to raise_error(ActionController::ParameterMissing)
-      end
-    end
-
     context 'when the form saves successfully' do
       before do
         expect(form_object).to receive(:save).and_return(true)


### PR DESCRIPTION
This finishes the logic for challenged and unchallenged VAT appeals.

- Add "What is your dispute about?" step
- Add "What is the penalty or surcharge amount?" step for when the dispute is about late payment or filing
- Fix issue with strong parameters breaking validations on form objects
- Fix issue with `WhatIsAppealAboutForm` accidentally having its attribute as boolean