### PR TITLE
Add "Taxpayer's details" steps to details task

### DIFF
--- a/app/controllers/steps/details/company_details_controller.rb
+++ b/app/controllers/steps/details/company_details_controller.rb
@@ -1,0 +1,22 @@
+module Steps::Details
+  class CompanyDetailsController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = CompanyDetailsForm.new(
+        tribunal_case:                        current_tribunal_case,
+        taxpayer_company_name:                current_tribunal_case.taxpayer_company_name,
+        taxpayer_company_registration_number: current_tribunal_case.taxpayer_company_registration_number,
+        taxpayer_company_fao:                 current_tribunal_case.taxpayer_company_fao,
+        taxpayer_contact_address:             current_tribunal_case.taxpayer_contact_address,
+        taxpayer_contact_postcode:            current_tribunal_case.taxpayer_contact_postcode,
+        taxpayer_contact_email:               current_tribunal_case.taxpayer_contact_email,
+        taxpayer_contact_phone:               current_tribunal_case.taxpayer_contact_phone
+      )
+      @back_link_path = edit_steps_details_taxpayer_type_path
+    end
+
+    def update
+      update_and_advance(:company_details, CompanyDetailsForm, as: :company_details)
+    end
+  end
+end

--- a/app/controllers/steps/details/individual_details_controller.rb
+++ b/app/controllers/steps/details/individual_details_controller.rb
@@ -1,0 +1,20 @@
+module Steps::Details
+  class IndividualDetailsController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = IndividualDetailsForm.new(
+        tribunal_case:             current_tribunal_case,
+        taxpayer_individual_name:  current_tribunal_case.taxpayer_individual_name,
+        taxpayer_contact_address:  current_tribunal_case.taxpayer_contact_address,
+        taxpayer_contact_postcode: current_tribunal_case.taxpayer_contact_postcode,
+        taxpayer_contact_email:    current_tribunal_case.taxpayer_contact_email,
+        taxpayer_contact_phone:    current_tribunal_case.taxpayer_contact_phone
+      )
+      @back_link_path = edit_steps_details_taxpayer_type_path
+    end
+
+    def update
+      update_and_advance(:individual_details, IndividualDetailsForm, as: :individual_details)
+    end
+  end
+end

--- a/app/forms/steps/details/company_details_form.rb
+++ b/app/forms/steps/details/company_details_form.rb
@@ -1,0 +1,35 @@
+module Steps::Details
+  class CompanyDetailsForm < BaseForm
+    attribute :taxpayer_company_name, String
+    attribute :taxpayer_company_registration_number, String
+    attribute :taxpayer_company_fao, String
+    attribute :taxpayer_contact_address, String
+    attribute :taxpayer_contact_postcode, String
+    attribute :taxpayer_contact_email, String
+    attribute :taxpayer_contact_phone, String
+
+    validates_presence_of :taxpayer_company_name,
+                          :taxpayer_company_registration_number,
+                          :taxpayer_company_fao,
+                          :taxpayer_contact_address,
+                          :taxpayer_contact_postcode,
+                          :taxpayer_contact_email,
+                          :taxpayer_contact_phone
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.update(
+        taxpayer_company_name:                taxpayer_company_name,
+        taxpayer_company_registration_number: taxpayer_company_registration_number,
+        taxpayer_company_fao:                 taxpayer_company_fao,
+        taxpayer_contact_address:             taxpayer_contact_address,
+        taxpayer_contact_postcode:            taxpayer_contact_postcode,
+        taxpayer_contact_email:               taxpayer_contact_email,
+        taxpayer_contact_phone:               taxpayer_contact_phone
+      )
+    end
+  end
+end

--- a/app/forms/steps/details/individual_details_form.rb
+++ b/app/forms/steps/details/individual_details_form.rb
@@ -1,0 +1,29 @@
+module Steps::Details
+  class IndividualDetailsForm < BaseForm
+    attribute :taxpayer_individual_name, String
+    attribute :taxpayer_contact_address, String
+    attribute :taxpayer_contact_postcode, String
+    attribute :taxpayer_contact_email, String
+    attribute :taxpayer_contact_phone, String
+
+    validates_presence_of :taxpayer_individual_name,
+                          :taxpayer_contact_address,
+                          :taxpayer_contact_postcode,
+                          :taxpayer_contact_email,
+                          :taxpayer_contact_phone
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.update(
+        taxpayer_individual_name:  taxpayer_individual_name,
+        taxpayer_contact_address:  taxpayer_contact_address,
+        taxpayer_contact_postcode: taxpayer_contact_postcode,
+        taxpayer_contact_email:    taxpayer_contact_email,
+        taxpayer_contact_phone:    taxpayer_contact_phone
+      )
+    end
+  end
+end

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -5,6 +5,10 @@ class DetailsDecisionTree < DecisionTree
     case step.to_sym
     when :taxpayer_type
       after_taxpayer_type_step
