### PR TITLE
Implement task list start page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,5 +38,7 @@
 @import 'elements/phase-banner';
 @import 'elements/components';
 
+@import 'local/developer_tools';
+@import 'local/tasklist';
 @import 'local/typography';
 

--- a/app/assets/stylesheets/local/developer_tools.scss
+++ b/app/assets/stylesheets/local/developer_tools.scss
@@ -1,0 +1,8 @@
+#footer .developer_tools {
+  margin: 0;
+
+  .button-destroy_session {
+    background-color: $mellow-red;
+    color: $page-colour;
+  }
+}

--- a/app/assets/stylesheets/local/tasklist.scss
+++ b/app/assets/stylesheets/local/tasklist.scss
@@ -1,0 +1,89 @@
+.homepage-top {
+  text-align: center;
+  background-color: $govuk-blue;
+  color: $page-colour;
+  margin-bottom: 30px;
+
+  .homepage-top-inner {
+    position: relative;
+    overflow: hidden;
+    max-width: 1020px;
+    margin: 0 auto;
+    text-align: left;
+  }
+
+  .floated-inner-block {
+    margin: 0 15px;
+  }
+
+  h1 {
+    font-family: "nta", Arial, sans-serif;
+    font-size: 32px;
+    line-height: 1.09375;
+    font-weight: 400;
+    text-transform: none;
+    font-size-adjust: 0.5;
+    font-weight: bold;
+    padding: 25px 0 15px;
+
+    @media (min-width: 641px) {
+      font-size: 48px;
+      line-height: 1.04167;
+    }
+  }
+
+  @media (min-width: 641px) {
+    .welcome-text {
+      width: 66.66%;
+    }
+
+    .inner-block {
+      margin: 0 30px;
+    }
+    .inner-block.floated-children {
+      margin: 0 15px;
+    }
+  }
+}
+
+.task-list {
+  font-size: 24px;
+  border-top: 1px solid $grey-2;
+  list-style-position: inside;
+  padding-left: 0;
+  margin-top: 45px;
+  margin-bottom: 45px;
+
+  li {
+    padding: 15px 0;
+    border-bottom: 1px solid $grey-2;
+    margin: 0;
+    position: relative;
+  }
+
+  a.task-link {
+    font-weight: bold;
+    display: block;
+  }
+
+  span.task-status {
+    position: absolute;
+    right: 5px;
+    top: 20px;
+
+    padding: 2px 5px 0;
+    font-size: 16px;
+    line-height: 1.25;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: $page-colour;
+    background-color: $black;
+  }
+
+  a.button-start {
+    position: absolute;
+    right: 5px;
+    top: 20px;
+  }
+}

--- a/app/controllers/start_controller.rb
+++ b/app/controllers/start_controller.rb
@@ -1,4 +1,6 @@
 class StartController < ApplicationController
   def index
+    tribunal_case = TribunalCase.find_by_id(session[:tribunal_case_id])
+    @presenter = TaskListPresenter.new(tribunal_case)
   end
 end

--- a/app/controllers/steps/cost/challenged_decision_controller.rb
+++ b/app/controllers/steps/cost/challenged_decision_controller.rb
@@ -16,6 +16,8 @@ class Steps::Cost::ChallengedDecisionController < StepController
   def current_tribunal_case
     # This step, and only this step, should create a tribunal case if
     # there isn't one in the session - because it's the first
+    # TODO: Reconsider where this should go - it's not very intuitive
+    #   to be doing this here.
     super || TribunalCase.create.tap do |tribunal_case|
       session[:tribunal_case_id] = tribunal_case.id
     end

--- a/app/controllers/steps/cost/determine_cost_controller.rb
+++ b/app/controllers/steps/cost/determine_cost_controller.rb
@@ -5,6 +5,9 @@ class Steps::Cost::DetermineCostController < StepController
     @change_answers = ChangeCostAnswersPresenter.new(current_tribunal_case)
     @lodgement_fee = CostDeterminer.new(current_tribunal_case).lodgement_fee
 
+    # TODO: Consider where we should actually do this update.
+    #   It doesn't hurt to do this over and over again but is
+    #   strictly speaking in violation of REST.
     current_tribunal_case.update(lodgement_fee: @lodgement_fee)
   end
 end

