### PR TITLE
Add 'What is dispute about?' form for income tax

### DIFF
--- a/app/controllers/steps/what_is_dispute_about_income_tax_controller.rb
+++ b/app/controllers/steps/what_is_dispute_about_income_tax_controller.rb
@@ -1,0 +1,13 @@
+class Steps::WhatIsDisputeAboutIncomeTaxController < StepController
+  def edit
+    super
+    @form_object = WhatIsDisputeAboutIncomeTaxForm.new(
+      tribunal_case: current_tribunal_case,
+      what_is_dispute_about: current_tribunal_case.what_is_dispute_about
+    )
+  end
+
+  def update
+    update_and_advance(:what_is_dispute_about, WhatIsDisputeAboutIncomeTaxForm, as: :what_is_dispute_about_income_tax)
+  end
+end

--- a/app/forms/what_is_dispute_about_income_tax_form.rb
+++ b/app/forms/what_is_dispute_about_income_tax_form.rb
@@ -1,0 +1,19 @@
+class WhatIsDisputeAboutIncomeTaxForm < BaseForm
+  attribute :what_is_dispute_about, String
+
+  def self.choices
+    %w(
+      late_return_or_payment
+      amount_of_tax_owed
+      paye_coding_notice
+    )
+  end
+  validates_inclusion_of :what_is_dispute_about, in: choices
+
+  private
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    tribunal_case.update(what_is_dispute_about: what_is_dispute_about)
+  end
+end

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -19,6 +19,8 @@ class DecisionTree
       after_what_is_appeal_about_unchallenged_step
     when :what_is_dispute_about_vat
       after_what_is_dispute_about_vat_step
+    when :what_is_dispute_about_income_tax
+      after_what_is_dispute_about_income_tax_step
     when :what_is_late_penalty_or_surcharge
       after_what_is_late_penalty_or_surcharge_step
     else
@@ -39,6 +41,8 @@ class DecisionTree
 
   def after_what_is_appeal_about_challenged_step
     case answer
+    when :income_tax
+      { controller: :what_is_dispute_about_income_tax, action: :edit }
     when :vat
       { controller: :what_is_dispute_about_vat, action: :edit }
     else
@@ -62,6 +66,15 @@ class DecisionTree
     when :late_return_or_payment
       { controller: :what_is_late_penalty_or_surcharge, action: :edit }
     when :amount_of_tax_owed
+      { controller: :determine_cost, action: :show }
+    end
+  end
+
+  def after_what_is_dispute_about_income_tax_step
+    case answer
+    when :late_return_or_payment
+      { controller: :what_is_late_penalty_or_surcharge, action: :edit }
+    when :amount_of_tax_owed, :paye_coding_notice
       { controller: :determine_cost, action: :show }
     end
   end

--- a/app/views/steps/what_is_dispute_about_income_tax/edit.html.erb
+++ b/app/views/steps/what_is_dispute_about_income_tax/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%=t '.description_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :what_is_dispute_about,
+        choices: WhatIsDisputeAboutIncomeTaxForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,11 @@ en:
         heading: What is your appeal about?
         lead_text: The type of tax or issue you're disputing is usually shown on the original notice letter from HMRC, or review conclusion letter (if you challenged the decision directly with HMRC).
         description_text: If the tax or issue is not listed below or you’re making a different type of appeal or application, please select ‘other’.
+    what_is_dispute_about_income_tax:
+      edit:
+        heading: What is your dispute about?
+        lead_text: Your dispute will be stated on either the original notice letter from HMRC, or the review conclusion letter if your case was reviewed.
+        description_text: You can't combine separate disputes on separate letters into one appeal.
     what_is_dispute_about_vat:
       edit:
         heading: What is your dispute about?
@@ -215,6 +220,14 @@ en:
           attributes:
             what_is_appeal_about:
               inclusion: Select what your appeal is about
+        what_is_dispute_about_income_tax_form:
+          attributes:
+            what_is_dispute_about:
+              inclusion: Select what your dispute is about
+        what_is_dispute_about_vat_form:
+          attributes:
+            what_is_dispute_about:
+              inclusion: Select what your dispute is about
   helpers:
     fieldset:
       did_challenge_hmrc_form:
@@ -222,6 +235,8 @@ en:
       what_is_appeal_about_form:
         what_is_appeal_about: What is your appeal about?
       what_is_dispute_about_vat_form:
