### PR TITLE
Refactor "back" link on step pages into helper

### DIFF
--- a/app/controllers/steps/cost/case_type_challenged_controller.rb
+++ b/app/controllers/steps/cost/case_type_challenged_controller.rb
@@ -11,5 +11,10 @@ module Steps::Cost
     def update
       update_and_advance(:case_type, CaseTypeForm, as: :case_type_challenged)
     end
+
+    def previous_step_path
+      edit_steps_cost_challenged_decision_path
+    end
   end
 end
+

--- a/app/controllers/steps/cost/case_type_unchallenged_controller.rb
+++ b/app/controllers/steps/cost/case_type_unchallenged_controller.rb
@@ -11,5 +11,10 @@ module Steps::Cost
     def update
       update_and_advance(:case_type, CaseTypeForm, as: :case_type_unchallenged)
     end
+
+    def previous_step_path
+      edit_steps_cost_challenged_decision_path
+    end
   end
 end
+

--- a/app/controllers/steps/cost/challenged_decision_controller.rb
+++ b/app/controllers/steps/cost/challenged_decision_controller.rb
@@ -12,6 +12,10 @@ module Steps::Cost
       update_and_advance(:challenged_decision, ChallengedDecisionForm)
     end
 
+    def previous_step_path
+      steps_cost_start_path
+    end
+
     private
 
     def current_tribunal_case

--- a/app/controllers/steps/cost/dispute_type_controller.rb
+++ b/app/controllers/steps/cost/dispute_type_controller.rb
@@ -11,5 +11,13 @@ module Steps::Cost
     def update
       update_and_advance(:dispute_type, DisputeTypeForm)
     end
+
+    def previous_step_path
+      if current_tribunal_case.challenged_decision
+        edit_steps_cost_case_type_challenged_path
+      else
+        edit_steps_cost_case_type_unchallenged_path
+      end
+    end
   end
 end

--- a/app/controllers/steps/cost/penalty_amount_controller.rb
+++ b/app/controllers/steps/cost/penalty_amount_controller.rb
@@ -11,5 +11,9 @@ module Steps::Cost
     def update
       update_and_advance(:penalty_amount, PenaltyAmountForm, as: :penalty_amount)
     end
+
+    def previous_step_path
+      edit_steps_cost_dispute_type_path
+    end
   end
 end

--- a/app/controllers/steps/details/company_details_controller.rb
+++ b/app/controllers/steps/details/company_details_controller.rb
@@ -12,11 +12,14 @@ module Steps::Details
         taxpayer_contact_email:               current_tribunal_case.taxpayer_contact_email,
         taxpayer_contact_phone:               current_tribunal_case.taxpayer_contact_phone
       )
-      @back_link_path = edit_steps_details_taxpayer_type_path
     end
 
     def update
       update_and_advance(:company_details, CompanyDetailsForm, as: :company_details)
+    end
+
+    def previous_step_path
+      edit_steps_details_taxpayer_type_path
     end
   end
 end

--- a/app/controllers/steps/details/individual_details_controller.rb
+++ b/app/controllers/steps/details/individual_details_controller.rb
@@ -10,11 +10,14 @@ module Steps::Details
         taxpayer_contact_email:    current_tribunal_case.taxpayer_contact_email,
         taxpayer_contact_phone:    current_tribunal_case.taxpayer_contact_phone
       )
-      @back_link_path = edit_steps_details_taxpayer_type_path
     end
 
     def update
       update_and_advance(:individual_details, IndividualDetailsForm, as: :individual_details)
+    end
+
+    def previous_step_path
+      edit_steps_details_taxpayer_type_path
     end
   end
 end

--- a/app/controllers/steps/details/taxpayer_type_controller.rb
+++ b/app/controllers/steps/details/taxpayer_type_controller.rb
@@ -6,11 +6,14 @@ module Steps::Details
         tribunal_case: current_tribunal_case,
         taxpayer_type: current_tribunal_case.taxpayer_type
       )