--- a/app/controllers/steps/cost/determine_cost_controller.rb
+++ b/app/controllers/steps/cost/determine_cost_controller.rb
@@ -4,5 +4,7 @@ class Steps::Cost::DetermineCostController < StepController
 
     @change_answers = ChangeCostAnswersPresenter.new(current_tribunal_case)
     @lodgement_fee = CostDeterminer.new(current_tribunal_case).lodgement_fee
+
+    current_tribunal_case.update(lodgement_fee: @lodgement_fee)
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -10,4 +10,8 @@ class TribunalCase < ApplicationRecord
   composed_of :penalty_amount,
     allow_nil:  true,
     mapping:    [%w(penalty_amount value)]
+
+  composed_of :lodgement_fee,
+    allow_nil:  true,
+    mapping:    [%w(lodgement_fee value)]
 end

--- a/app/presenters/task_list_presenter.rb
+++ b/app/presenters/task_list_presenter.rb
@@ -1,0 +1,29 @@
+class TaskListPresenter
+  TaskListRow = Struct.new(:title, :minutes_to_complete, :value, :start_path)
+
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::NumberHelper
+
+  def initialize(tribunal_case)
+    @tribunal_case = tribunal_case
+  end
+
+  attr_reader :tribunal_case
+
+  def rows
+    [
+      cost_determination_row
+    ]
+  end
+
+  private
+
+  def cost_determination_row
+    if tribunal_case&.lodgement_fee?
+      value = number_to_currency(tribunal_case.lodgement_fee.to_gbp)
+      TaskListRow.new(:determine_cost, 5, value, steps_cost_start_path)
+    else
+      TaskListRow.new(:determine_cost, 5, nil, steps_cost_start_path)
+    end
+  end
+end

--- a/app/services/glimr_fees.rb
+++ b/app/services/glimr_fees.rb
@@ -1,0 +1,14 @@
+class GlimrFees
+  def self.fee_amount(fee)
+    case fee
+    when LodgementFee::FEE_LEVEL_1
+      20_00
+    when LodgementFee::FEE_LEVEL_2
+      50_00
+    when LodgementFee::FEE_LEVEL_3
+      200_00
+    else
+      raise ArgumentError, 'Fee must be a known Fee value'
+    end
+  end
+end

--- a/app/value_objects/fee.rb
+++ b/app/value_objects/fee.rb
@@ -1,10 +1,10 @@
 class Fee < ValueObject
   def initialize(raw_value)
