### PR TITLE
Add Rails generator for tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
   AllCops:
     Exclude:
-      - lib/generators/step/templates/*.rb
+      - 'lib/generators/step/templates/*.rb'
+      - 'db/schema.rb'
+      - 'vendor/**/*'
     TargetRubyVersion: 2.3
     DisabledByDefault: true
   Lint/AmbiguousOperator:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
   AllCops:
+    Exclude:
+      - lib/generators/step/templates/*.rb
     TargetRubyVersion: 2.3
     DisabledByDefault: true
   Lint/AmbiguousOperator:

--- a/lib/generators/step/USAGE
+++ b/lib/generators/step/USAGE
@@ -1,0 +1,37 @@
+Description:
+    Generates a step for a given task.
+
+    CAUTION: This requires the task to exist already. It won't create a
+    task supercontroller, or task folders, or decision tree - instead
+    it will fail unceremoniously.
+
+    Assumes you want to generate an intermediate step, i.e. not a start page
+    or "check your answers" page.
+
+Example:
+    rails generate step Cost DisputeType
+
+    This will create:
+        app/controllers/steps/cost/dispute_type_controller.rb
+        app/forms/steps/cost/dispute_type_form.rb
+        app/views/steps/cost/dispute_type/edit.html.erb
+        spec/controllers/steps/cost/dispute_type_controller_spec.rb
+        spec/forms/steps/cost/dispute_type_form_spec.rb
+
+    This will update:
+        config/routes.rb
+          (adds an `edit_step` route for the step)
+        app/services/cost_decision_tree.rb
+          (adds the step to the decision tree)
+
+    You will have to do yourself:
+        - Change `@back_link_path` in the controller
+        - Add the fields into the form object (and write specs)
+        - Add the fields to the tribunal_case model (and migrate)
+        - Add the relevant form code in the view
+        - Update the step X of Y in the view
+        - Make the decision tree decide something
+        - Add specs for the decision tree
+        - Add a value object if required (and add the `composed_of` to the model)
+        - Add i18n
+        - Write feature specs

--- a/lib/generators/step/step_generator.rb
+++ b/lib/generators/step/step_generator.rb
@@ -1,0 +1,37 @@
+class StepGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
+  argument :task_name, :type => :string
+  argument :step_name, :type => :string
+
+  def copy_controller
+    template 'controller.rb', "app/controllers/steps/#{task_name.underscore}/#{step_name.underscore}_controller.rb"
+    template 'controller_spec.rb', "spec/controllers/steps/#{task_name.underscore}/#{step_name.underscore}_controller_spec.rb"
+  end
+
+  def copy_template
+    template 'edit.html.erb', "app/views/steps/#{task_name.underscore}/#{step_name.underscore}/edit.html.erb"
+  end
+
+  def copy_form
+    template 'form.rb', "app/forms/steps/#{task_name.underscore}/#{step_name.underscore}_form.rb"
+    template 'form_spec.rb', "spec/forms/steps/#{task_name.underscore}/#{step_name.underscore}_form_spec.rb"
+  end
+
+  def add_to_routes
+    insert_into_file 'config/routes.rb', after: /namespace :#{task_name.underscore} do.+?(?=end)/m do
+      "  edit_step :#{step_name.underscore}\n    "
+    end
+  end
+
+  def add_to_decision_tree
+    tree_file = "app/services/#{task_name.underscore}_decision_tree.rb"
+
+    insert_into_file tree_file, before: "else\n      raise"do
+      "when :#{step_name.underscore}\n      after_#{step_name.underscore}_step\n    "
+    end
+
+    insert_into_file tree_file, before: /^end/ do
+      "  def after_#{step_name.underscore}_step\n    raise 'TODO: Implement me'\n  end\n"
+    end
+  end
+end

--- a/lib/generators/step/templates/controller.rb
+++ b/lib/generators/step/templates/controller.rb
@@ -1,0 +1,16 @@
+module Steps::<%= task_name.classify %>
+  class <%= step_name.classify %>Controller < Steps::<%= task_name.classify %>StepController
+    def edit
+      super
+      @form_object = <%= step_name.classify %>Form.new(
+        tribunal_case: current_tribunal_case,
+        <%= step_name.underscore  %>: current_tribunal_case.<%= step_name.underscore %>
+      )
+      @back_link_path = (raise 'TODO: Specify the back link path for this generated controller')
+    end
+
+    def update
+      update_and_advance(:<%= step_name.underscore %>, <%= step_name.classify %>Form)
+    end
+  end
+end

--- a/lib/generators/step/templates/controller_spec.rb
+++ b/lib/generators/step/templates/controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::<%= task_name.classify %>::<%= step_name.classify %>Controller, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::<%= task_name.classify %>::<%= step_name.classify %>Form, <%= task_name.classify %>DecisionTree
+end

--- a/lib/generators/step/templates/edit.html.erb
+++ b/lib/generators/step/templates/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p class="step-info">
+      <%%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
+      <%%=t 'generic.step', step: 0, of: 0 %>
+    </p>
+    <h1 class="heading-large"><%%=t '.heading' %></h1>
+
+    <p class="lede"><%%=t '.lead_text' %></p>
+
+    <%%= step_form @form_object do |f| %>
+      <!-- TODO: Add form fields here -->
+      <%%= f.submit class: 'button' %>
+    <%% end %>
+  </div>
+</div>

--- a/lib/generators/step/templates/form.rb
+++ b/lib/generators/step/templates/form.rb
@@ -1,0 +1,47 @@
+module Steps::<%= task_name.classify %>
+  class <%= step_name.classify %>Form < BaseForm
+    # TODO: Add more attributes or change type if necessary
+    attribute :<%= step_name.underscore %>, String
+
+    # TODO: Choices
+    #   - Uncomment the below if you have a value object
+    #   - Delete the method if you haven't
+    #
+    # def self.choices
+    #  <%= step_name.classify %>.values.map(&:to_s)
+    # end
+    # validates_inclusion_of :<%= step_name.underscore %>, in: choices
+
+    # TODO: Add any further validations here
+
+    private
+
+    # TODO:
+    #   - Uncomment the below if you have a value object
+    #   - Delete the method if you haven't
+    # def <%= step_name.underscore %>_value
+    #  <%= step_name.classify %>.new(<%= step_name %>)
+    # end
+
+    def changed?
+      # TODO: Make this return whether the form data has changed from the current
+      #  state of the tribunal_case object. If you have a value object, you could
+      #  do e.g.:
+      #
+      #  tribunal_case.<%= step_name.underscore %> != <%= step_name.underscore %>_value
+      raise 'TODO: Update <%= step_name.classify %>#changed?'
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return unless changed?
+
+      # TODO: Update this to persist your form object
+      tribunal_case.update(
+        <%= step_name.underscore %>: (raise 'TODO: Update <%= step_name.classify %>#persist!')
+        # The following are dependent attributes that need to be reset
+        # TODO: Are there any dependent attributes? Reset them here.
+      )
+    end
+  end
+end

--- a/lib/generators/step/templates/form_spec.rb
+++ b/lib/generators/step/templates/form_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe Steps::<%= task_name.classify %>::<%= step_name.classify %>Form do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    <%= step_name.underscore %>: <%= step_name.underscore %>
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, <%= step_name.underscore %>: nil) }
+  let(:<%= step_name.underscore %>) { nil }
+
+  subject { described_class.new(arguments) }
+
+  pending 'Write specs for <%= step_name.classify %>Form!'
+
+  # TODO: The below can be uncommented and serves as a starting point for
+  #   forms operating on a single value object.
+
+  # describe '#save' do
+  #   context 'when no tribunal_case is associated with the form' do
+  #     let(:tribunal_case)  { nil }
+  #     let(:<%= step_name.underscore %>) { 'value' }
+
+  #     it 'raises an error' do
+  #       expect { subject.save }.to raise_error(RuntimeError)
+  #     end
+  #   end
+
+  #   context 'when <%= step_name.underscore %> is not given' do
+  #     it 'returns false' do
+  #       expect(subject.save).to be(false)
+  #     end
+
+  #     it 'has a validation error on the field' do
+  #       expect(subject).to_not be_valid
+  #       expect(subject.errors[:<%= step_name.underscore %>]).to_not be_empty
+  #     end
+  #   end
+
+  #   context 'when <%= step_name.underscore %> is not valid' do
+  #     let(:<%= step_name.underscore %>) { 'INVALID VALUE' }
+
+  #     it 'returns false' do
+  #       expect(subject.save).to be(false)
+  #     end
+
+  #     it 'has a validation error on the field' do
+  #       expect(subject).to_not be_valid
+  #       expect(subject.errors[:<%= step_name.underscore %>]).to_not be_empty
+  #     end
+  #   end
+
+  #   context 'when <%= step_name.underscore %> is valid' do
+  #     let(:<%= step_name.underscore %>) { 'INSERT VALID VALUE HERE' }
+
+  #     it 'saves the record' do
+  #       expect(tribunal_case).to receive(:update).with(
+  #         # TODO: What's in the update?
+  #       )
+  #       expect(subject.save).to be(true)
+  #     end
+  #   end
+
+  #   context 'when in_time is already the same on the model' do
+  #     let(:tribunal_case) {
+  #       instance_double(
+  #         TribunalCase,
+  #         <%= step_name.underscore %>: 'INSERT EXISTING VALUE HERE'
+  #       )
+  #     }
+  #     let(:<%= step_name.underscore %>) { 'CHANGEME' }
+
+  #     it 'does not save the record but returns true' do
+  #       expect(tribunal_case).to_not receive(:update)
+  #       expect(subject.save).to be(true)
+  #     end
+  #   end
+  # end
+end
+


### PR DESCRIPTION
This allows us to scaffold steps very easily. Given a task (whose
decision tree and super step controller must exist already), it
generates a controller+spec, form+spec, and view for a new step.
It also adds the step to the routes and to the task's decision tree.

Each of these files and changes will either assume sensible defaults,
or have TODO comments and raised errors where things need to be changed.

<img width="597" alt="screen shot 2016-11-25 at 16 26 55" src="https://cloud.githubusercontent.com/assets/72141/20631359/f2a1672c-b32d-11e6-8146-164255f6942a.png">
