### PR TITLE
Initial start step for details task

### DIFF
--- a/app/controllers/steps/details/start_controller.rb
+++ b/app/controllers/steps/details/start_controller.rb
@@ -1,0 +1,7 @@
+module Steps::Details
+  class StartController < DetailsStepController
+    def show
+      @can_start = false
+    end
+  end
+end

--- a/app/controllers/steps/details_step_controller.rb
+++ b/app/controllers/steps/details_step_controller.rb
@@ -1,0 +1,2 @@
+class Steps::DetailsStepController < StepController
+end

--- a/app/controllers/steps/lateness/start_controller.rb
+++ b/app/controllers/steps/lateness/start_controller.rb
@@ -1,7 +1,7 @@
 module Steps::Lateness
   class StartController < StepController
     def show
-      @can_start = current_tribunal_case&.lodgement_fee?
+      @can_start = current_tribunal_case&.cost_task_completed?
     end
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -14,4 +14,17 @@ class TribunalCase < ApplicationRecord
   composed_of :lodgement_fee,
     allow_nil:  true,
     mapping:    [%w(lodgement_fee value)]
+
+  composed_of :in_time,
+    allow_nil:  true,
+    mapping:    [%w(in_time value)]
+
+  def cost_task_completed?
+    lodgement_fee?
+  end
+
+  def lateness_task_completed?
+    return false unless cost_task_completed? && in_time?
+    in_time.eql?(InTime::YES) || lateness_reason?
+  end
 end

--- a/app/presenters/task_list_presenter.rb
+++ b/app/presenters/task_list_presenter.rb
@@ -1,6 +1,6 @@
 class TaskListPresenter
   TaskListRow = Struct.new(:title, :minutes_to_complete, :value, :start_path, :show_start_button?)
-  
+
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::NumberHelper
 
@@ -13,14 +13,15 @@ class TaskListPresenter
   def rows
     [
       cost_determination_row,
-      lateness_row
+      lateness_row,
+      details_row
     ]
   end
 
   private
 
   def cost_determination_row
-    if tribunal_case&.lodgement_fee?
+    if tribunal_case&.cost_task_completed?
       value = number_to_currency(tribunal_case.lodgement_fee.to_gbp)
       TaskListRow.new(:determine_cost, 5, value, steps_cost_start_path, false)
     else
@@ -29,12 +30,20 @@ class TaskListPresenter
   end
 
   def lateness_row
-    if tribunal_case&.in_time
+    if tribunal_case&.lateness_task_completed?
       TaskListRow.new(:lateness, 5, tribunal_case.in_time, steps_lateness_start_path, false)
-    elsif tribunal_case&.lodgement_fee?
+    elsif tribunal_case&.cost_task_completed?
       TaskListRow.new(:lateness, 5, nil, steps_lateness_start_path, true)
     else
       TaskListRow.new(:lateness, 5, nil, steps_lateness_start_path, false)
+    end
+  end
+
+  def details_row
+    if tribunal_case&.cost_task_completed? && tribunal_case&.lateness_task_completed?
+      TaskListRow.new(:details, 20, nil, steps_details_start_path, true)
+    else
+      TaskListRow.new(:details, 20, nil, steps_details_start_path, false)
     end
   end
 end

--- a/app/views/steps/details/start/show.html.erb
+++ b/app/views/steps/details/start/show.html.erb
@@ -1,0 +1,20 @@
+<h1 class="heading-large">
+  <%=t '.heading' %>
+</h1>
+
+<p class="lede">
+  <%=t '.lead_text' %>
+</p>
+
+<%=t '.description_html' %>
+
+<% if @can_start %>
+  <p>
+    <%= link_to t('.continue'), root_path, class: 'button button-start', role: 'button' %>
+  </p>
+<% else %>
+  <p>
+    <strong><%=t '.previous_step_not_completed' %></strong><br>
+    <%= link_to t('.back_to_start'), root_path, class: 'link-back' %>
+  </p>
+<% end %>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -1,0 +1,24 @@
+en:
+  steps:
+    details:
+      start:
+        show:
+          heading: 3. Enter appeal details and pay fee
+          lead_text: You will need to include grounds for your appeal and upload a scan or photo of the letters from HMRC.
+          description_html: |
+            <h4 class="heading-small">What to get ready before you start</h4>
+            <ul class="list list-bullet">
+              <li>a scan or photo of the original notice letter or review conclusion letter from HMRC ready to upload</li>
+              <li>write down the reasons why you disagree with the decision(s) by HMRC so you can copy and paste the text or attach as a document</li>
+              <li>if you're completing this as a representative and you're not a legal professional, you'll need an email or scan of a letter from your client saying they can act on your behalf</li>
+              <li>a debit or credit card to pay the initial tribunal fee unless you're eligible for <a href="https://www.gov.uk/get-help-with-court-fees">help with fees</a></li>
+            </ul>
+            <p class="notice">
+              <i class="icon icon-important">
+                <span class="visuallyhidden">Warning</span>
+              </i>
+              <strong class="bold-small">
+                You can't save details as you go. Please get everything ready before you start.
+              </strong>
+            </p>
+          previous_step_not_completed: You must complete Step 1 and Step 2 before you can enter your appeal details. 