-    raise ArgumentError.new('Fee value must be integer or implicitly convertible') unless raw_value.respond_to?(:to_int)
-    super(raw_value.to_int)
+    raise ArgumentError.new('Fee value must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    super(raw_value.to_sym)
   end
 
   def to_gbp
-    (value / 100.0)
+    GlimrFees.fee_amount(self) / 100.0
   end
 end

--- a/app/value_objects/lodgement_fee.rb
+++ b/app/value_objects/lodgement_fee.rb
@@ -1,7 +1,7 @@
 class LodgementFee < Fee
   VALUES = [
-    FEE_LEVEL_1 =  new(20_00),
-    FEE_LEVEL_2 =  new(50_00),
-    FEE_LEVEL_3 = new(200_00)
+    FEE_LEVEL_1 = new(:fee_level_1),
+    FEE_LEVEL_2 = new(:fee_level_2),
+    FEE_LEVEL_3 = new(:fee_level_3)
   ]
 end

--- a/app/views/application/_developer_tools.html.erb
+++ b/app/views/application/_developer_tools.html.erb
@@ -1,0 +1,14 @@
+  <% content_for(:footer_top) do %>
+    <details class="developer_tools">
+      <summary><span class="summary">Developer Tools</span></summary>
+      <div class="panel panel-border-narrow">
+        <% if @form_object&.tribunal_case %>
+          <h4 class="heading-small">Current Case ID</h4>
+          <p>
+            <%= @form_object.tribunal_case.id %>
+          </p>
+        <% end %>
+        <%= link_to 'Destroy session', session_path, method: :delete, class: 'button button-destroy_session', data: { confirm: 'Are you sure?' } %>
+      </div>
+    </details>
+  <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,19 +35,7 @@
 <% end %>
 
 <% if Rails.env.development? %>
-  <% content_for(:footer_top) do %>
-    <details>
-      <summary><span class="summary">Debug Information</span></summary>
-      <div class="panel panel-border-narrow">
-        <% if @form_object&.tribunal_case %>
-          <h4 class="heading-small">Current Case ID</h4>
-          <p>
-            <%= @form_object.tribunal_case.id %>
-          </p>
-        <% end %>
-      </div>
-    </details>
-  <% end %>
+  <%= render partial: 'developer_tools' %>
 <% end %>
 
 <%= render template: "layouts/govuk_template" %>

--- a/app/views/start/index.html.erb
+++ b/app/views/start/index.html.erb
@@ -1,6 +1,18 @@
-<h1 class="heading-large">
-  <%=t '.heading' %>
-</h1>
+<header class="homepage-top">
+  <div class="homepage-top-inner">
+    <div class="welcome-block">
+        <div class="inner-block floated-children">
+          <div class="welcome-text">
+            <div class="floated-inner-block">
+              <h1>
+                <%=t '.heading' %>
+              </h1>
+            </div>
+          </div>
+        </div>
+      </div>
+  </div>
+</header>
 
 <p class="lede">
   <%=t '.lead_text' %>
@@ -8,8 +20,21 @@
 
 <%=t '.description_html' %>
 
-<p>
-  <%= link_to t('.start_now'), steps_cost_start_path, class: 'button button-start', role: 'button' %>
-</p>
+<ol class="list list-number task-list" data-task-list="">
+  <% @presenter.rows.each do |row| %>
+    <li>
+      <%= link_to t(row.title), row.start_path, class: 'task-link' %> (<%=t '.minutes_to_complete', count: row.minutes_to_complete %>)
+      <% if row.value %>
+        <span class="task-status">
+          <span data-key="fee">
+            <%= row.value %>
+          </span>
+        </span>
+      <% else %>
+        <%= link_to t('.start'), row.start_path, class: 'button button-start', role: 'button' %>
+      <% end %>
+    </li>
+  <% end %>
+</ol>
 
 <%=t '.further_html' %>

--- a/config/locales/start.yml
+++ b/config/locales/start.yml
@@ -1,6 +1,24 @@
 en:
   start:
     index:
-      heading: Appeal to an independent tax tribunal
-      lead_text: Use this service to settle a tax dispute with HM Revenue and Customs (HMRC).
-      start_now: Start now
+      heading: The tax tribunal is independent of government
+      lead_text: Use this service to settle a tax dispute by getting an impartial ruling from a judge.
+      description_html: |
+        <p>You must enter your appeal details in one go. You can't save and return to make changes at a later date.</p>
+        <p>Start your appeal by following each step below.</p>
+      further_html: |
+        <h2 class="heading-medium">Paying for an existing appeal</h2>
+        <p>If you have received a tribunal reference number and a confirmation code by email but still need to pay your fee, <a href="#">you can pay your tribunal fees online now</a>.</p>
+        <h2 class="heading-medium">Other ways to submit an appeal</h2>
+        <ul class="list list-bullet">
+          <li>You can submit an appeal or application by <a class="external" rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForms.do?court_forms_category=Tax%20(First-tier%20Tribunal)">paper form</a></li>
+          <li>
+            Send by post to First-tier Tribunal (Tax Chamber), PO Box 16972, Birmingham, B16 6TZ
+          </li>
+        </ul>
+      task_titles:
+        determine_cost: Find out the cost of your appeal
+      minutes_to_complete:
+        one: 1 minute to complete
+        other: "%{count} minutes to complete"
+      start: Start

--- a/db/migrate/20161117121149_add_lodgement_fee_to_tribunal_case.rb
+++ b/db/migrate/20161117121149_add_lodgement_fee_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddLodgementFeeToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :lodgement_fee, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161111110118) do
+ActiveRecord::Schema.define(version: 20161117121149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20161111110118) do
     t.string   "case_type"
     t.string   "dispute_type"
     t.string   "penalty_amount"