-      @back_link_path = steps_details_start_path
     end
 
     def update
       update_and_advance(:taxpayer_type, TaxpayerTypeForm)
+    end
+
+    def previous_step_path
+      steps_details_start_path
     end
   end
 end

--- a/app/controllers/steps/lateness/in_time_controller.rb
+++ b/app/controllers/steps/lateness/in_time_controller.rb
@@ -11,5 +11,9 @@ module Steps::Lateness
     def update
       update_and_advance(:in_time, InTimeForm)
     end
+
+    def previous_step_path
+      steps_lateness_start_path
+    end
   end
 end

--- a/app/controllers/steps/lateness/lateness_reason_controller.rb
+++ b/app/controllers/steps/lateness/lateness_reason_controller.rb
@@ -11,5 +11,9 @@ module Steps::Lateness
     def update
       update_and_advance(:lateness_reason, LatenessReasonForm)
     end
+
+    def previous_step_path
+      edit_steps_lateness_in_time_path
+    end
   end
 end

--- a/app/forms/steps/cost/dispute_type_form.rb
+++ b/app/forms/steps/cost/dispute_type_form.rb
@@ -19,10 +19,6 @@ module Steps::Cost
       end.map(&:to_s)
     end
 
-    def case_challenged?
-      tribunal_case.challenged_decision
-    end
-
     private
 
     def dispute_type_value

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,14 @@ module ApplicationHelper
 
     form_for record, opts, &block
   end
+
+  # Render a back link pointing to a controller-defined previous step, and a step
+  # header to show the user how far they have come in the task
+  def step_header(task, step_number)
+    render partial: 'step_header', locals: {
+      task:        task,
+      step_number: step_number,
+      path:        controller.previous_step_path
+    }
+  end
 end

--- a/app/views/application/_step_header.html.erb
+++ b/app/views/application/_step_header.html.erb
@@ -1,0 +1,4 @@
+<p class="step-info">
+  <%= link_to t('generic.back_link'), path, class: 'link-back' %>
+  <%= t("steps.#{task}.step_header", step: step_number) %>
+</p>

--- a/app/views/steps/cost/case_type_challenged/edit.html.erb
+++ b/app/views/steps/cost/case_type_challenged/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), edit_steps_cost_challenged_decision_path, class: 'link-back' %>
-      <%=t 'steps.cost.step_header', step: 2 %>
-    </p>
+    <%= step_header(:cost, 2) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/cost/case_type_unchallenged/edit.html.erb
+++ b/app/views/steps/cost/case_type_unchallenged/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), edit_steps_cost_challenged_decision_path, class: 'link-back' %>
-      <%=t 'steps.cost.step_header', step: 2 %>
-    </p>
+    <%= step_header(:cost, 2) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/cost/challenged_decision/edit.html.erb
+++ b/app/views/steps/cost/challenged_decision/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), root_path, class: 'link-back' %>
-      <%=t 'steps.cost.step_header', step: 1 %>
-    </p>
+    <%= step_header(:cost, 1) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/cost/dispute_type/edit.html.erb
+++ b/app/views/steps/cost/dispute_type/edit.html.erb
@@ -1,13 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <% if @form_object.case_challenged? %>
-        <%= link_to t('generic.back_link'), edit_steps_cost_case_type_challenged_path, class: 'link-back' %>
-      <% else %>
-        <%= link_to t('generic.back_link'), edit_steps_cost_case_type_unchallenged_path, class: 'link-back' %>
-      <% end %>
-      <%=t 'steps.cost.step_header', step: 3 %>
-    </p>
+    <%= step_header(:cost, 3) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/cost/penalty_amount/edit.html.erb
+++ b/app/views/steps/cost/penalty_amount/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), edit_steps_cost_dispute_type_path, class: 'link-back' %>
-      <%=t 'steps.cost.step_header', step: 4 %>
-    </p>
+    <%= step_header(:cost, 4) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/details/company_details/edit.html.erb
+++ b/app/views/steps/details/company_details/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
-      <%=t 'steps.details.step_header', step: 2 %>
-    </p>
+    <%= step_header(:details, 2) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/details/individual_details/edit.html.erb
+++ b/app/views/steps/details/individual_details/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
-      <%=t 'steps.details.step_header', step: 2 %>
-    </p>
+    <%= step_header(:details, 2) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/details/taxpayer_type/edit.html.erb
+++ b/app/views/steps/details/taxpayer_type/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), @back_link_path, class: 'link-back' %>
-      <%=t 'steps.details.step_header', step: 1 %>
-    </p>
+    <%= step_header(:details, 1) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/lateness/in_time/edit.html.erb
+++ b/app/views/steps/lateness/in_time/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), steps_lateness_start_path, class: 'link-back' %>
-      <%=t 'steps.lateness.step_header', step: 1 %>
-    </p>
+    <%= step_header(:lateness, 1) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -1,9 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="step-info">
-      <%= link_to t('generic.back_link'), edit_steps_lateness_in_time_path, class: 'link-back' %>
-      <%=t 'steps.lateness.step_header', step: 2 %>
-    </p>
+    <%= step_header(:lateness, 2) %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>

