### PR TITLE
Implement "Check you meet the deadline" step

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,4 @@
-class StartController < ApplicationController
+class HomeController < ApplicationController
   def index
     tribunal_case = TribunalCase.find_by_id(session[:tribunal_case_id])
     @presenter = TaskListPresenter.new(tribunal_case)

--- a/app/controllers/steps/lateness/in_time_controller.rb
+++ b/app/controllers/steps/lateness/in_time_controller.rb
@@ -1,0 +1,13 @@
+class Steps::Lateness::InTimeController < StepController
+  def edit
+    super
+    @form_object = InTimeForm.new(
+      tribunal_case: current_tribunal_case,
+      in_time:       current_tribunal_case.in_time
+    )
+  end
+
+  def update
+    update_and_advance(:in_time, InTimeForm)
+  end
+end

--- a/app/controllers/steps/lateness/lateness_reason_controller.rb
+++ b/app/controllers/steps/lateness/lateness_reason_controller.rb
@@ -1,0 +1,13 @@
+class Steps::Lateness::LatenessReasonController < StepController
+  def edit
+    super
+    @form_object = LatenessReasonForm.new(
+      tribunal_case:   current_tribunal_case,
+      lateness_reason: current_tribunal_case.lateness_reason
+    )
+  end
+
+  def update
+    update_and_advance(:lateness_reason, LatenessReasonForm)
+  end
+end

--- a/app/controllers/steps/lateness/start_controller.rb
+++ b/app/controllers/steps/lateness/start_controller.rb
@@ -1,0 +1,5 @@
+class Steps::Lateness::StartController < StepController
+  def show
+    @can_start = current_tribunal_case&.lodgement_fee?
+  end
+end

--- a/app/forms/in_time_form.rb
+++ b/app/forms/in_time_form.rb
@@ -1,0 +1,29 @@
+class InTimeForm < BaseForm
+  attribute :in_time, String
+
+  def self.choices
+    InTime.values.map(&:to_s)
+  end
+  validates_inclusion_of :in_time, in: choices
+
+  private
+
+  def in_time_value
+    InTime.new(in_time)
+  end
+
+  def changed?
+    tribunal_case.in_time != in_time_value
+  end
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    return true unless changed?
+
+    tribunal_case.update(
+      in_time:         in_time_value,
+      # The following are dependent attributes that need to be reset
+      lateness_reason: nil
+    )
+  end
+end

--- a/app/forms/lateness_reason_form.rb
+++ b/app/forms/lateness_reason_form.rb
@@ -1,0 +1,12 @@
+class LatenessReasonForm < BaseForm
+  attribute :lateness_reason, String
+
+  validates_length_of :lateness_reason, minimum: 5
+
+  private
+
+  def persist!
+    raise 'No TribunalCase given' unless tribunal_case
+    tribunal_case.update(lateness_reason: lateness_reason)
+  end
+end

--- a/app/presenters/task_list_presenter.rb
+++ b/app/presenters/task_list_presenter.rb
@@ -1,5 +1,5 @@
 class TaskListPresenter
-  TaskListRow = Struct.new(:title, :minutes_to_complete, :value, :start_path)
+  TaskListRow = Struct.new(:title, :minutes_to_complete, :value, :start_path, :can_start?)
 
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::NumberHelper
@@ -12,7 +12,8 @@ class TaskListPresenter
 
   def rows
     [
-      cost_determination_row
+      cost_determination_row,
+      lateness_row
     ]
   end
 
@@ -21,9 +22,19 @@ class TaskListPresenter
   def cost_determination_row
     if tribunal_case&.lodgement_fee?
       value = number_to_currency(tribunal_case.lodgement_fee.to_gbp)
-      TaskListRow.new(:determine_cost, 5, value, steps_cost_start_path)
+      TaskListRow.new(:determine_cost, 5, value, steps_cost_start_path, false)
     else
