### PR TITLE
Move i18n of step headers into individual locale files

### DIFF
--- a/app/views/steps/cost/case_type_challenged/edit.html.erb
+++ b/app/views/steps/cost/case_type_challenged/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), edit_steps_cost_challenged_decision_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 2, of: 4 %>
+      <%=t 'steps.cost.step_header', step: 2 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/cost/case_type_unchallenged/edit.html.erb
+++ b/app/views/steps/cost/case_type_unchallenged/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), edit_steps_cost_challenged_decision_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 2, of: 4 %>
+      <%=t 'steps.cost.step_header', step: 2 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/cost/challenged_decision/edit.html.erb
+++ b/app/views/steps/cost/challenged_decision/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), root_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 1, of: 4 %>
+      <%=t 'steps.cost.step_header', step: 1 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/cost/dispute_type/edit.html.erb
+++ b/app/views/steps/cost/dispute_type/edit.html.erb
@@ -6,7 +6,7 @@
       <% else %>
         <%= link_to t('generic.back_link'), edit_steps_cost_case_type_unchallenged_path, class: 'link-back' %>
       <% end %>
-      <%=t 'generic.step', step: 3, of: 4 %>
+      <%=t 'steps.cost.step_header', step: 3 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/cost/penalty_amount/edit.html.erb
+++ b/app/views/steps/cost/penalty_amount/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), edit_steps_cost_dispute_type_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 4, of: 4 %>
+      <%=t 'steps.cost.step_header', step: 4 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/details/taxpayer_type/edit.html.erb
+++ b/app/views/steps/details/taxpayer_type/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 1, of: 0 %>
+      <%=t 'steps.details.step_header', step: 1 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/lateness/in_time/edit.html.erb
+++ b/app/views/steps/lateness/in_time/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), steps_lateness_start_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 1, of: 2 %>
+      <%=t 'steps.lateness.step_header', step: 1 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <p class="step-info">
       <%= link_to t('generic.back_link'), edit_steps_lateness_in_time_path, class: 'link-back' %>
-      <%=t 'generic.step', step: 2, of: 2 %>
+      <%=t 'steps.lateness.step_header', step: 2 %>
     </p>
     <h1 class="heading-large"><%=t '.heading' %></h1>
 

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -1,6 +1,7 @@
 en:
   steps:
     cost:
+      step_header: Question %{step} of 4
       start:
         show:
           heading: 1. Find out the cost of your appeal

--- a/config/locales/default.yml
+++ b/config/locales/default.yml
@@ -5,7 +5,6 @@ en:
         unit: £
         precision: 0
   generic:
-    step: Question %{step} of %{of}
     back_link: Back
   errors:
     # WARNING: This means every possible error message must be a full

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -1,6 +1,7 @@
 en:
   steps:
     details:
+      step_header: Question %{step} of ?
       start:
         show:
           heading: 3. Enter appeal details and pay fee

--- a/config/locales/lateness.yml
+++ b/config/locales/lateness.yml
@@ -1,6 +1,7 @@
 en:
   steps:
     lateness:
+      step_header: Question %{step} of 2
       start:
         show:
           heading: 2. Check you meet tribunal deadlines


### PR DESCRIPTION
This moves the step headers ("Question 1 of 99") from `en.generic.step`
to the individual task locale files. This way, we no longer have to
specify the second number in each and every view template and can just
change it in one place if the total number of questions in a task
changes.