### PR TITLE
Add HTML-formatted fieldset labels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/govuk_elements_form_builder.git
-  revision: 728be7bcfdf9d44bb9cd46c2aca924a94b7a8903
+  revision: 72d4f260de4175660c23c96b855f106059000cfc
   specs:
     govuk_elements_form_builder (0.0.1)
       rails (>= 4.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,55 +1,59 @@
 /*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
+* This is a manifest file that'll be compiled into application.css, which will include all the files
+* listed below.
+*
+* Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
+* or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
+*
+* You're free to add application-wide styles to this file and they'll appear at the bottom of the
+* compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
+* files in this directory. Styles in this file should be added after the last require_* statement.
+* It is generally better to create a new file per style scope.
+*
+*= require_tree .
+*= require_self
+*/
 
- // From GDS's alphagov/govuk_frontend_toolkit
- @import 'colours';
- @import 'font_stack';
- @import 'measurements';
- @import 'conditionals';
- @import 'device-pixels';
- @import 'grid_layout';
- @import 'typography';
- @import 'shims';
+// From GDS's alphagov/govuk_frontend_toolkit
+@import 'colours';
+@import 'font_stack';
+@import 'measurements';
+@import 'conditionals';
+@import 'device-pixels';
+@import 'grid_layout';
+@import 'typography';
+@import 'shims';
 
- @import 'design-patterns/alpha-beta';
- @import 'design-patterns/buttons';
- @import 'design-patterns/breadcrumbs';
+@import 'design-patterns/alpha-beta';
+@import 'design-patterns/buttons';
+@import 'design-patterns/breadcrumbs';
 
- // From GDS's alphagov/govuk_elements
- @import 'elements/helpers';
- @import 'elements/reset';
+// From GDS's alphagov/govuk_elements
+@import 'elements/helpers';
+@import 'elements/reset';
 
- // Base (unclassed HTML elements)
- // These are predefined by govuk_template
- // If you're not using govuk_template, uncomment the line below.
- // HTML elements, set by the GOV.UK template
- // @import 'elements/base'
+// Base (unclassed HTML elements)
+// These are predefined by govuk_template
+// If you're not using govuk_template, uncomment the line below.
+// HTML elements, set by the GOV.UK template
+// @import 'elements/base'
 
- @import 'elements/layout';
- @import 'elements/elements-typography';
- @import 'elements/buttons';
- @import 'elements/icons';
- @import 'elements/lists';
- @import 'elements/tables';
- @import 'elements/details';
- @import 'elements/panels';
- @import 'elements/forms';
- @import 'elements/forms/form-block-labels';
- @import 'elements/forms/form-date';
- @import 'elements/forms/form-validation';
- @import 'elements/breadcrumbs';
- @import 'elements/phase-banner';
- @import 'elements/components';
+@import 'elements/layout';
+@import 'elements/elements-typography';
+@import 'elements/buttons';
+@import 'elements/icons';
+@import 'elements/lists';
+@import 'elements/tables';
+@import 'elements/details';
+@import 'elements/panels';
+@import 'elements/forms';
+@import 'elements/forms/form-block-labels';
+@import 'elements/forms/form-date';
+@import 'elements/forms/form-validation';
+@import 'elements/breadcrumbs';
+@import 'elements/phase-banner';
+@import 'elements/components';
+
+strong {
+font-weight: bold;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,18 +228,18 @@ en:
     label:
       what_is_appeal_about_form:
         what_is_appeal_about:
-          income_tax: Income Tax
-          vat: Value Added Tax (VAT)
-          apn_penalty: Advance Payment Notice (APN) penalty
-          inaccurate_return: Inaccurate return
-          closure_notice: Closure notice
-          information_notice: Information notices (Schedule 36)
-          request_permission_for_review: Request permission for a review
-          other: Other
+          income_tax_html: <strong>Income Tax</strong><br>for example, Pay As You Earn (PAYE), self-assessment
+          vat_html: <strong>Value Added Tax (VAT)</strong>
+          apn_penalty_html: <strong>Advance Payment Notice (APN) penalty</strong><br>for example, non-compliance with Disclosure Of Tax Avoidance Schemes (DOTAS)
+          inaccurate_return_html: <strong>Inaccurate return</strong><br>penalty for an inaccurate return or document
+          closure_notice_html: <strong>Closure notice</strong><br>request HMRC close an ongoing enquiry into your tax returns
+          information_notice_html: <strong>Information notices (Schedule 36)</strong><br>including penalties for non-compliance with information notices
+          request_permission_for_review_html: <strong>Request permission for a review</strong><br>apply to get a late review accepted by HMRC, UK Border Force (UKBF) or National Crime Authority (NCA)
+          other_html: <strong>Other</strong>
       what_is_dispute_about_vat_form:
         what_is_dispute_about:
-          late_return_or_payment: Late return or payment
-          amount_of_tax_owed: Amount of tax owed
+          late_return_or_payment_html: <strong>Late return or payment</strong><br>penalty or surcharge for late filing of returns and documents or late payment of duties
+          amount_of_tax_owed_html: <strong>Amount of tax owed</strong>
       what_is_late_penalty_or_surcharge_form:
         what_is_penalty_or_surcharge_amount:
           100_or_less: £100 or less


### PR DESCRIPTION
Now that the GOV.UK Elements Form Builder is updated to support HTML in labels, port over the 'enhanced' text from the prototype.