--- a/config/locales/home.yml
+++ b/config/locales/home.yml
@@ -19,6 +19,7 @@ en:
       task_titles:
         determine_cost: Find out the cost of your appeal
         lateness: Check you meet the tribunal deadline
+        details: Enter appeal details and pay fee
       minutes_to_complete:
         one: 1 minute to complete
         other: "%{count} minutes to complete"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,10 @@ Rails.application.routes.draw do
       edit_step :in_time
       edit_step :lateness_reason
     end
+
+    namespace :details do
+      show_step :start
+    end
   end
 
   resource :session, only: [:destroy]

--- a/spec/controllers/steps/details/start_controller_spec.rb
+++ b/spec/controllers/steps/details/start_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::StartController, type: :controller do
+  it_behaves_like 'a start step controller'
+end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -1,4 +1,120 @@
 require 'spec_helper'
 
 RSpec.describe TribunalCase, type: :model do
+  subject { described_class.new(attributes) }
+  let(:attributes) { {} }
+
+  describe '#cost_task_completed?' do
+    let(:attributes) { { lodgement_fee: lodgement_fee } }
+
+    context 'when a lodgement fee has been determined' do
+      let(:lodgement_fee) { LodgementFee::FEE_LEVEL_1 }
+
+      it 'returns true' do
+        expect(subject.cost_task_completed?).to eq(true)
+      end
+    end
+
+    context 'when no lodgement fee has been determined yet' do
+      let(:lodgement_fee) { nil }
+
+      it 'returns false' do
+        expect(subject.cost_task_completed?).to eq(false)
+      end
+    end
+  end
+
+  describe '#lateness_task_completed?' do
+    let(:attributes) { {
+      lodgement_fee:   lodgement_fee,
+      in_time:         in_time,
+      lateness_reason: lateness_reason
+    } }
+    let(:in_time)         { nil }
+    let(:lateness_reason) { nil }
+
+    context 'when a lodgement fee has been determined' do
+      let(:lodgement_fee) { LodgementFee::FEE_LEVEL_1 }
+
+      context 'when there is no in_time value' do
+        let(:in_time) { nil }
+
+        it 'returns false' do
+          expect(subject.lateness_task_completed?).to eq(false)
+        end
+
+        context 'even when a lateness reason exists' do
+          let(:lateness_reason) { 'I can never happen' }
+
+          it 'still returns false' do
+            expect(subject.lateness_task_completed?).to eq(false)
+          end
+        end
+      end
+
+      context 'when the appeal is in time' do
+        let(:in_time) { InTime.new(:yes) }
+
+        it 'returns true' do
+          expect(subject.lateness_task_completed?).to eq(true)
+        end
+      end
+
+      context 'when the appeal is late' do
+        let(:in_time) { InTime.new(:no) }
+
+        context 'and there is a reason given' do
+          let(:lateness_reason) { 'Sorry' }
+
+          it 'returns true' do
+            expect(subject.lateness_task_completed?).to eq(true)
+          end
+        end
+
+        context 'and there is no reason given' do
+          let(:lateness_reason) { nil }
+
+          it 'returns false' do
+            expect(subject.lateness_task_completed?).to eq(false)
+          end
+        end
+      end
+
+      context 'when the appeal lateness is unsure' do
+        let(:in_time) { InTime.new(:unsure) }
+
+        context 'and there is a reason given' do
+          let(:lateness_reason) { 'Sorry' }
+
+          it 'returns true' do
+            expect(subject.lateness_task_completed?).to eq(true)
+          end
+        end
+
+        context 'and there is no reason given' do
+          let(:lateness_reason) { nil }
+
+          it 'returns false' do
+            expect(subject.lateness_task_completed?).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when no lodgement fee has been determined yet' do
+      let(:lodgement_fee) { nil }
+
+      it 'returns false' do
+        expect(subject.lateness_task_completed?).to eq(false)
+      end
+
+      context 'even when a later step has been completed' do
+        let(:in_time) { InTime.new(:yes) }
+
+        it 'still returns false' do
+          expect(subject.lateness_task_completed?).to eq(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a start page for the third ("Enter appeal details") task and
includes some refactoring of the task list logic.

- Add "_details_" task and associated route namespace,
  `DetailsStepController`, and i18n file
- Add basic start step for details task
- Add row for details task to task list
- Fix missing `composed_of` for `InTime` value object in `TribunalCase`
  model
- Add `TribunalCase#cost_task_completed?` and
  `TribunalCase#lateness_task_completed?` for more semantically
  meaningful checking of whether a task is completed (instead of
  checking the values for `lodgement_fee`, `in_time`, and
  `lateness_reason`)
- Use new task completed checking across the app