+    when :individual_details
+      after_individual_details_step
+    when :company_details
+      after_company_details_step
     else
       raise "Invalid step '#{step}'"
     end
@@ -13,6 +17,19 @@ class DetailsDecisionTree < DecisionTree
   private
 
   def after_taxpayer_type_step
+    case answer
+    when :individual
+      { controller: :individual_details, action: :edit }
+    when :company
+      { controller: :company_details, action: :edit }
+    end
+  end
+
+  def after_individual_details_step
+    { controller: '/home', action: :index }
+  end
+
+  def after_company_details_step
     { controller: '/home', action: :index }
   end
 end

--- a/app/views/steps/details/company_details/edit.html.erb
+++ b/app/views/steps/details/company_details/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p class="step-info">
+      <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
+      <%=t 'steps.details.step_header', step: 2 %>
+    </p>
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_field :taxpayer_company_name %>
+      <%= f.text_field :taxpayer_company_registration_number %>
+      <%= f.text_field :taxpayer_company_fao %>
+      <%= f.text_area :taxpayer_contact_address, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_field :taxpayer_contact_postcode %>
+      <%= f.text_field :taxpayer_contact_email %>
+      <%= f.text_field :taxpayer_contact_phone %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/details/individual_details/edit.html.erb
+++ b/app/views/steps/details/individual_details/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p class="step-info">
+      <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
+      <%=t 'steps.details.step_header', step: 2 %>
+    </p>
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_field :taxpayer_individual_name %>
+      <%= f.text_area :taxpayer_contact_address, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_field :taxpayer_contact_postcode %>
+      <%= f.text_field :taxpayer_contact_email %>
+      <%= f.text_field :taxpayer_contact_phone %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -27,6 +27,14 @@ en:
         edit:
           heading: Is the appeal for an individual or company?
           lead_text: Select whether the taxpayer is an individual or a company.
+      individual_details:
+        edit:
+          heading: Taxpayer's details
+          lead_text: Enter details for the taxpayer involved in the appeal. These will usually be shown on any correspondence with HMRC.
+      company_details:
+        edit:
+          heading: Taxpayer's details
+          lead_text: Enter details for the taxpayer involved in the appeal. These will usually be shown on any correspondence with HMRC.
   activemodel:
     errors:
       models:
@@ -34,6 +42,10 @@ en:
           attributes:
             taxpayer_type:
               inclusion: Select whether the appeal is for an individual or company
+        steps/details/individual_details_form:
+          blank: You must enter the taxpayer's %{attribute}
+        steps/details/company_details_form:
+          blank: You must enter the taxpayer's %{attribute}
   helpers:
     fieldset:
       steps_details_taxpayer_type_form:
@@ -43,3 +55,17 @@ en:
         taxpayer_type:
           individual_html: <strong>Individual</strong>
           company_html: <strong>Company</strong><br>including partnerships (LLP), trusts, clubs and associations
+      steps_details_individual_details_form:
+        taxpayer_individual_name: Name (first name and last name)
+        taxpayer_contact_address: Address
+        taxpayer_contact_postcode: Postcode
+        taxpayer_contact_email: Email address
+        taxpayer_contact_phone: Phone number
+      steps_details_company_details_form:
+        taxpayer_company_name: Company name
+        taxpayer_company_registration_number: Company registration number
+        taxpayer_company_fao: Company contact person (first name and last name)
+        taxpayer_contact_address: Address
+        taxpayer_contact_postcode: Postcode
+        taxpayer_contact_email: Email address
+        taxpayer_contact_phone: Phone number

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     namespace :details do
       show_step :start
       edit_step :taxpayer_type
+      edit_step :individual_details
+      edit_step :company_details
     end
   end
 