-      TaskListRow.new(:determine_cost, 5, nil, steps_cost_start_path)
+      TaskListRow.new(:determine_cost, 5, nil, steps_cost_start_path, true)
+    end
+  end
+
+  def lateness_row
+    if tribunal_case&.in_time
+      TaskListRow.new(:lateness, 5, tribunal_case.in_time, steps_lateness_start_path, false)
+    elsif tribunal_case&.lodgement_fee?
+      TaskListRow.new(:lateness, 5, nil, steps_lateness_start_path, true)
+    else
+      TaskListRow.new(:lateness, 5, nil, steps_lateness_start_path, false)
     end
   end
 end

--- a/app/presenters/task_list_presenter.rb
+++ b/app/presenters/task_list_presenter.rb
@@ -1,6 +1,6 @@
 class TaskListPresenter
-  TaskListRow = Struct.new(:title, :minutes_to_complete, :value, :start_path, :can_start?)
-
+  TaskListRow = Struct.new(:title, :minutes_to_complete, :value, :start_path, :show_start_button?)
+  
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::NumberHelper
 

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -21,6 +21,10 @@ class DecisionTree
       after_dispute_type_step
     when :penalty_amount
       after_penalty_amount_step
+    when :in_time
+      after_in_time_step
+    when :lateness_reason
+      after_lateness_reason_step
     else
       raise "Invalid step '#{step}'"
     end
@@ -68,6 +72,19 @@ class DecisionTree
 
   def after_penalty_amount_step
     { controller: :determine_cost, action: :show }
+  end
+
+  def after_in_time_step
+    case answer
+    when :yes
+      { controller: '/home', action: :index }
+    when :no, :unsure
+      { controller: :lateness_reason, action: :edit }
+    end
+  end
+
+  def after_lateness_reason_step
+    { controller: '/home', action: :index }
   end
 
   def step

