### PR TITLE
Add 'Check Your Answers' functionality to endpoint

### DIFF
--- a/app/controllers/steps/determine_cost_controller.rb
+++ b/app/controllers/steps/determine_cost_controller.rb
@@ -1,5 +1,7 @@
 class Steps::DetermineCostController < StepController
   def show
     raise 'No tribunal case in session' unless current_tribunal_case
+
+    @change_answers = ChangeCostAnswersPresenter.new(current_tribunal_case)
   end
 end

--- a/app/forms/did_challenge_hmrc_form.rb
+++ b/app/forms/did_challenge_hmrc_form.rb
@@ -5,8 +5,14 @@ class DidChallengeHmrcForm < BaseForm
 
   private
 
+  def changed?
+    tribunal_case.did_challenge_hmrc != did_challenge_hmrc
+  end
+
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
+    return unless changed?
+
     tribunal_case.update(
       did_challenge_hmrc: did_challenge_hmrc,
       # The following are dependent attributes that need to be reset

--- a/app/forms/did_challenge_hmrc_form.rb
+++ b/app/forms/did_challenge_hmrc_form.rb
@@ -7,6 +7,12 @@ class DidChallengeHmrcForm < BaseForm
 
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
-    tribunal_case.update(did_challenge_hmrc: did_challenge_hmrc)
+    tribunal_case.update(
+      did_challenge_hmrc: did_challenge_hmrc,
+      # The following are dependent attributes that need to be reset
+      what_is_appeal_about: nil,
+      what_is_dispute_about: nil,
+      what_is_penalty_or_surcharge_amount: nil
+    )
   end
 end

--- a/app/forms/what_is_appeal_about_form.rb
+++ b/app/forms/what_is_appeal_about_form.rb
@@ -11,6 +11,11 @@ class WhatIsAppealAboutForm < BaseForm
 
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
-    tribunal_case.update(what_is_appeal_about: what_is_appeal_about)
+    tribunal_case.update(
+      what_is_appeal_about: what_is_appeal_about,
+      # The following are dependent attributes that need to be reset
+      what_is_dispute_about: nil,
+      what_is_penalty_or_surcharge_amount: nil
+    )
   end
 end

--- a/app/forms/what_is_appeal_about_form.rb
+++ b/app/forms/what_is_appeal_about_form.rb
@@ -9,8 +9,14 @@ class WhatIsAppealAboutForm < BaseForm
 
   private
 
+  def changed?
+    tribunal_case.what_is_appeal_about != what_is_appeal_about
+  end
+
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
+    return unless changed?
+
     tribunal_case.update(
       what_is_appeal_about: what_is_appeal_about,
       # The following are dependent attributes that need to be reset

--- a/app/forms/what_is_dispute_about_income_tax_form.rb
+++ b/app/forms/what_is_dispute_about_income_tax_form.rb
@@ -14,6 +14,10 @@ class WhatIsDisputeAboutIncomeTaxForm < BaseForm
 
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
-    tribunal_case.update(what_is_dispute_about: what_is_dispute_about)
+    tribunal_case.update(
+      what_is_dispute_about: what_is_dispute_about,
+      # The following are dependent attributes that need to be reset
+      what_is_penalty_or_surcharge_amount: nil
+    )
   end
 end

--- a/app/forms/what_is_dispute_about_income_tax_form.rb
+++ b/app/forms/what_is_dispute_about_income_tax_form.rb
@@ -12,8 +12,14 @@ class WhatIsDisputeAboutIncomeTaxForm < BaseForm
 
   private
 
+  def changed?
+    tribunal_case.what_is_dispute_about != what_is_dispute_about
+  end
+
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
+    return unless changed?
+
     tribunal_case.update(
       what_is_dispute_about: what_is_dispute_about,
       # The following are dependent attributes that need to be reset

--- a/app/forms/what_is_dispute_about_vat_form.rb
+++ b/app/forms/what_is_dispute_about_vat_form.rb
@@ -13,6 +13,10 @@ class WhatIsDisputeAboutVatForm < BaseForm
 
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
-    tribunal_case.update(what_is_dispute_about: what_is_dispute_about)
+    tribunal_case.update(
+      what_is_dispute_about: what_is_dispute_about,
+      # The following are dependent attributes that need to be reset
+      what_is_penalty_or_surcharge_amount: nil
+    )
   end
 end

--- a/app/forms/what_is_dispute_about_vat_form.rb
+++ b/app/forms/what_is_dispute_about_vat_form.rb
@@ -11,8 +11,14 @@ class WhatIsDisputeAboutVatForm < BaseForm
 
   private
 
+  def changed?
+    tribunal_case.what_is_dispute_about != what_is_dispute_about
+  end
+
   def persist!
     raise 'No TribunalCase given' unless tribunal_case
+    return unless changed?
+
     tribunal_case.update(
       what_is_dispute_about: what_is_dispute_about,
       # The following are dependent attributes that need to be reset

--- a/app/presenters/change_cost_answers_presenter.rb
+++ b/app/presenters/change_cost_answers_presenter.rb
@@ -1,0 +1,77 @@
+class ChangeCostAnswersPresenter
+  ChangeCostAnswerRow = Struct.new(:question, :answer, :change_path)
+
+  include Rails.application.routes.url_helpers
+
+  def initialize(tribunal_case)
+    @tribunal_case = tribunal_case
+  end
+
+  attr_reader :tribunal_case
+
+  def rows
+    [
+      did_challenge_hmrc_question,
+      what_is_appeal_about_question,
+      what_is_dispute_about_question,
+      what_is_penalty_or_surcharge_amount_question
+    ].compact
+  end
+
+  private
+
+  def did_challenge_hmrc_question
+    row(
+      tribunal_case.did_challenge_hmrc,
+      as:   :did_challenge_hmrc,
+      path: edit_steps_did_challenge_hmrc_path
+    )
+  end
+
+  def what_is_appeal_about_question
+    path = if tribunal_case.did_challenge_hmrc
+             edit_steps_what_is_appeal_about_challenged_path
+           else
+             edit_steps_what_is_appeal_about_unchallenged_path
+           end
+
+    row(
+      tribunal_case.what_is_appeal_about,
+      as:   :what_is_appeal_about,
+      path: path
+    )
+  end
+
+  def what_is_dispute_about_question
+    path = if tribunal_case.what_is_appeal_about == 'income_tax'
+             edit_steps_what_is_dispute_about_income_tax_path
+           else
+             edit_steps_what_is_dispute_about_vat_path
+           end
+
+    row(
+      tribunal_case.what_is_dispute_about,
+      as:   :what_is_dispute_about,
+      path: path
+    )
+  end
+
+  def what_is_penalty_or_surcharge_amount_question
+    row(
+      tribunal_case.what_is_penalty_or_surcharge_amount,
+      as:   :what_is_penalty_or_surcharge_amount,
+      path: edit_steps_what_is_late_penalty_or_surcharge_path
+    )
+  end
+
+  def row(model_attribute, as:, path:)
+    # `false` counts as blank, but is a valid value here so we can't use #blank?
+    return if model_attribute.nil? || model_attribute == ''
+
+    ChangeCostAnswerRow.new(
+      ".questions.#{as}",
+      ".answers.#{as}.#{model_attribute}",
+      path
+    )
+  end
+end

--- a/app/views/steps/determine_cost/show.html.erb
+++ b/app/views/steps/determine_cost/show.html.erb
@@ -4,6 +4,25 @@
 <%=t '.lead_text' %>
 </p>
 
+<table>
+  <thead>
+    <tr>
+      <th scope="col"><%=t '.check_your_answers' %></th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @change_answers.rows.each do |row| %>
+      <tr>
+        <td><%=t row.question %></td>
+        <td><strong><%=t row.answer %></strong></td>
+        <td><%= link_to t('.change'), row.change_path %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
 <p>
   <%= link_to t('.start_again'), session_path, method: :delete, class: 'link-back' %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,33 @@ en:
         heading: Your Appeal
         lead_text: To submit an appeal you will have to pay
         start_again: Start again
+        change: Change
+        questions:
+          did_challenge_hmrc: Did you challenge the decision with HMRC first?
+          what_is_appeal_about: What is your appeal about?
+          what_is_dispute_about: What is your dispute about?
+          what_is_penalty_or_surcharge_amount: What is the penalty or surcharge amount?
+        answers:
+          did_challenge_hmrc:
+            'true': 'Yes'
+            'false': 'No'
+          what_is_appeal_about:
+            income_tax: Income Tax
+            vat: Value Added Tax (VAT)
+            apn_penalty: Advance Payment Notice (APN) penalty
+            inaccurate_return: Inaccurate return
+            closure_notice: Closure notice
+            information_notice: Information notices (Schedule 36)
+            request_permission_for_review: Request permission for a review
+            other_html: Other
+          what_is_dispute_about:
+            late_return_or_payment: Late return or payment
+            amount_of_tax_owed: Amount of tax owed
+            paye_coding_notice: Pay As You Earn (PAYE) coding notice
+          what_is_penalty_or_surcharge_amount:
+            100_or_less: £100 or less
+            101_to_20000: £101 – £20,000
+            20001_or_more: £20,001 or more
     must_challenge_hmrc:
       show:
         heading: You must challenge HMRC before you can appeal

--- a/spec/forms/did_challenge_hmrc_form_spec.rb
+++ b/spec/forms/did_challenge_hmrc_form_spec.rb
@@ -57,5 +57,15 @@ RSpec.describe DidChallengeHmrcForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when did_challenge_hmrc is already the same on the model' do
+      let(:tribunal_case)      { instance_double(TribunalCase, did_challenge_hmrc: true) }
+      let(:did_challenge_hmrc) { true }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
   end
 end

--- a/spec/forms/did_challenge_hmrc_form_spec.rb
+++ b/spec/forms/did_challenge_hmrc_form_spec.rb
@@ -48,7 +48,12 @@ RSpec.describe DidChallengeHmrcForm do
       let(:did_challenge_hmrc) { true }
 
       it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with( did_challenge_hmrc: true)
+        expect(tribunal_case).to receive(:update).with(
+          did_challenge_hmrc: true,
+          what_is_appeal_about: nil,
+          what_is_dispute_about: nil,
+          what_is_penalty_or_surcharge_amount: nil
+        )
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/what_is_appeal_about_form_spec.rb
+++ b/spec/forms/what_is_appeal_about_form_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe WhatIsAppealAboutForm do
       end
     end
 
-    context 'when did_challenge_hmrc is valid' do
+    context 'when what_is_appeal_about is valid' do
       let(:what_is_appeal_about) { 'income_tax' }
 
       it 'saves the record' do
@@ -53,6 +53,16 @@ RSpec.describe WhatIsAppealAboutForm do
           what_is_dispute_about: nil,
           what_is_penalty_or_surcharge_amount: nil
         )
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when what_is_appeal_about is already the same on the model' do
+      let(:tribunal_case)      { instance_double(TribunalCase, what_is_appeal_about: 'vat') }
+      let(:what_is_appeal_about) { 'vat' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/what_is_appeal_about_form_spec.rb
+++ b/spec/forms/what_is_appeal_about_form_spec.rb
@@ -48,7 +48,11 @@ RSpec.describe WhatIsAppealAboutForm do
       let(:what_is_appeal_about) { 'income_tax' }
 
       it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with( what_is_appeal_about: 'income_tax')
+        expect(tribunal_case).to receive(:update).with(
+          what_is_appeal_about: 'income_tax',
+          what_is_dispute_about: nil,
+          what_is_penalty_or_surcharge_amount: nil
+        )
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/what_is_dispute_about_income_tax_form_spec.rb
+++ b/spec/forms/what_is_dispute_about_income_tax_form_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe WhatIsDisputeAboutIncomeTaxForm do
       let(:what_is_dispute_about) { 'paye_coding_notice' }
 
       it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with( what_is_dispute_about: 'paye_coding_notice')
+        expect(tribunal_case).to receive(:update).with(
+          what_is_dispute_about: 'paye_coding_notice',
+          what_is_penalty_or_surcharge_amount: nil
+        )
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/what_is_dispute_about_income_tax_form_spec.rb
+++ b/spec/forms/what_is_dispute_about_income_tax_form_spec.rb
@@ -55,5 +55,15 @@ RSpec.describe WhatIsDisputeAboutIncomeTaxForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when what_is_dispute_about is already the same on the model' do
+      let(:tribunal_case)      { instance_double(TribunalCase, what_is_dispute_about: 'paye_coding_notice') }
+      let(:what_is_dispute_about) { 'paye_coding_notice' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
   end
 end

--- a/spec/forms/what_is_dispute_about_vat_form_spec.rb
+++ b/spec/forms/what_is_dispute_about_vat_form_spec.rb
@@ -55,5 +55,15 @@ RSpec.describe WhatIsDisputeAboutVatForm do
         expect(subject.save).to be(true)
       end
     end
+
+    context 'when what_is_dispute_about is already the same on the model' do
+      let(:tribunal_case)      { instance_double(TribunalCase, what_is_dispute_about: 'late_return_or_payment') }
+      let(:what_is_dispute_about) { 'late_return_or_payment' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
   end
 end

--- a/spec/forms/what_is_dispute_about_vat_form_spec.rb
+++ b/spec/forms/what_is_dispute_about_vat_form_spec.rb
@@ -48,7 +48,10 @@ RSpec.describe WhatIsDisputeAboutVatForm do
       let(:what_is_dispute_about) { 'late_return_or_payment' }
 
       it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with( what_is_dispute_about: 'late_return_or_payment')
+        expect(tribunal_case).to receive(:update).with(
+          what_is_dispute_about: 'late_return_or_payment',
+          what_is_penalty_or_surcharge_amount: nil
+        )
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/what_is_late_penalty_or_surcharge_form_spec.rb
+++ b/spec/forms/what_is_late_penalty_or_surcharge_form_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe WhatIsLatePenaltyOrSurchargeForm do
+  let(:arguments) { {
+    tribunal_case:                       tribunal_case,
+    what_is_penalty_or_surcharge_amount: what_is_penalty_or_surcharge_amount
+  } }
+  let(:tribunal_case)         { instance_double(TribunalCase, what_is_penalty_or_surcharge_amount: nil) }
+  let(:what_is_penalty_or_surcharge_amount) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)                       { nil }
+      let(:what_is_penalty_or_surcharge_amount) { '100_or_less' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when what_is_penalty_or_surcharge_amount is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_penalty_or_surcharge_amount]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_penalty_or_surcharge_amount is not valid' do
+      let(:what_is_penalty_or_surcharge_amount) { 'loads-of-$$$' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:what_is_penalty_or_surcharge_amount]).to_not be_empty
+      end
+    end
+
+    context 'when what_is_penalty_or_surcharge_amount is valid' do
+      let(:what_is_penalty_or_surcharge_amount) { '100_or_less' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          what_is_penalty_or_surcharge_amount: '100_or_less'
+        )
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/change_cost_answers_presenter_spec.rb
+++ b/spec/presenters/change_cost_answers_presenter_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe ChangeCostAnswersPresenter do
+  subject { described_class.new(tribunal_case) }
+  let(:tribunal_case) {
+    instance_double(
+      TribunalCase,
+      did_challenge_hmrc:                  did_challenge_hmrc,
+      what_is_appeal_about:                what_is_appeal_about,
+      what_is_dispute_about:               what_is_dispute_about,
+      what_is_penalty_or_surcharge_amount: what_is_penalty_or_surcharge_amount
+    )
+  }
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  let(:did_challenge_hmrc)                  { true }
+  let(:what_is_appeal_about)                { 'foo' }
+  let(:what_is_dispute_about)               { nil }
+  let(:what_is_penalty_or_surcharge_amount) { nil }
+
+  describe '#rows' do
+    describe '`did_challenge_hmrc` row' do
+      let(:row) { subject.rows.first }
+
+      context 'when appeal is challenged' do
+        let(:did_challenge_hmrc) { true }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.did_challenge_hmrc')
+          expect(row.answer).to      eq('.answers.did_challenge_hmrc.true')
+          expect(row.change_path).to eq(paths.edit_steps_did_challenge_hmrc_path)
+        end
+      end
+
+      context 'when appeal is unchallenged' do
+        let(:did_challenge_hmrc) { false }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.did_challenge_hmrc')
+          expect(row.answer).to      eq('.answers.did_challenge_hmrc.false')
+          expect(row.change_path).to eq(paths.edit_steps_did_challenge_hmrc_path)
+        end
+      end
+    end
+
+    describe '`what_is_appeal_about` row' do
+      let(:row) { subject.rows.second }
+      let(:what_is_appeal_about) { 'foo' }
+
+      context 'when appeal is challenged' do
+        let(:did_challenge_hmrc) { true }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.what_is_appeal_about')
+          expect(row.answer).to      eq('.answers.what_is_appeal_about.foo')
+          expect(row.change_path).to eq(paths.edit_steps_what_is_appeal_about_challenged_path)
+        end
+      end
+
+      context 'when appeal is unchallenged' do
+        let(:did_challenge_hmrc) { false }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.what_is_appeal_about')
+          expect(row.answer).to      eq('.answers.what_is_appeal_about.foo')
+          expect(row.change_path).to eq(paths.edit_steps_what_is_appeal_about_unchallenged_path)
+        end
+      end
+    end
+
+    describe '`what_is_dispute_about` row' do
+      let(:row) { subject.rows[2] }
+
+      context 'when `what_is_dispute_about` is nil' do
+        let(:what_is_dispute_about) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `what_is_appeal_about` is income_tax' do
+        let(:what_is_dispute_about) { 'foo' }
+        let(:what_is_appeal_about)  { 'income_tax' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.what_is_dispute_about')
+          expect(row.answer).to      eq('.answers.what_is_dispute_about.foo')
+          expect(row.change_path).to eq(paths.edit_steps_what_is_dispute_about_income_tax_path)
+        end
+      end
+
+      context 'when `what_is_appeal_about` is vat' do
+        let(:what_is_dispute_about) { 'foo' }
+        let(:what_is_appeal_about)  { 'vat' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.what_is_dispute_about')
+          expect(row.answer).to      eq('.answers.what_is_dispute_about.foo')
+          expect(row.change_path).to eq(paths.edit_steps_what_is_dispute_about_vat_path)
+        end
+      end
+    end
+
+    describe '`what_is_penalty_or_surcharge_amount` row' do
+      let(:row) { subject.rows[3] }
+
+      # Needed so that the row is in the correct position
+      let(:what_is_dispute_about) { 'foo' }
+      let(:what_is_appeal_about)  { 'bar' }
+
+      context 'when `what_is_penalty_or_surcharge_amount` is nil' do
+        let(:what_is_penalty_or_surcharge_amount) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `what_is_penalty_or_surcharge_amount` is given' do
+        let(:what_is_penalty_or_surcharge_amount)  { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.what_is_penalty_or_surcharge_amount')
+          expect(row.answer).to      eq('.answers.what_is_penalty_or_surcharge_amount.foo')
+          expect(row.change_path).to eq(paths.edit_steps_what_is_late_penalty_or_surcharge_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add `ChangeCostAnswersPresenter` to model the 'Check Your Answers' section of the endpoint that shows your appeal cost
- Reset dependent attributes when updating attributes in form objects
- Add missing spec for `WhatIsLatePenaltyOrSurchargeForm`

![screen shot 2016-11-03 at 11 58 07](https://cloud.githubusercontent.com/assets/72141/19964958/848747f2-a1bc-11e6-8bc2-d534ae46eb26.png)