+    t.string   "lodgement_fee"
   end
 
 end

--- a/spec/presenters/task_list_presenter_spec.rb
+++ b/spec/presenters/task_list_presenter_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe TaskListPresenter do
+  subject { described_class.new(tribunal_case) }
+  let(:tribunal_case) {
+    instance_double(
+      TribunalCase,
+      lodgement_fee: lodgement_fee,
+      lodgement_fee?: !!lodgement_fee
+    )
+  }
+  let(:lodgement_fee) { nil }
+
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  describe '#rows' do
+    it 'should always return all rows' do
+      expect(subject.rows.count).to eq(1)
+    end
+
+    describe 'the first row' do
+      let(:row) { subject.rows.first }
+
+      context 'when there is a case without a lodgement fee in the session' do
+        let(:lodgement_fee) { nil }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:determine_cost)
+          expect(row.value).to be_nil
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_cost_start_path)
+        end
+      end
+
+      context 'when there is a case with a lodgement fee in the session' do
+        let(:lodgement_fee) { double(LodgementFee, to_gbp: 123.00) }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:determine_cost)
+          expect(row.value).to eq('£123')
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_cost_start_path)
+        end
+      end
+
+      context 'when there is no case in the session' do
+        let(:tribunal_case) { nil }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:determine_cost)
+          expect(row.value).to be_nil
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_cost_start_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/cost_determiner_spec.rb
+++ b/spec/services/cost_determiner_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CostDeterminer do
           let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_1) }
 
           it "has £20 lodgement fee" do
-            expect(subject.lodgement_fee.value).to eq(2000)
+            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_1)
           end
         end
 
@@ -51,7 +51,7 @@ RSpec.describe CostDeterminer do
           let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_2) }
 
           it "has £50 lodgement fee" do
-            expect(subject.lodgement_fee.value).to eq(5000)
+            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
           end
         end
 
@@ -59,7 +59,7 @@ RSpec.describe CostDeterminer do
           let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_3) }
 
           it "has £200 lodgement fee" do
-            expect(subject.lodgement_fee.value).to eq(20000)
+            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
           end
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe CostDeterminer do
         let(:case_attrs) { super().merge(dispute_type: DisputeType::AMOUNT_OF_TAX_OWED) }
 
         it "has £200 lodgement fee" do
-          expect(subject.lodgement_fee.value).to eq(20000)
+          expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
         end
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::APN_PENALTY) }
 
       it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee.value).to eq(5000)
+        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::CLOSURE_NOTICE) }
 
       it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee.value).to eq(5000)
+        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::INFORMATION_NOTICE) }
 
       it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee.value).to eq(5000)
+        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::REQUEST_PERMISSION_FOR_REVIEW) }
 
       it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee.value).to eq(5000)
+        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
       end
     end
 
@@ -109,7 +109,7 @@ RSpec.describe CostDeterminer do
       let(:case_attrs) { super().merge(case_type: CaseType::OTHER) }
 
       it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee.value).to eq(5000)
+        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.describe CostDeterminer do
         let(:case_attrs) { super().merge(dispute_type: DisputeType::AMOUNT_OF_TAX_OWED) }
 
         it "has £200 lodgement fee" do
-          expect(subject.lodgement_fee.value).to eq(20000)
+          expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
         end
       end
 
@@ -134,7 +134,7 @@ RSpec.describe CostDeterminer do
         let(:case_attrs) { super().merge(dispute_type: DisputeType::PAYE_CODING_NOTICE) }
 
         it "has £50 lodgement fee" do
-          expect(subject.lodgement_fee.value).to eq(5000)
+          expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
         end
       end
 
@@ -151,7 +151,7 @@ RSpec.describe CostDeterminer do
           let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_1) }
 
           it "has £20 lodgement fee" do
-            expect(subject.lodgement_fee.value).to eq(2000)
+            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_1)
           end
         end
 
@@ -159,7 +159,7 @@ RSpec.describe CostDeterminer do
           let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_2) }
 
           it "has £50 lodgement fee" do
-            expect(subject.lodgement_fee.value).to eq(5000)
+            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
           end
         end
 