--- a/app/value_objects/in_time.rb
+++ b/app/value_objects/in_time.rb
@@ -1,0 +1,16 @@
+class InTime < ValueObject
+  VALUES = [
+    YES    = new(:yes),
+    NO     = new(:no),
+    UNSURE = new(:unsure)
+  ].freeze
+
+  def initialize(raw_value)
+    raise ArgumentError.new('In time must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    super(raw_value.to_sym)
+  end
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -30,7 +30,7 @@
             <%= row.value %>
           </span>
         </span>
-      <% elsif row.can_start? %>
+      <% elsif row.show_start_button? %>
         <%= link_to t('.start'), row.start_path, class: 'button button-start', role: 'button' %>
       <% end %>
     </li>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,14 +23,14 @@
 <ol class="list list-number task-list" data-task-list="">
   <% @presenter.rows.each do |row| %>
     <li>
-      <%= link_to t(row.title), row.start_path, class: 'task-link' %> (<%=t '.minutes_to_complete', count: row.minutes_to_complete %>)
+      <%= link_to t(".task_titles.#{row.title}"), row.start_path, class: 'task-link' %> (<%=t '.minutes_to_complete', count: row.minutes_to_complete %>)
       <% if row.value %>
         <span class="task-status">
-          <span data-key="fee">
+          <span>
             <%= row.value %>
           </span>
         </span>
-      <% else %>
+      <% elsif row.can_start? %>
         <%= link_to t('.start'), row.start_path, class: 'button button-start', role: 'button' %>
       <% end %>
     </li>

--- a/app/views/steps/cost/case_type_challenged/edit.html.erb
+++ b/app/views/steps/cost/case_type_challenged/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <p class="step-info">
-      <%= link_to 'Back', edit_steps_cost_challenged_decision_path, class: 'link-back' %>
+      <%= link_to t('generic.back_link'), edit_steps_cost_challenged_decision_path, class: 'link-back' %>
       <%=t 'generic.step', step: 2, of: 4 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>

--- a/app/views/steps/cost/case_type_unchallenged/edit.html.erb
+++ b/app/views/steps/cost/case_type_unchallenged/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <p class="step-info">
-      <%= link_to 'Back', edit_steps_cost_challenged_decision_path, class: 'link-back' %>
+      <%= link_to t('generic.back_link'), edit_steps_cost_challenged_decision_path, class: 'link-back' %>
       <%=t 'generic.step', step: 2, of: 4 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>

--- a/app/views/steps/cost/challenged_decision/edit.html.erb
+++ b/app/views/steps/cost/challenged_decision/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <p class="step-info">
-      <%= link_to 'Back', root_path, class: 'link-back' %>
+      <%= link_to t('generic.back_link'), root_path, class: 'link-back' %>
       <%=t 'generic.step', step: 1, of: 4 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>

--- a/app/views/steps/cost/dispute_type/edit.html.erb
+++ b/app/views/steps/cost/dispute_type/edit.html.erb
@@ -2,9 +2,9 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <% if @form_object.case_challenged? %>
-        <%= link_to 'Back', edit_steps_cost_case_type_challenged_path, class: 'link-back' %>
+        <%= link_to t('generic.back_link'), edit_steps_cost_case_type_challenged_path, class: 'link-back' %>
       <% else %>
-        <%= link_to 'Back', edit_steps_cost_case_type_unchallenged_path, class: 'link-back' %>
+        <%= link_to t('generic.back_link'), edit_steps_cost_case_type_unchallenged_path, class: 'link-back' %>
       <% end %>
       <%=t 'generic.step', step: 3, of: 4 %>
     </p>

--- a/app/views/steps/lateness/in_time/edit.html.erb
+++ b/app/views/steps/lateness/in_time/edit.html.erb
@@ -1,16 +1,16 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <p class="step-info">
-      <%= link_to t('generic.back_link'), edit_steps_cost_dispute_type_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 4, of: 4 %>
+      <%= link_to t('generic.back_link'), steps_lateness_start_path, class: 'link-back' %>
+      <%=t 'generic.step', step: 1, of: 2 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :penalty_amount,
-        choices: PenaltyAmountForm.choices %>
+      <%= f.radio_button_fieldset :in_time,
+        choices: InTimeForm.choices %>
       <%= f.submit class: 'button' %>
     <% end %>
   </div>

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -1,0 +1,29 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p class="step-info">
+      <%= link_to t('generic.back_link'), edit_steps_lateness_in_time_path, class: 'link-back' %>
+      <%=t 'generic.step', step: 2, of: 2 %>
+    </p>
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_area :lateness_reason, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+
+    <details>
+      <summary>
+        <span class="summary">
+          <%=t '.details_title' %>
+        </span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <p>
+          <%=t '.details_content' %>
+        </p>
+      </div>
+    </details>
+  </div>
+</div>

--- a/app/views/steps/lateness/start/show.html.erb
+++ b/app/views/steps/lateness/start/show.html.erb
@@ -1,0 +1,20 @@
+<h1 class="heading-large">
+  <%=t '.heading' %>
+</h1>
+
+<p class="lede">
+  <%=t '.lead_text' %>
+</p>
+
+<%=t '.description_html' %>
+
+<% if @can_start %>
+  <p>
+    <%= link_to t('.continue'), edit_steps_lateness_in_time_path, class: 'button button-start', role: 'button' %>
+  </p>
+<% else %>
+  <p>
+    <strong><%=t '.previous_step_not_completed' %></strong><br>
+    <%= link_to t('.back_to_start'), root_path, class: 'link-back' %>
+  </p>
+<% end %>

--- a/config/locales/default.yml
+++ b/config/locales/default.yml
@@ -6,6 +6,7 @@ en:
         precision: 0
   generic:
     step: Question %{step} of %{of}
+    back_link: Back
   errors:
     # WARNING: This means every possible error message must be a full
     #  English sentence because the attribute name won't be prepended!

--- a/config/locales/home.yml
+++ b/config/locales/home.yml
@@ -1,5 +1,5 @@
 en:
-  start:
+  home:
     index:
       heading: The tax tribunal is independent of government
       lead_text: Use this service to settle a tax dispute by getting an impartial ruling from a judge.
@@ -18,6 +18,7 @@ en:
         </ul>
       task_titles:
         determine_cost: Find out the cost of your appeal
+        lateness: Check you meet the tribunal deadline
       minutes_to_complete:
         one: 1 minute to complete
         other: "%{count} minutes to complete"

--- a/config/locales/lateness.yml
+++ b/config/locales/lateness.yml
@@ -1,0 +1,50 @@
+en:
+  steps:
+    lateness:
+      start:
+        show:
+          heading: 2. Check you meet tribunal deadlines
+          lead_text: You must appeal within the time stated on your last letter from HMRC. This is usually 30 days.
+          description_html: |
+            <p>If you have asked HMRC for a review with a tax officer not originally involved in your case, you should wait until the review finishes.</p>
+            <p>Once the review is completed and you have received a letter from HMRC with the review conclusions you can then appeal to the tax tribunal.</p>
+            <h4 class="heading-small">What you will need</h4>
+            <ul class="list list-bullet">
+              <li>date you received your last letter from HMRC</li>
+              <li>reasons why you're outside the time limit if you want to submit an appeal late</li>
+            </ul>
+          previous_step_not_completed: You must complete Step 1 before you can check whether or not you meet the tribunal deadlines.
+          back_to_start: Return to start page
+      in_time:
+        edit:
+          heading: Do you think you're in time to appeal to the tax tribunal?
+          lead_text: Use the date shown on the last letter you received from HMRC to work out whether you meet the deadline to appeal to the tax tribunal. You usually have up to 30 days.
+      lateness_reason:
+        edit:
+          heading: Why are you late with your appeal?
+          lead_text: Enter the reasons why you are late appealing to the tribunal. The judge will consider your case. Your appeal fee will not be refunded if your reasons are not accepted.
+          details_title: Help with late appeals
+          details_content: You must provide reasonable grounds for submitting your appeal late. These are usually unforeseen circumstances or events beyond your control which meant you weren't able to meet the appeal deadlines.
+  activemodel:
+    errors:
+      models:
+        in_time_form:
+          attributes:
+            in_time:
+              inclusion: Select whether you think you are in time to appeal to the tax tribunal
+        lateness_reason_form:
+          attributes:
+            lateness_reason:
+              too_short: You must explain why you are late. Use at least %{count} characters.
+  helpers:
+    fieldset:
+      in_time_form:
+        in_time: Do you think you're in time to appeal to the tax tribunal?
+    label:
+      in_time_form:
+        in_time:
+          "yes": Yes, I am in time
+          "no": No, I am late
+          unsure: I'm not sure
+      lateness_reason_form:
+        lateness_reason: Reason(s) for late appeal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 class ActionDispatch::Routing::Mapper
-  def edit_update_step(name)
+  def edit_step(name)
     resource name,
              only:       [:edit, :update],
              controller: name,
@@ -16,17 +16,23 @@ end
 Rails.application.routes.draw do
   namespace :steps do
     namespace :cost do
-      show_step        :start
-      edit_update_step :challenged_decision
-      edit_update_step :case_type_challenged
-      edit_update_step :case_type_unchallenged
-      edit_update_step :dispute_type
-      edit_update_step :penalty_amount
-      show_step        :determine_cost
-      show_step        :must_challenge_hmrc
+      show_step :start
+      edit_step :challenged_decision
+      edit_step :case_type_challenged
+      edit_step :case_type_unchallenged
+      edit_step :dispute_type
+      edit_step :penalty_amount
+      show_step :determine_cost
+      show_step :must_challenge_hmrc
+    end
+
+    namespace :lateness do
+      show_step :start
+      edit_step :in_time
+      edit_step :lateness_reason
     end
   end
 
   resource :session, only: [:destroy]
-  root to: 'start#index'
+  root to: 'home#index'
 end

--- a/db/migrate/20161117172226_add_in_time_to_tribunal_case.rb
+++ b/db/migrate/20161117172226_add_in_time_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddInTimeToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :in_time, :string
+  end
+end

--- a/db/migrate/20161118094611_add_lateness_reason_to_tribunal_case.rb
+++ b/db/migrate/20161118094611_add_lateness_reason_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddLatenessReasonToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :lateness_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161117121149) do
+ActiveRecord::Schema.define(version: 20161118094611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20161117121149) do
     t.string   "dispute_type"
     t.string   "penalty_amount"
     t.string   "lodgement_fee"
