### PR TITLE
Add ability to prefill session in development

### DIFF
--- a/app/assets/stylesheets/local/developer_tools.scss
+++ b/app/assets/stylesheets/local/developer_tools.scss
@@ -1,8 +1,23 @@
 #footer .developer_tools {
   margin: 0;
 
+  h4 {
+    font-size: 16px;
+    font-weight: bold;
+  }
+
+  .details {
+    color: $secondary-text-colour;
+    margin: 0;
+  }
+
   .button-destroy_session {
     background-color: $mellow-red;
+    color: $page-colour;
+  }
+
+  .button-create_session {
+    background-color: $mauve;
     color: $page-colour;
   }
 }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,32 @@
 class SessionsController < ApplicationController
+  def create_and_fill_cost
+    raise 'For development use only' unless Rails.env.development?
+    # :nocov:
+    tribunal_case.update(case_type: CaseType::OTHER, challenged_decision: true, lodgement_fee: LodgementFee::FEE_LEVEL_3)
+    redirect_to root_path
+    # :nocov:
+  end
+
+  def create_and_fill_cost_and_lateness
+    raise 'For development use only' unless Rails.env.development?
+    # :nocov:
+    tribunal_case.update(in_time: InTime::YES)
+    create_and_fill_cost
+    # :nocov:
+  end
+
   def destroy
     reset_session
     redirect_to root_path
   end
+
+  private
+
+  # :nocov:
+  def tribunal_case
+    @tribunal_case ||= TribunalCase.find_by_id(session[:tribunal_case_id]) || TribunalCase.create.tap do |tribunal_case|
+      session[:tribunal_case_id] = tribunal_case.id
+    end
+  end
+  # :nocov:
 end

--- a/app/views/application/_developer_tools.html.erb
+++ b/app/views/application/_developer_tools.html.erb
@@ -8,7 +8,15 @@
             <%= @form_object.tribunal_case.id %>
           </p>
         <% end %>
-        <%= link_to 'Destroy session', session_path, method: :delete, class: 'button button-destroy_session', data: { confirm: 'Are you sure?' } %>
+        <h4>Destroy session</h4>
+        <p class="details">Deletes all data entered in this session and lets you start a case again from scratch.</p>
+        <p><%= link_to 'Destroy session', session_path, method: :delete, class: 'button button-destroy_session', data: { confirm: 'Are you sure?' } %></p>
+        <h4>Quick case set up</h4>
+        <p class="details">Creates a case (or if one is in the session already, updates it) and prefills it so you can go straight to the next task.</p>
+        <p>
+          <%= link_to 'Set up appeal cost', create_and_fill_cost_session_path, method: :post, class: 'button button-create_session' %>
+          <%= link_to 'Set up appeal cost & lateness', create_and_fill_cost_and_lateness_session_path, method: :post, class: 'button button-create_session' %>
+        </p>
       </div>
     </details>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :session, only: [:destroy]
+  resource :session, only: [:destroy] do
+    member do
+      post :create_and_fill_cost
+      post :create_and_fill_cost_and_lateness
+    end
+  end
   root to: 'home#index'
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -12,4 +12,24 @@ RSpec.describe SessionsController, type: :controller do
       expect(subject).to redirect_to(root_path)
     end
   end
+
+  describe '#create_and_fill_cost' do
+    before do
+      expect(Rails.env).to receive(:development?).at_least(:once).and_return(false)
+    end
+
+    it 'will not work in a non-development environment' do
+      expect { post :create_and_fill_cost }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#create_and_fill_cost_and_lateness' do
+    before do
+      expect(Rails.env).to receive(:development?).at_least(:once).and_return(false)
+    end
+
+    it 'will not work in a non-development environment' do
+      expect { post :create_and_fill_cost_and_lateness }.to raise_error(RuntimeError)
+    end
+  end
 end


### PR DESCRIPTION
Makes development (and demonstrating!) much less annoying by adding
buttons to the "developer tools" area that create a new session (if
one doesn't exist) and prefill it with useful data.