### PR TITLE
Expire sessions after 30 minutes

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,2 +1,3 @@
-
-Rails.application.config.session_store :cookie_store, key: '_tax-tribunals-datacapture_session'
+Rails.application.config.session_store :cookie_store,
+  key:          '_tax-tribunals-datacapture_session',
+  expire_after: 30.minutes


### PR DESCRIPTION
We are exploring ways to handle session expiry in a more user friendly manner (dialogue box or some such before the session expires, offering an option to continue) in the future. This may or may not be mitigated by "save and return" functionality also.