+    t.string   "in_time"
+    t.text     "lateness_reason"
   end
 
 end

--- a/spec/controllers/steps/lateness/in_time_controller_spec.rb
+++ b/spec/controllers/steps/lateness/in_time_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Lateness::InTimeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', InTimeForm
+end

--- a/spec/controllers/steps/lateness/lateness_reason_controller_spec.rb
+++ b/spec/controllers/steps/lateness/lateness_reason_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Lateness::LatenessReasonController, type: :controller do
+  it_behaves_like 'an intermediate step controller', LatenessReasonForm
+end

--- a/spec/controllers/steps/lateness/start_controller_spec.rb
+++ b/spec/controllers/steps/lateness/start_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Lateness::StartController, type: :controller do
+  it_behaves_like 'a start step controller'
+end

--- a/spec/forms/in_time_form_spec.rb
+++ b/spec/forms/in_time_form_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe InTimeForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    in_time:       in_time
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, in_time: nil) }
+  let(:in_time)       { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:in_time) { 'yes' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when in_time is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:in_time]).to_not be_empty
+      end
+    end
+
+    context 'when in_time is not valid' do
+      let(:in_time) { 'like, totally not' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:in_time]).to_not be_empty
+      end
+    end
+
+    context 'when in_time is valid' do
+      let(:in_time) { 'unsure' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          in_time:         InTime::UNSURE,
+          lateness_reason: nil
+        )
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when in_time is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          in_time: InTime::YES
+        )
+      }
+      let(:in_time) { 'yes' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/lateness_reason_form_spec.rb
+++ b/spec/forms/lateness_reason_form_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe LatenessReasonForm do
+  let(:arguments) { {
+    tribunal_case:   tribunal_case,
+    lateness_reason: lateness_reason
+  } }
+  let(:tribunal_case)   { instance_double(TribunalCase, lateness_reason: nil) }
+  let(:lateness_reason) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:lateness_reason) { 'I am a gummy bear' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when lateness_reason is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:lateness_reason]).to_not be_empty
+      end
+    end
+
+    context 'when lateness_reason is too short' do
+      let(:lateness_reason) { 'meh' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:lateness_reason]).to_not be_empty
+      end
+    end
+
+    context 'when lateness_reason is valid' do
+      let(:lateness_reason) { 'Forgive me, dear judge' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          lateness_reason: lateness_reason
+        )
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/task_list_presenter_spec.rb
+++ b/spec/presenters/task_list_presenter_spec.rb
@@ -5,17 +5,19 @@ RSpec.describe TaskListPresenter do
   let(:tribunal_case) {
     instance_double(
       TribunalCase,
-      lodgement_fee: lodgement_fee,
-      lodgement_fee?: !!lodgement_fee
+      lodgement_fee:  lodgement_fee,
+      lodgement_fee?: !!lodgement_fee,
+      in_time:        in_time
     )
   }
   let(:lodgement_fee) { nil }