@@ -167,7 +167,7 @@ RSpec.describe CostDeterminer do
           let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_3) }
 
           it "has £200 lodgement fee" do
-            expect(subject.lodgement_fee.value).to eq(20000)
+            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
           end
         end
       end

--- a/spec/services/glimr_fees_spec.rb
+++ b/spec/services/glimr_fees_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe GlimrFees do
+  describe '.fee_amount' do
+    subject { described_class.fee_amount(fee) }
+
+    context 'with lodgement fee level 1' do
+      let(:fee) { LodgementFee::FEE_LEVEL_1 }
+
+      it { is_expected.to eq(20_00) }
+    end
+
+    context 'with lodgement fee level 2' do
+      let(:fee) { LodgementFee::FEE_LEVEL_2 }
+
+      it { is_expected.to eq(50_00) }
+    end
+
+    context 'with lodgement fee level 3' do
+      let(:fee) { LodgementFee::FEE_LEVEL_3 }
+
+      it { is_expected.to eq(200_00) }
+    end
+
+    context 'with an unexpected argument' do
+      let(:fee) { LodgementFee.new(:foo_bar) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/support/features_helpers.rb
+++ b/spec/support/features_helpers.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 def start_application
   visit '/'
-  click_link 'Start now'
+  click_link 'Start'
 end
 
 def start_task

--- a/spec/value_objects/fee_spec.rb
+++ b/spec/value_objects/fee_spec.rb
@@ -1,38 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe Fee do
-  let(:amount) { 123 }
-  subject      { described_class.new(amount) }
+  let(:level)  { :fee_level_999 }
+  subject      { described_class.new(level) }
 
   it 'is immutable' do
     expect(subject).to be_frozen
   end
 
-  it 'does not accept values that are not implicitly convertible to integers' do
-    expect { described_class.new('ALL THE MONEYS') }.to raise_error(ArgumentError)
+  it 'does not accept values that are not implicitly convertible to symbols' do
+    expect { described_class.new(12345) }.to raise_error(ArgumentError)
   end
 
   describe '#value' do
     it 'returns the stored value' do
-      expect(subject.value).to eq(123)
+      expect(subject.value).to eq(:fee_level_999)
     end
   end
 
   describe '#to_s' do
     it 'returns a string representation of the fee' do
-      expect(subject.to_s).to eq('123')
+      expect(subject.to_s).to eq('fee_level_999')
     end
   end
 
   describe '#to_gbp' do
-    it 'returns a float representation of the fee in GBP' do
-      expect(subject.to_gbp).to eq(1.23)
+    it 'returns a float representation of the fee from GLiMR in GBP' do
+      expect(GlimrFees).to receive(:fee_amount).with(subject).and_return(123_45)
+      expect(subject.to_gbp).to eq(123.45)
     end
   end
 
   describe '#==' do
     context 'when comparing to an equal Fee' do
-      let(:other) { described_class.new(amount) }
+      let(:other) { described_class.new(level) }
 
       it 'returns true' do
         expect(subject).to eq(other)
@@ -40,7 +41,7 @@ RSpec.describe Fee do
     end
 
     context 'when comparing to a different fee' do
-      let(:other) { described_class.new(321) }
+      let(:other) { described_class.new(:fee_level_111) }
 
       it 'returns false' do
         expect(subject).to_not eq(other)
@@ -48,7 +49,7 @@ RSpec.describe Fee do
     end
 
     context 'when comparing to a different class' do
-      let(:other) { 123 }
+      let(:other) { :fee_level_999 }
 
       it 'returns false' do
         expect(subject).to_not eq(other)


### PR DESCRIPTION
This brings the start page of the app in line with the prototype
by adding an overarching start page with a "task list" (initially
just the one existing task) which updates according to your
progress through the app.

- Modify start page to show task list and user progress using new
  `TaskListPresenter`
- Save determined `LodgementFee` to `TribunalCase`
- Remove lodgement fee GBP amount from value object and instead
  add new `GlimrFees` class. For now this has the values hard-
  coded in it but eventually this should pull fee amounts from
  GLiMR periodically and cache them.
- Add copy and giant blue independence banner to start page
- Tweak "developer tools" to show button to destroy current
  session