--- a/db/migrate/20161129155123_add_taxpayer_details_to_tribunal_case.rb
+++ b/db/migrate/20161129155123_add_taxpayer_details_to_tribunal_case.rb
@@ -1,0 +1,12 @@
+class AddTaxpayerDetailsToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :taxpayer_individual_name, :string
+    add_column :tribunal_cases, :taxpayer_contact_address, :text
+    add_column :tribunal_cases, :taxpayer_contact_postcode, :text
+    add_column :tribunal_cases, :taxpayer_contact_email, :string
+    add_column :tribunal_cases, :taxpayer_contact_phone, :string
+    add_column :tribunal_cases, :taxpayer_company_name, :string
+    add_column :tribunal_cases, :taxpayer_company_fao, :string
+    add_column :tribunal_cases, :taxpayer_company_registration_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161128113853) do
+ActiveRecord::Schema.define(version: 20161129155123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,8 +36,8 @@ ActiveRecord::Schema.define(version: 20161128113853) do
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.boolean  "challenged_decision"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.string   "case_type"
     t.string   "dispute_type"
     t.string   "penalty_amount"
@@ -45,6 +45,14 @@ ActiveRecord::Schema.define(version: 20161128113853) do
     t.string   "in_time"
     t.text     "lateness_reason"
     t.string   "taxpayer_type"
+    t.string   "taxpayer_individual_name"
+    t.text     "taxpayer_contact_address"
+    t.text     "taxpayer_contact_postcode"
+    t.string   "taxpayer_contact_email"
+    t.string   "taxpayer_contact_phone"
+    t.string   "taxpayer_company_name"
+    t.string   "taxpayer_company_fao"
+    t.string   "taxpayer_company_registration_number"
   end
 
 end

--- a/spec/controllers/steps/details/company_details_controller_spec.rb
+++ b/spec/controllers/steps/details/company_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::CompanyDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::CompanyDetailsForm, DetailsDecisionTree
+end

--- a/spec/controllers/steps/details/individual_details_controller_spec.rb
+++ b/spec/controllers/steps/details/individual_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::IndividualDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::IndividualDetailsForm, DetailsDecisionTree
+end

--- a/spec/features/details_spec.rb
+++ b/spec/features/details_spec.rb
@@ -8,8 +8,31 @@ RSpec.feature 'Details', type: :feature do
     start_task
   end
 
-  scenario 'WIP: Individual-or-company step redirects back to homepage' do
+  scenario 'appeal for an individual' do
     answer_question 'Is the appeal for an individual or company?', with: 'Individual'
+
+    fill_in 'Name (first name and last name)', with: 'Jane Taxpayer'
+    fill_in 'Address', with: '123 New Street'
+    fill_in 'Postcode', with: 'AB1 2CD'
+    fill_in 'Email address', with: 'jane.taxpayer@aol.co.uk'
+    fill_in 'Phone number', with: '0118 999 881 999 119 7253'
+    continue
+
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario 'appeal for a company' do
+    answer_question 'Is the appeal for an individual or company?', with: 'Company'
+
+    fill_in 'Company name', with: 'ACME Ltd'
+    fill_in 'Company registration number', with: 'ABC123'
+    fill_in 'Company contact person (first name and last name)', with: 'Jane Taxpayer'
+    fill_in 'Address', with: '123 New Street'
+    fill_in 'Postcode', with: 'AB1 2CD'
+    fill_in 'Email address', with: 'jane.taxpayer@aol.co.uk'
+    fill_in 'Phone number', with: '0118 999 881 999 119 7253'
+    continue
+
     expect(page).to have_current_path(root_path)
   end
 end

--- a/spec/forms/steps/details/company_details_form_spec.rb
+++ b/spec/forms/steps/details/company_details_form_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::CompanyDetailsForm do
+  let(:arguments) { {
+    tribunal_case:                        tribunal_case,
+    taxpayer_company_name:                taxpayer_company_name,
+    taxpayer_company_registration_number: taxpayer_company_registration_number,
+    taxpayer_company_fao:                 taxpayer_company_fao,
+    taxpayer_contact_address:             taxpayer_contact_address,
+    taxpayer_contact_postcode:            taxpayer_contact_postcode,
+    taxpayer_contact_email:               taxpayer_contact_email,
+    taxpayer_contact_phone:               taxpayer_contact_phone
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase) }
+
+  let(:taxpayer_company_name)                { 'ACME Limited' }
+  let(:taxpayer_company_registration_number) { '123ABC' }
+  let(:taxpayer_company_fao)                 { 'Jane Taxpayer' }
+  let(:taxpayer_contact_address)             { '123 New Street' }
+  let(:taxpayer_contact_postcode)            { 'AB1 2CD' }
+  let(:taxpayer_contact_email)               { 'jane.taxpayer@aol.co.uk' }
+  let(:taxpayer_contact_phone)               { '0118 999 881 999 119 7253' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when taxpayer_company_name is not present' do
+      let(:taxpayer_company_name) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_company_name]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_company_registration_number is not present' do
+      let(:taxpayer_company_registration_number) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_company_registration_number]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_company_fao is not present' do
+      let(:taxpayer_company_fao) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_company_fao]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_address is not present' do
+      let(:taxpayer_contact_address) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_address]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_postcode is not present' do
+      let(:taxpayer_contact_postcode) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_postcode]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_email is not present' do
+      let(:taxpayer_contact_email) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_email]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_phone is not present' do
+      let(:taxpayer_contact_phone) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_phone]).to_not be_empty
+      end
+    end
+
+    context 'when individual_details is valid' do
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          taxpayer_company_name:                taxpayer_company_name,
+          taxpayer_company_registration_number: taxpayer_company_registration_number,
+          taxpayer_company_fao:                 taxpayer_company_fao,
+          taxpayer_contact_address:             taxpayer_contact_address,
+          taxpayer_contact_postcode:            taxpayer_contact_postcode,
+          taxpayer_contact_email:               taxpayer_contact_email,
+          taxpayer_contact_phone:               taxpayer_contact_phone
+        )
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/details/individual_details_form_spec.rb
+++ b/spec/forms/steps/details/individual_details_form_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::IndividualDetailsForm do
+  let(:arguments) { {
+    tribunal_case:             tribunal_case,
+    taxpayer_individual_name:  taxpayer_individual_name,
+    taxpayer_contact_address:  taxpayer_contact_address,
+    taxpayer_contact_postcode: taxpayer_contact_postcode,
+    taxpayer_contact_email:    taxpayer_contact_email,
+    taxpayer_contact_phone:    taxpayer_contact_phone
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase) }
+
+  let(:taxpayer_individual_name)  { 'Jane McTaxpayer' }
+  let(:taxpayer_contact_address)  { '123 New Street' }
+  let(:taxpayer_contact_postcode) { 'AB1 2CD' }
+  let(:taxpayer_contact_email)    { 'jane.taxpayer@aol.co.uk' }
+  let(:taxpayer_contact_phone)    { '0118 999 881 999 119 7253' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when taxpayer_individual_name is not present' do
+      let(:taxpayer_individual_name) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_individual_name]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_address is not present' do
+      let(:taxpayer_contact_address) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_address]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_postcode is not present' do
+      let(:taxpayer_contact_postcode) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_postcode]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_email is not present' do
+      let(:taxpayer_contact_email) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_email]).to_not be_empty
+      end
+    end
+
+    context 'when taxpayer_contact_phone is not present' do
+      let(:taxpayer_contact_phone) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:taxpayer_contact_phone]).to_not be_empty
+      end
+    end
+
+    context 'when individual_details is valid' do
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          taxpayer_individual_name:  taxpayer_individual_name,
+          taxpayer_contact_address:  taxpayer_contact_address,
+          taxpayer_contact_postcode: taxpayer_contact_postcode,
+          taxpayer_contact_email:    taxpayer_contact_email,
+          taxpayer_contact_phone:    taxpayer_contact_phone
+        )
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -8,7 +8,42 @@ RSpec.describe DetailsDecisionTree do
 
   describe '#destination' do
     context 'when the step is `taxpayer_type`' do