+  let(:in_time)       { nil }
 
   let(:paths) { Rails.application.routes.url_helpers }
 
   describe '#rows' do
     it 'should always return all rows' do
-      expect(subject.rows.count).to eq(1)
+      expect(subject.rows.count).to eq(2)
     end
 
     describe 'the first row' do
@@ -51,6 +53,60 @@ RSpec.describe TaskListPresenter do
           expect(row.value).to be_nil
           expect(row.minutes_to_complete).to eq(5)
           expect(row.start_path).to eq(paths.steps_cost_start_path)
+        end
+      end
+    end
+
+    describe 'the second row' do
+      let(:row) { subject.rows.second }
+
+      context 'when there is a case without a lodgement fee in the session' do
+        let(:lodgement_fee) { nil }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:lateness)
+          expect(row.value).to be_nil
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_lateness_start_path)
+          expect(row.can_start?).to eq(false)
+        end
+      end
+
+      context 'when there is a case with a lodgement fee but no in_time value in the session' do
+        let(:lodgement_fee) { double(LodgementFee, to_gbp: 123.00) }
+        let(:in_time)       { nil }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:lateness)
+          expect(row.value).to be_nil
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_lateness_start_path)
+          expect(row.can_start?).to eq(true)
+        end
+      end
+
+      context 'when there is a case with a lodgement fee and in_time value in the session' do
+        let(:lodgement_fee) { double(LodgementFee, to_gbp: 123.00) }
+        let(:in_time)       { InTime::YES }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:lateness)
+          expect(row.value).to eq(InTime::YES)
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_lateness_start_path)
+          expect(row.can_start?).to eq(false)
+        end
+      end
+
+      context 'when there is no case in the session' do
+        let(:tribunal_case) { nil }
+
+        it 'has the correct values' do
+          expect(row.title).to eq(:lateness)
+          expect(row.value).to be_nil
+          expect(row.minutes_to_complete).to eq(5)
+          expect(row.start_path).to eq(paths.steps_lateness_start_path)
+          expect(row.can_start?).to eq(false)
         end
       end
     end