--- a/spec/forms/steps/cost/dispute_type_form_spec.rb
+++ b/spec/forms/steps/cost/dispute_type_form_spec.rb
@@ -17,34 +17,6 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
 
   subject { described_class.new(arguments) }
 
-  describe '#case_challenged?' do
-    context 'when the case has been challenged' do
-      let(:tribunal_case) {
-        instance_double(
-          TribunalCase,
-          challenged_decision: true
-        )
-      }
-
-      it 'returns true' do
-        expect(subject.case_challenged?).to eq(true)
-      end
-    end
-
-    context 'when the case has not been challenged' do
-      let(:tribunal_case) {
-        instance_double(
-          TribunalCase,
-          challenged_decision: false
-        )
-      }
-
-      it 'returns false' do
-        expect(subject.case_challenged?).to eq(false)
-      end
-    end
-  end
-
   describe '#choices' do
     context 'when the appeal is about income tax' do
       let(:case_type) { CaseType::INCOME_TAX }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,9 +1,16 @@
 require 'spec_helper'
 
+# TestController doesn't have this method so we can't stub it nicely
+class ActionView::TestCase::TestController
+  def previous_step_path
+    '/foo/bar'
+  end
+end
+
 RSpec.describe ApplicationHelper do
   let(:record) { double('Record') }
 
-  describe '.step_form' do
+  describe '#step_form' do
     let(:expected_defaults) { {
       url: {
         controller: "application",
@@ -23,6 +30,17 @@ RSpec.describe ApplicationHelper do
     it 'accepts additional options like FormHelper#form_for would' do
       expect(helper).to receive(:form_for).with(record, expected_defaults.merge(foo: 'bar'))
       helper.step_form(record, { foo: 'bar' })
+    end
+  end
+
+  describe '#step_header' do
+    it 'renders the expected content' do
+      expect(helper).to receive(:render).with(partial: 'step_header', locals: {
+        task:        :my_task,
+        step_number: 999,
+        path:        '/foo/bar'
+      })
+      helper.step_header(:my_task, 999)
     end
   end
 end


### PR DESCRIPTION
The tasks shouldn't be using different code to implement the "Back to
previous step" functionality (two have the back links in the views, one
sets an ivar in the controller). This harmonises the different tasks and
DRYs up the logic.

Also, the current logic in the details task fails when the user has
already submitted the form as the ivar only gets set in the `edit`
action, but not the `update` action.

- Add `#previous_step_path` method to step controllers that defines the
  path for the previous path's edit action
- Add a `_step_header` partial for the step header markup
- Add `ApplicationHelper#step_header` that renders the step header
  partial with appropriate content
- Update all step views to use the helper