### PR TITLE
Add `taxpayer_type` step for details task

### DIFF
--- a/app/controllers/steps/details/start_controller.rb
+++ b/app/controllers/steps/details/start_controller.rb
@@ -1,7 +1,7 @@
 module Steps::Details
-  class StartController < DetailsStepController
+  class StartController < Steps::DetailsStepController
     def show
-      @can_start = false
+      @can_start = current_tribunal_case&.cost_task_completed?
     end
   end
 end

--- a/app/controllers/steps/details/taxpayer_type_controller.rb
+++ b/app/controllers/steps/details/taxpayer_type_controller.rb
@@ -1,0 +1,16 @@
+module Steps::Details
+  class TaxpayerTypeController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = TaxpayerTypeForm.new(
+        tribunal_case: current_tribunal_case,
+        taxpayer_type: current_tribunal_case.taxpayer_type
+      )
+      @back_link_path = steps_details_start_path
+    end
+
+    def update
+      update_and_advance(:taxpayer_type, TaxpayerTypeForm)
+    end
+  end
+end

--- a/app/controllers/steps/details_step_controller.rb
+++ b/app/controllers/steps/details_step_controller.rb
@@ -1,2 +1,7 @@
 class Steps::DetailsStepController < StepController
+  private
+
+  def decision_tree_class
+    DetailsDecisionTree
+  end
 end

--- a/app/forms/steps/details/taxpayer_type_form.rb
+++ b/app/forms/steps/details/taxpayer_type_form.rb
@@ -1,0 +1,30 @@
+module Steps::Details
+  class TaxpayerTypeForm < BaseForm
+    attribute :taxpayer_type, String
+
+    def self.choices
+     TaxpayerType.values.map(&:to_s)
+    end
+    validates_inclusion_of :taxpayer_type, in: choices
+
+    private
+
+    def taxpayer_type_value
+     TaxpayerType.new(taxpayer_type)
+    end
+
+    def changed?
+      tribunal_case.taxpayer_type != taxpayer_type_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return unless changed?
+
+      tribunal_case.update(
+        taxpayer_type: taxpayer_type_value
+        # The following are dependent attributes that need to be reset
+      )
+    end
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,9 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.has_value_object(value_object)
+    composed_of value_object,
+      allow_nil:  true,
+      mapping:    [[value_object.to_s, 'value']]
+  end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,23 +1,15 @@
 class TribunalCase < ApplicationRecord
-  composed_of :case_type,
-    allow_nil:  true,
-    mapping:    [%w(case_type value)]
+  # Cost task
+  has_value_object :case_type
+  has_value_object :dispute_type
+  has_value_object :penalty_amount
+  has_value_object :lodgement_fee
 
-  composed_of :dispute_type,
-    allow_nil:  true,
-    mapping:    [%w(dispute_type value)]
+  # Lateness task
+  has_value_object :in_time
 
-  composed_of :penalty_amount,
-    allow_nil:  true,
-    mapping:    [%w(penalty_amount value)]
-
-  composed_of :lodgement_fee,
-    allow_nil:  true,
-    mapping:    [%w(lodgement_fee value)]
-
-  composed_of :in_time,
-    allow_nil:  true,
-    mapping:    [%w(in_time value)]
+  # Details task
+  has_value_object :taxpayer_type
 
   def cost_task_completed?
     lodgement_fee?

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -1,0 +1,18 @@
+class DetailsDecisionTree < DecisionTree
+  def destination
+    return @next_step if @next_step
+
+    case step.to_sym
+    when :taxpayer_type
+      after_taxpayer_type_step
+    else
+      raise "Invalid step '#{step}'"
+    end
+  end
+
+  private
+
+  def after_taxpayer_type_step
+    { controller: '/home', action: :index }
+  end
+end