-      let(:step) { { taxpayer_type: 'anything_for_now'  } }
+      context 'and the answer is `individual`' do
+        let(:step) { { taxpayer_type: 'individual'  } }
+
+        it 'sends the user to the `individual_details` step' do
+          expect(subject.destination).to eq({
+            controller: :individual_details,
+            action:     :edit
+          })
+        end
+      end
+
+      context 'and the answer is `company`' do
+        let(:step) { { taxpayer_type: 'company'  } }
+
+        it 'sends the user to the `company_details` step' do
+          expect(subject.destination).to eq({
+            controller: :company_details,
+            action:     :edit
+          })
+        end
+      end
+    end
+
+    context 'when the step is `individual_details`' do
+      let(:step) { { individual_details: 'anything'  } }
+
+      it 'sends the user to the task list' do
+        expect(subject.destination).to eq({
+          controller: '/home',
+          action:     :index
+        })
+      end
+    end
+
+    context 'when the step is `company_details`' do
+      let(:step) { { company_details: 'anything'  } }
 
       it 'sends the user to the task list' do
         expect(subject.destination).to eq({


### PR DESCRIPTION
This allows the taxpayer to specify their (or their company's) details
in order for the tribunal to be able to process their appeal.

- Add step for individual taxpayer's details
- Add step for company taxpayer's details