### PR TITLE
Fix generator forcing singular class name

### DIFF
--- a/lib/generators/step/templates/controller.rb
+++ b/lib/generators/step/templates/controller.rb
@@ -1,8 +1,8 @@
-module Steps::<%= task_name.classify %>
-  class <%= step_name.classify %>Controller < Steps::<%= task_name.classify %>StepController
+module Steps::<%= task_name.camelize %>
+  class <%= step_name.camelize %>Controller < Steps::<%= task_name.camelize %>StepController
     def edit
       super
-      @form_object = <%= step_name.classify %>Form.new(
+      @form_object = <%= step_name.camelize %>Form.new(
         tribunal_case: current_tribunal_case,
         <%= step_name.underscore  %>: current_tribunal_case.<%= step_name.underscore %>
       )
@@ -10,7 +10,7 @@ module Steps::<%= task_name.classify %>
     end
 
     def update
-      update_and_advance(:<%= step_name.underscore %>, <%= step_name.classify %>Form)
+      update_and_advance(:<%= step_name.underscore %>, <%= step_name.camelize %>Form)
     end
   end
 end

--- a/lib/generators/step/templates/controller_spec.rb
+++ b/lib/generators/step/templates/controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Steps::<%= task_name.classify %>::<%= step_name.classify %>Controller, type: :controller do
-  it_behaves_like 'an intermediate step controller', Steps::<%= task_name.classify %>::<%= step_name.classify %>Form, <%= task_name.classify %>DecisionTree
+RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Controller, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form, <%= task_name.camelize %>DecisionTree
 end

--- a/lib/generators/step/templates/form.rb
+++ b/lib/generators/step/templates/form.rb
@@ -20,7 +20,7 @@ module Steps::<%= task_name.camelize %>
     #   - Uncomment the below if you have a value object
     #   - Delete the method if you haven't
     # def <%= step_name.underscore %>_value
-    #  <%= step_name.camelize %>.new(<%= step_name %>)
+    #  <%= step_name.camelize %>.new(<%= step_name.underscore %>)
     # end
 
     def changed?

--- a/lib/generators/step/templates/form.rb
+++ b/lib/generators/step/templates/form.rb
@@ -1,5 +1,5 @@
-module Steps::<%= task_name.classify %>
-  class <%= step_name.classify %>Form < BaseForm
+module Steps::<%= task_name.camelize %>
+  class <%= step_name.camelize %>Form < BaseForm
     # TODO: Add more attributes or change type if necessary
     attribute :<%= step_name.underscore %>, String
 
@@ -8,7 +8,7 @@ module Steps::<%= task_name.classify %>
     #   - Delete the method if you haven't
     #
     # def self.choices
-    #  <%= step_name.classify %>.values.map(&:to_s)
+    #  <%= step_name.camelize %>.values.map(&:to_s)
     # end
     # validates_inclusion_of :<%= step_name.underscore %>, in: choices
 
@@ -20,7 +20,7 @@ module Steps::<%= task_name.classify %>
     #   - Uncomment the below if you have a value object
     #   - Delete the method if you haven't
     # def <%= step_name.underscore %>_value
-    #  <%= step_name.classify %>.new(<%= step_name %>)
+    #  <%= step_name.camelize %>.new(<%= step_name %>)
     # end
 
     def changed?
@@ -29,7 +29,7 @@ module Steps::<%= task_name.classify %>
       #  do e.g.:
       #
       #  tribunal_case.<%= step_name.underscore %> != <%= step_name.underscore %>_value
-      raise 'TODO: Update <%= step_name.classify %>#changed?'
+      raise 'TODO: Update <%= step_name.camelize %>#changed?'
     end
 
     def persist!
@@ -38,7 +38,7 @@ module Steps::<%= task_name.classify %>
 
       # TODO: Update this to persist your form object
       tribunal_case.update(
-        <%= step_name.underscore %>: (raise 'TODO: Update <%= step_name.classify %>#persist!')
+        <%= step_name.underscore %>: (raise 'TODO: Update <%= step_name.camelize %>#persist!')
         # The following are dependent attributes that need to be reset
         # TODO: Are there any dependent attributes? Reset them here.
       )

--- a/lib/generators/step/templates/form_spec.rb
+++ b/lib/generators/step/templates/form_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Steps::<%= task_name.classify %>::<%= step_name.classify %>Form do
+RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form do
   let(:arguments) { {
     tribunal_case: tribunal_case,
     <%= step_name.underscore %>: <%= step_name.underscore %>
@@ -10,7 +10,7 @@ RSpec.describe Steps::<%= task_name.classify %>::<%= step_name.classify %>Form d
 
   subject { described_class.new(arguments) }
 
-  pending 'Write specs for <%= step_name.classify %>Form!'
+  pending 'Write specs for <%= step_name.camelize %>Form!'
 
   # TODO: The below can be uncommented and serves as a starting point for
   #   forms operating on a single value object.


### PR DESCRIPTION
The generator templates are using the `#classify` inflection which
(wrongly, in our case) singularizes the class name it's supposed
to create – so e.g. the 'Details' task ends up being 'Detail'.