### PR TITLE
Add value object for dispute_type

### DIFF
--- a/app/forms/case_type_form.rb
+++ b/app/forms/case_type_form.rb
@@ -2,7 +2,7 @@ class CaseTypeForm < BaseForm
   attribute :case_type, String
 
   def self.choices
-    TribunalCase.case_type_values.map(&:to_s)
+    CaseType.values.map(&:to_s)
   end
 
   validates_inclusion_of :case_type, in: choices

--- a/app/forms/dispute_type_form.rb
+++ b/app/forms/dispute_type_form.rb
@@ -5,17 +5,17 @@ class DisputeTypeForm < BaseForm
 
   def choices
     if include_paye_coding_notice?
-      %w(
-        late_return_or_payment
-        amount_of_tax_owed
-        paye_coding_notice
-      )
+      [
+        DisputeType::LATE_RETURN_OR_PAYMENT,
+        DisputeType::AMOUNT_OF_TAX_OWED,
+        DisputeType::PAYE_CODING_NOTICE
+      ]
     else
-      %w(
-        late_return_or_payment
-        amount_of_tax_owed
-      )
-    end
+      [
+        DisputeType::LATE_RETURN_OR_PAYMENT,
+        DisputeType::AMOUNT_OF_TAX_OWED
+      ]
+    end.map(&:to_s)
   end
 
   def case_challenged?
@@ -24,12 +24,16 @@ class DisputeTypeForm < BaseForm
 
   private
 
+  def dispute_type_value
+    DisputeType.new(dispute_type)
+  end
+
   def include_paye_coding_notice?
     tribunal_case&.case_type == CaseType::INCOME_TAX
   end
 
   def changed?
-    tribunal_case.dispute_type != dispute_type
+    tribunal_case.dispute_type != dispute_type_value
   end
 
   def persist!
@@ -37,7 +41,7 @@ class DisputeTypeForm < BaseForm
     return unless changed?
 
     tribunal_case.update(
-      dispute_type: dispute_type,
+      dispute_type: dispute_type_value,
       # The following are dependent attributes that need to be reset
       penalty_amount: nil
     )

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,10 +1,9 @@
 class TribunalCase < ApplicationRecord
   composed_of :case_type,
-    class_name: 'CaseType',
     allow_nil:  true,
     mapping:    [%w(case_type value)]
 
-  def self.case_type_values
-    CaseType.values
-  end
+  composed_of :dispute_type,
+    allow_nil:  true,
+    mapping:    [%w(dispute_type value)]
 end

--- a/app/services/cost_determiner.rb
+++ b/app/services/cost_determiner.rb
@@ -29,9 +29,9 @@ class CostDeterminer
 
   def vat_lodgement_fee
     case tribunal_case.dispute_type
-    when 'amount_of_tax_owed'
+    when DisputeType::AMOUNT_OF_TAX_OWED
       LodgementFee::FEE_LEVEL_3
-    when 'late_return_or_payment'
+    when DisputeType::LATE_RETURN_OR_PAYMENT
       penalty_amount_tribunal_case_cost
     else
       raise "Unable to determine cost of VAT tribunal_case"
@@ -40,11 +40,11 @@ class CostDeterminer
 
   def income_tax_lodgement_fee
     case tribunal_case.dispute_type
-    when 'paye_coding_notice'
+    when DisputeType::PAYE_CODING_NOTICE
       LodgementFee::FEE_LEVEL_2
-    when 'amount_of_tax_owed'
+    when DisputeType::AMOUNT_OF_TAX_OWED
       LodgementFee::FEE_LEVEL_3
-    when 'late_return_or_payment'
+    when DisputeType::LATE_RETURN_OR_PAYMENT
       penalty_amount_tribunal_case_cost
     else
       raise "Unable to determine cost of income tax tribunal_case"

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -11,7 +11,7 @@ class CaseType < ValueObject
   ].freeze
 
   def initialize(raw_value)