--- a/spec/presenters/task_list_presenter_spec.rb
+++ b/spec/presenters/task_list_presenter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TaskListPresenter do
           expect(row.value).to be_nil
           expect(row.minutes_to_complete).to eq(5)
           expect(row.start_path).to eq(paths.steps_lateness_start_path)
-          expect(row.can_start?).to eq(false)
+          expect(row.show_start_button?).to eq(false)
         end
       end
 
@@ -81,7 +81,7 @@ RSpec.describe TaskListPresenter do
           expect(row.value).to be_nil
           expect(row.minutes_to_complete).to eq(5)
           expect(row.start_path).to eq(paths.steps_lateness_start_path)
-          expect(row.can_start?).to eq(true)
+          expect(row.show_start_button?).to eq(true)
         end
       end
 
@@ -94,7 +94,7 @@ RSpec.describe TaskListPresenter do
           expect(row.value).to eq(InTime::YES)
           expect(row.minutes_to_complete).to eq(5)
           expect(row.start_path).to eq(paths.steps_lateness_start_path)
-          expect(row.can_start?).to eq(false)
+          expect(row.show_start_button?).to eq(false)
         end
       end
 
@@ -106,7 +106,7 @@ RSpec.describe TaskListPresenter do
           expect(row.value).to be_nil
           expect(row.minutes_to_complete).to eq(5)
           expect(row.start_path).to eq(paths.steps_lateness_start_path)
-          expect(row.can_start?).to eq(false)
+          expect(row.show_start_button?).to eq(false)
         end
       end
     end

--- a/spec/services/decision_tree_spec.rb
+++ b/spec/services/decision_tree_spec.rb
@@ -156,12 +156,58 @@ RSpec.describe DecisionTree do
       end
     end
 
+    context 'when the step is `in_time`' do
+      context 'and the answer is `yes`' do
+        let(:step) { { in_time: 'yes' } }
+
+        it 'sends the user to the task list' do
+          expect(subject.destination).to eq({
+            controller: '/home',
+            action:     :index
+          })
+        end
+      end
+
+      context 'and the answer is `no`' do
+        let(:step) { { in_time: 'no' } }
+
+        it 'sends the user to the `lateness_reason` step' do
+          expect(subject.destination).to eq({
+            controller: :lateness_reason,
+            action:     :edit
+          })
+        end
+      end
+
+      context 'and the answer is `unsure`' do
+        let(:step) { { in_time: 'unsure' } }
+
+        it 'sends the user to the `lateness_reason` step' do
+          expect(subject.destination).to eq({
+            controller: :lateness_reason,
+            action:     :edit
+          })
+        end
+      end
+    end
+
     context 'when the step is invalid' do
       let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.destination }.to raise_error(RuntimeError)
       end
+    end
+  end
+
+  context 'when the step is `penalty_amount`' do
+    let(:step) { { lateness_reason: 'anything' } }
+
+    it 'sends the user to the home page' do
+      expect(subject.destination).to eq({
+        controller: '/home',
+        action:     :index
+      })
     end
   end
 end


### PR DESCRIPTION
This step allows the user to specify whether or not they think they
are in time to apply to the tribunal. If they know they aren't, or
they aren't sure, they can give reasons for the judge to consider
their case anyway.

- Add controllers and forms to handle the lateness check functionality
- Update decision tree to handle lateness answers
- Tweak task list to show start button only for the "next" step
- Do not allow user to start lateness step until they have completed
  cost determination
- Rename task list controller from `StartController` to `HomeController`
  to avoid confusion with the `StartController` controllers in the
  individual task namespaces
- Rename `edit_update_step` routes helper to `edit_step` to simplify
  the naming (it's clear that edit needs an update anyway)
- Fix hardcorded text in "Back" link to be i18nised