+        what_is_dispute_about: What is your dispute about?
+      what_is_dispute_about_income_tax_form:
         what_is_dispute_about: What is your dispute about?
       what_is_late_penalty_or_surcharge_form:
         what_is_penalty_or_surcharge_amount: What is the penalty or surcharge amount?
@@ -236,6 +251,11 @@ en:
           information_notice_html: <strong>Information notices (Schedule 36)</strong><br>including penalties for non-compliance with information notices
           request_permission_for_review_html: <strong>Request permission for a review</strong><br>apply to get a late review accepted by HMRC, UK Border Force (UKBF) or National Crime Authority (NCA)
           other_html: <strong>Other</strong>
+      what_is_dispute_about_income_tax_form:
+        what_is_dispute_about:
+          late_return_or_payment_html: <strong>Late return or payment</strong><br>penalty or surcharge for late filing of returns and documents or late payment of duties
+          amount_of_tax_owed_html: <strong>Amount of tax owed</strong>
+          paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
       what_is_dispute_about_vat_form:
         what_is_dispute_about:
           late_return_or_payment_html: <strong>Late return or payment</strong><br>penalty or surcharge for late filing of returns and documents or late payment of duties

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ STEPS = %i(
   what_is_appeal_about_challenged
   what_is_appeal_about_unchallenged
   what_is_dispute_about_vat
+  what_is_dispute_about_income_tax
   what_is_late_penalty_or_surcharge
 )
 

--- a/spec/controllers/steps/what_is_dispute_about_income_tax_controller_spec.rb
+++ b/spec/controllers/steps/what_is_dispute_about_income_tax_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::WhatIsDisputeAboutIncomeTaxController, type: :controller do
+    it_behaves_like 'an intermediate step controller', WhatIsDisputeAboutIncomeTaxForm
+end

--- a/spec/features/cost_decisions_spec.rb
+++ b/spec/features/cost_decisions_spec.rb
@@ -3,71 +3,79 @@ require 'rails_helper'
 RSpec.feature 'Cost decisions', :type => :feature do
   before { start_application }
 
-  scenario 'Challenged income tax appeal' do
+  scenario 'unchallenged income tax appeal' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Income Tax'
+
+    expect(page).to have_text('You must challenge HMRC before you can appeal')
+  end
+
+  scenario 'Challenged income tax appeal on the basis of amount of tax owed' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'Yes'
     answer_question 'What is your appeal about?', with: 'Income Tax'
+    answer_question 'What is your dispute about?', with: 'Amount of tax owed'
 
     expect(page).to have_text('To submit an appeal you will have to pay')
   end
 
-  context 'unchallenged' do
-    before do
-      answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
-    end
+  scenario 'Challenged income tax appeal on the basis of amount of late return/payment' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'Yes'
+    answer_question 'What is your appeal about?', with: 'Income Tax'
+    answer_question 'What is your dispute about?', with: 'Late return or payment'
+    answer_question 'What is the penalty or surcharge amount?', with: '£100 or less'
 
-    scenario 'income tax appeal' do
-      answer_question 'What is your appeal about?', with: 'Income Tax'
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-      expect(page).to have_text('You must challenge HMRC before you can appeal')
-    end
+  scenario 'unchallenged VAT appeal on the basis of amount of tax owed' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Value Added Tax (VAT)'
+    answer_question 'What is your dispute about?', with: 'Amount of tax owed'
 
-    context 'VAT appeal' do
-      before do
-        answer_question 'What is your appeal about?', with: 'Value Added Tax (VAT)'
-      end
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-      scenario 'on the basis of amount of tax owed' do
-        answer_question 'What is your dispute about?', with: 'Amount of tax owed'
+  scenario 'unchallenged VAT appeal on the basis of late return/payment' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Value Added Tax (VAT)'
+    answer_question 'What is your dispute about?', with: 'Late return or payment'
+    answer_question 'What is the penalty or surcharge amount?', with: '£100 or less'
 
-        expect(page).to have_text('To submit an appeal you will have to pay')
-      end
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-      scenario 'on the basis of late return/payment' do
-        answer_question 'What is your dispute about?', with: 'Late return or payment'
-        answer_question 'What is the penalty or surcharge amount?', with: '£100 or less'
+  scenario 'closure notice appeal' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Closure notice'
 
-        expect(page).to have_text('To submit an appeal you will have to pay')
-      end
-    end
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-    scenario 'closure notice appeal' do
-      answer_question 'What is your appeal about?', with: 'Closure notice'
+  scenario 'information notice appeal' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Information notice'
 