-    raise ArgumentError.new('Fee value must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    raise ArgumentError.new('Case type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
     super(raw_value.to_sym)
   end
 

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -1,0 +1,12 @@
+class DisputeType < ValueObject
+  VALUES = [
+    PAYE_CODING_NOTICE     = new(:paye_coding_notice),
+    LATE_RETURN_OR_PAYMENT = new(:late_return_or_payment),
+    AMOUNT_OF_TAX_OWED     = new(:amount_of_tax_owed)
+  ].freeze
+
+  def initialize(raw_value)
+    raise ArgumentError.new('Dispute type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    super(raw_value.to_sym)
+  end
+end

--- a/spec/forms/case_type_form_spec.rb
+++ b/spec/forms/case_type_form_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe CaseTypeForm do
     end
 
     context 'when case_type is already the same on the model' do
-      let(:tribunal_case)      { instance_double(TribunalCase, case_type: CaseType.new('vat')) }
-      let(:case_type) { 'vat' }
+      let(:tribunal_case) { instance_double(TribunalCase, case_type: CaseType::VAT) }
+      let(:case_type)     { 'vat' }
 
       it 'does not save the record but returns true' do
         expect(tribunal_case).to_not receive(:update)

--- a/spec/forms/dispute_type_form_spec.rb
+++ b/spec/forms/dispute_type_form_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe DisputeTypeForm do
   let(:arguments) { {
-    tribunal_case:         tribunal_case,
-    dispute_type: dispute_type
+    tribunal_case: tribunal_case,
+    dispute_type:  dispute_type
   } }
   let(:tribunal_case) {
     instance_double(
@@ -47,7 +47,7 @@ RSpec.describe DisputeTypeForm do
 
   describe '#choices' do
     context 'when the appeal is about income tax' do
-      let(:case_type) { CaseType.new('income_tax') }
+      let(:case_type) { CaseType::INCOME_TAX }
 
       it 'includes PAYE coding notice' do
         expect(subject.choices).to eq(%w(
@@ -59,7 +59,7 @@ RSpec.describe DisputeTypeForm do
     end
 
     context 'when the appeal is not about income tax' do
-      let(:case_type) { CaseType.new('vat') }
+      let(:case_type) { CaseType::VAT }
 
       it 'does not include PAYE coding notice' do
         expect(subject.choices).to eq(%w(
@@ -109,7 +109,7 @@ RSpec.describe DisputeTypeForm do
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          dispute_type: 'amount_of_tax_owed',
+          dispute_type: DisputeType::AMOUNT_OF_TAX_OWED,
           penalty_amount: nil
         )
         expect(subject.save).to be(true)
@@ -121,7 +121,7 @@ RSpec.describe DisputeTypeForm do
       let(:dispute_type) { 'paye_coding_notice' }
 
       context 'and the appeal is about income tax' do
-        let(:case_type) { CaseType.new('income_tax') }
+        let(:case_type) { CaseType::INCOME_TAX }
 
         it 'is valid' do
           expect(subject).to be_valid
@@ -129,7 +129,7 @@ RSpec.describe DisputeTypeForm do
       end
 
       context 'and the appeal is not about income tax' do
-        let(:case_type) { CaseType.new('vat') }
+        let(:case_type) { CaseType::VAT }
 
         it 'is not valid' do
           expect(subject).to_not be_valid
@@ -141,7 +141,8 @@ RSpec.describe DisputeTypeForm do
       let(:tribunal_case) {
         instance_double(
           TribunalCase,
-          dispute_type: 'paye_coding_notice', case_type:  CaseType.new('income_tax')
+          dispute_type: DisputeType::PAYE_CODING_NOTICE,
+          case_type:    CaseType::INCOME_TAX
         )
       }
       let(:dispute_type) { 'paye_coding_notice' }

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -1,10 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe TribunalCase, type: :model do
-  describe '.case_type_values' do
-    it 'gets values from the CaseType' do
-      expect(CaseType).to receive(:values).and_return(['foo'])
-      expect(described_class.case_type_values).to eq(['foo'])
-    end
-  end
 end

--- a/spec/services/cost_determiner_spec.rb
+++ b/spec/services/cost_determiner_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::VAT) }
 
       context "when dispute is about an unhandled value" do
-        let(:case_attrs) { super().merge(dispute_type: 'something') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType.new('$^&%*')) }
 
         specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of VAT tribunal_case") }
       end
 
       context "when dispute is about late return/payment" do
-        let(:case_attrs) { super().merge(dispute_type: 'late_return_or_payment') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType::LATE_RETURN_OR_PAYMENT) }
 
         context "when the penalty/surcharge amounts is £100" do
           let(:case_attrs) { super().merge(penalty_amount: '100_or_less') }
@@ -59,7 +59,7 @@ RSpec.describe CostDeterminer do
       end
 
       context "when dispute is about amount of tax owed" do
-        let(:case_attrs) { super().merge(dispute_type: 'amount_of_tax_owed') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType::AMOUNT_OF_TAX_OWED) }
 
         it "has £200 lodgement fee" do
           expect(subject.lodgement_fee.value).to eq(20000)
@@ -111,13 +111,13 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::INCOME_TAX) }
 
       context "when dispute is about an unhandled value" do
-        let(:case_attrs) { super().merge(dispute_type: 'something') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType.new('%$^&*@')) }
 
         specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of income tax tribunal_case") }
       end
 
       context "when dispute is about amount of tax owed" do
-        let(:case_attrs) { super().merge(dispute_type: 'amount_of_tax_owed') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType::AMOUNT_OF_TAX_OWED) }
 
         it "has £200 lodgement fee" do
           expect(subject.lodgement_fee.value).to eq(20000)
@@ -125,7 +125,7 @@ RSpec.describe CostDeterminer do
       end
 
       context "when dispute is about paye coding" do
-        let(:case_attrs) { super().merge(dispute_type: 'paye_coding_notice') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType::PAYE_CODING_NOTICE) }
 
         it "has £50 lodgement fee" do
           expect(subject.lodgement_fee.value).to eq(5000)
@@ -133,7 +133,7 @@ RSpec.describe CostDeterminer do
       end
 
       context "when dispute is about late return/payment" do
-        let(:case_attrs) { super().merge(dispute_type: 'late_return_or_payment') }
+        let(:case_attrs) { super().merge(dispute_type: DisputeType::LATE_RETURN_OR_PAYMENT) }
 
         context "when the penalty/surcharge amounts is £100" do
           let(:case_attrs) { super().merge(penalty_amount: '100_or_less') }


### PR DESCRIPTION
- Add `DisputeType` in line with the other value objects
- Clean up some remaining incorrect use of value objects
- Move `CaseType` values out of `TribunalCase` model