--- a/app/value_objects/taxpayer_type.rb
+++ b/app/value_objects/taxpayer_type.rb
@@ -1,0 +1,15 @@
+class TaxpayerType < ValueObject
+  VALUES = [
+    INDIVIDUAL = new(:individual),
+    COMPANY    = new(:company)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+
+  def initialize(raw_value)
+    raise ArgumentError.new('Taxpayer type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    super(raw_value.to_sym)
+  end
+end

--- a/app/views/steps/details/start/show.html.erb
+++ b/app/views/steps/details/start/show.html.erb
@@ -10,7 +10,7 @@
 
 <% if @can_start %>
   <p>
-    <%= link_to t('.continue'), root_path, class: 'button button-start', role: 'button' %>
+    <%= link_to t('.continue'), edit_steps_details_taxpayer_type_path, class: 'button button-start', role: 'button' %>
   </p>
 <% else %>
   <p>

--- a/app/views/steps/details/taxpayer_type/edit.html.erb
+++ b/app/views/steps/details/taxpayer_type/edit.html.erb
@@ -1,0 +1,17 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p class="step-info">
+      <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
+      <%=t 'generic.step', step: 1, of: 0 %>
+    </p>
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :taxpayer_type,
+        choices: Steps::Details::TaxpayerTypeForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -22,3 +22,23 @@ en:
               </strong>
             </p>
           previous_step_not_completed: You must complete Step 1 and Step 2 before you can enter your appeal details. 
+      taxpayer_type:
+        edit:
+          heading: Is the appeal for an individual or company?
+          lead_text: Select whether the taxpayer is an individual or a company.
+  activemodel:
+    errors:
+      models:
+        steps/details/taxpayer_type_form:
+          attributes:
+            taxpayer_type:
+              inclusion: Select whether the appeal is for an individual or company
+  helpers:
+    fieldset:
+      steps_details_taxpayer_type_form:
+        taxpayer_type: Is the appeal for an individual or company?
+    label:
+      steps_details_taxpayer_type_form:
+        taxpayer_type:
+          individual_html: <strong>Individual</strong>
+          company_html: <strong>Company</strong><br>including partnerships (LLP), trusts, clubs and associations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
     namespace :details do
       show_step :start
+      edit_step :taxpayer_type
     end
   end
 

--- a/db/migrate/20161128113853_add_taxpayer_type_to_tribunal_case.rb
+++ b/db/migrate/20161128113853_add_taxpayer_type_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddTaxpayerTypeToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :taxpayer_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161118094611) do
+ActiveRecord::Schema.define(version: 20161128113853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "taxpayers", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet     "current_sign_in_ip"
+    t.inet     "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.string   "tribunal_case_id"
+    t.index ["email"], name: "index_taxpayers_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_taxpayers_on_reset_password_token", unique: true, using: :btree
+  end
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.boolean  "challenged_decision"
@@ -26,6 +44,7 @@ ActiveRecord::Schema.define(version: 20161118094611) do
     t.string   "lodgement_fee"
     t.string   "in_time"
     t.text     "lateness_reason"
+    t.string   "taxpayer_type"
   end
 
 end

--- a/spec/controllers/steps/details/taxpayer_type_controller_spec.rb
+++ b/spec/controllers/steps/details/taxpayer_type_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::TaxpayerTypeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::TaxpayerTypeForm, DetailsDecisionTree
+end

--- a/spec/features/details_spec.rb
+++ b/spec/features/details_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.feature 'Details', type: :feature do
+  before do
+    visit_homepage
+    complete_cost_task
+    complete_lateness_task
+    start_task
+  end
+
+  scenario 'WIP: Individual-or-company step redirects back to homepage' do
+    answer_question 'Is the appeal for an individual or company?', with: 'Individual'
+    expect(page).to have_current_path(root_path)
+  end
+end

--- a/spec/forms/steps/details/taxpayer_type_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_type_form_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::TaxpayerTypeForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    taxpayer_type: taxpayer_type
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, taxpayer_type: nil) }
+  let(:taxpayer_type) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:taxpayer_type) { 'company' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when taxpayer_type is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_type]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_type is not valid' do
+      let(:taxpayer_type) { 'frustrated_from_essex' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_type]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_type is valid' do
+      let(:taxpayer_type) { 'individual' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          taxpayer_type: TaxpayerType::INDIVIDUAL
+        )
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when in_time is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          taxpayer_type: TaxpayerType.new(:individual)
+        )
+      }
+      let(:taxpayer_type) { 'individual' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end
+

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe DetailsDecisionTree do
+  let(:object)    { double('Object') }
+  let(:step)      { double('Step') }
+  let(:next_step) { nil }
+  subject { described_class.new(object: object, step: step, next_step: next_step) }
+
+  describe '#destination' do
+    context 'when the step is `taxpayer_type`' do
+      let(:step) { { taxpayer_type: 'anything_for_now'  } }
+
+      it 'sends the user to the task list' do
+        expect(subject.destination).to eq({
+          controller: '/home',
+          action:     :index
+        })
+      end
+    end
+
+    context 'when the step is invalid' do
+      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+
+      it 'raises an error' do
+        expect { subject.destination }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/support/features_helpers.rb
+++ b/spec/support/features_helpers.rb
@@ -27,6 +27,11 @@ def complete_cost_task
   click_link 'Continue'
 end
 
+def complete_lateness_task
+  start_task
+  answer_question "Do you think you're in time to appeal to the tax tribunal?", with: 'Yes, I am in time'
+end
+
 def expect_amount_on(page, gbp: nil)
   expect(page).to have_text("#{I18n.t('steps.cost.determine_cost.show.fee_label')} £#{gbp}")
 end


### PR DESCRIPTION
This asks the question "Is the appeal for an individual or company?" and
is the first question of the details task.

- Includes the basic decision tree setup for the details task
- Refactors the `TribunalCase` model and extracts a `#has_value_object`
  method that encapsulates the value object pattern we use throughout
  the application