-      expect(page).to have_text('To submit an appeal you will have to pay')
-    end
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-    scenario 'information notice appeal' do
-      answer_question 'What is your appeal about?', with: 'Information notice'
+  scenario 'request for permission to review' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Request permission for a review'
 
-      expect(page).to have_text('To submit an appeal you will have to pay')
-    end
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-    scenario 'request for permission to review' do
-      answer_question 'What is your appeal about?', with: 'Request permission for a review'
+  scenario 'APN penalty appeal' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Advance Payment Notice (APN) penalty'
 
-      expect(page).to have_text('To submit an appeal you will have to pay')
-    end
+    expect(page).to have_text('To submit an appeal you will have to pay')
+  end
 
-    scenario 'APN penalty appeal' do
-      answer_question 'What is your appeal about?', with: 'Advance Payment Notice (APN) penalty'
+  scenario 'inaccurate return appeal' do
+    answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
+    answer_question 'What is your appeal about?', with: 'Inaccurate return'
 
-      expect(page).to have_text('To submit an appeal you will have to pay')
-    end
-
-    scenario 'inaccurate return appeal' do
-      answer_question 'What is your appeal about?', with: 'Inaccurate return'
-
-      expect(page).to have_text('To submit an appeal you will have to pay')
-    end
+    expect(page).to have_text('To submit an appeal you will have to pay')
   end
 end

--- a/spec/forms/what_is_dispute_about_income_tax_form_spec.rb
+++ b/spec/forms/what_is_dispute_about_income_tax_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe WhatIsDisputeAboutIncomeTaxForm do
+  let(:arguments) { {
+    tribunal_case:         tribunal_case,
+    what_is_dispute_about: what_is_dispute_about
+  } }
+  let(:tribunal_case)         { instance_double(TribunalCase, what_is_dispute_about: nil) }
+  let(:what_is_dispute_about) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)         { nil }
+      let(:what_is_dispute_about) { 'amount_of_tax_owed' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when what_is_dispute_about is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_dispute_about]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_dispute_about is not valid' do
+      let(:what_is_dispute_about) { 'feliz-navidad' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_dispute_about]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_dispute_about is valid' do
+      let(:what_is_dispute_about) { 'paye_coding_notice' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with( what_is_dispute_about: 'paye_coding_notice')
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/decision_tree_spec.rb
+++ b/spec/services/decision_tree_spec.rb
@@ -43,6 +43,17 @@ RSpec.describe DecisionTree do
         end
       end
 
+      context 'and the answer is `income_tax`' do
+        let(:step) { { what_is_appeal_about_challenged: 'income_tax' } }
+
+        it 'sends the user to the what_is_dispute_about_income_tax step' do
+          expect(subject.destination).to eq({
+            controller: :what_is_dispute_about_income_tax,
+            action:     :edit
+          })
+        end
+      end
+
       context 'and the answer is anything else' do
         let(:step) { { what_is_appeal_about_challenged: 'anything_for_now' } }
 
@@ -95,6 +106,41 @@ RSpec.describe DecisionTree do
               action:     :show
             })
           end
+        end
+      end
+    end
+
+    context 'when the step is `what_is_dispute_about_income_tax`' do
+      context 'and the answer is `amount_of_tax_owed`' do
+        let(:step) { { what_is_dispute_about_income_tax: 'amount_of_tax_owed' } }
+
+        it 'sends the user to the `determine_cost` endpoint' do
+          expect(subject.destination).to eq({
+            controller: :determine_cost,
+            action:     :show
+          })
+        end
+      end
+
+      context 'and the answer is `paye_coding_notice`' do
+        let(:step) { { what_is_dispute_about_income_tax: 'paye_coding_notice' } }
+
+        it 'sends the user to the `determine_cost` endpoint' do
+          expect(subject.destination).to eq({
+            controller: :determine_cost,
+            action:     :show
+          })
+        end
+      end
+
+      context 'and the answer is `late_return_or_payment`' do
+        let(:step) { { what_is_dispute_about_income_tax: 'late_return_or_payment' } }
+
+        it 'sends the user to the `what_is_late_penalty_or_surcharge` step' do
+          expect(subject.destination).to eq({
+            controller: :what_is_late_penalty_or_surcharge,
+            action:     :edit
+          })
         end
       end
     end


### PR DESCRIPTION
- Add `WhatIsDisputeAboutIncomeTaxForm` and `WhatIsDisputeAboutIncomeTaxController` complete with requisite route
- Modify decision tree accordingly
- Clean up cost decisions feature specs a bit