### PR TITLE
Clean up decision tree logic

### DIFF
--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -4,13 +4,13 @@ class CostDecisionTree < DecisionTree
 
     case step.to_sym
     when :challenged_decision
-      after_challenged_decision_step
+      edit(:case_type)
     when :case_type
       after_case_type_step
     when :dispute_type
       after_dispute_type_step
     when :penalty_amount
-      after_penalty_amount_step
+      show(:determine_cost)
     else
       raise "Invalid step '#{step}'"
     end
@@ -19,13 +19,13 @@ class CostDecisionTree < DecisionTree
   def previous
     case step.to_sym
     when :challenged_decision
-      before_challenged_decision_step
+      show(:start)
     when :case_type
-      before_case_type_step
+      edit(:challenged_decision)
     when :dispute_type
-      before_dispute_type_step
+      edit(:case_type)
     when :penalty_amount
-      before_penalty_amount_step
+      edit(:dispute_type)
     else
       raise "Invalid step '#{step}'"
     end
@@ -33,51 +33,27 @@ class CostDecisionTree < DecisionTree
 
   private
 
-  def before_challenged_decision_step
-    { controller: :start, action: :show }
-  end
-
-  def after_challenged_decision_step
-    { controller: :case_type, action: :edit }
-  end
-
-  def before_case_type_step
-    { controller: :challenged_decision, action: :edit }
-  end
-
   def after_case_type_step
     case answer
     when :income_tax
       if @object.challenged_decision
-        { controller: :dispute_type, action: :edit }
+        edit(:dispute_type)
       else
-        { controller: :must_challenge_hmrc, action: :show }
+        show(:must_challenge_hmrc)
       end
     when :vat
-      { controller: :dispute_type, action: :edit }
+      edit(:dispute_type)
     else
-      { controller: :determine_cost, action: :show }
+      show(:determine_cost)
     end
-  end
-
-  def before_dispute_type_step
-    { controller: :case_type, action: :edit }
   end
 
   def after_dispute_type_step
     case answer
     when :late_return_or_payment
-      { controller: :penalty_amount, action: :edit }
+      edit(:penalty_amount)
     when :amount_of_tax_owed, :paye_coding_notice
-      { controller: :determine_cost, action: :show }
+      show(:determine_cost)
     end
-  end
-
-  def before_penalty_amount_step
-    { controller: :dispute_type, action: :edit }
-  end
-
-  def after_penalty_amount_step
-    { controller: :determine_cost, action: :show }
   end
 end

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -16,4 +16,16 @@ class DecisionTree
   def answer
     @step.values.first.to_sym
   end
+
+  def show(step)
+    { controller: step, action: :show }
+  end
+
+  def edit(step)
+    { controller: step, action: :edit }
+  end
+
+  def home
+    { controller: '/home', action: :index }
+  end
 end

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -5,10 +5,8 @@ class DetailsDecisionTree < DecisionTree
     case step.to_sym
     when :taxpayer_type
       after_taxpayer_type_step
-    when :individual_details
-      after_individual_details_step
-    when :company_details
-      after_company_details_step
+    when :individual_details, :company_details
+      home
     else
       raise "Invalid step '#{step}'"
     end
@@ -17,11 +15,9 @@ class DetailsDecisionTree < DecisionTree
   def previous
     case step.to_sym
     when :taxpayer_type
-      before_taxpayer_type_step
-    when :individual_details
-      before_individual_details_step
-    when :company_details
-      before_company_details_step
+      show(:start)
+    when :individual_details, :company_details
+      edit(:taxpayer_type)
     else
       raise "Invalid step '#{step}'"
     end
@@ -29,32 +25,12 @@ class DetailsDecisionTree < DecisionTree
 
   private
 
-  def before_taxpayer_type_step
-    { controller: :start, action: :show }
-  end
-
   def after_taxpayer_type_step
     case answer
     when :individual
-      { controller: :individual_details, action: :edit }
+      edit(:individual_details)
     when :company
-      { controller: :company_details, action: :edit }
+      edit(:company_details)
     end
-  end
-
-  def before_individual_details_step
-    { controller: :taxpayer_type, action: :edit }
-  end
-
-  def after_individual_details_step
-    { controller: '/home', action: :index }
-  end
-
-  def before_company_details_step
-    { controller: :taxpayer_type, action: :edit }
-  end
-
-  def after_company_details_step
-    { controller: '/home', action: :index }
   end
 end

--- a/app/services/lateness_decision_tree.rb
+++ b/app/services/lateness_decision_tree.rb
@@ -6,7 +6,7 @@ class LatenessDecisionTree < DecisionTree
     when :in_time
       after_in_time_step
     when :lateness_reason
-      after_lateness_reason_step
+      home
     else
       raise "Invalid step '#{step}'"
     end
@@ -15,9 +15,9 @@ class LatenessDecisionTree < DecisionTree
   def previous
     case step.to_sym
     when :in_time
-      before_in_time_step
+      show(:start)
     when :lateness_reason
-      before_lateness_reason_step
+      edit(:in_time)
     else
       raise "Invalid step '#{step}'"
     end
@@ -25,24 +25,12 @@ class LatenessDecisionTree < DecisionTree
 
   private
 
-  def before_in_time_step
-    { controller: :start, action: :show }
-  end
-
   def after_in_time_step
     case answer
     when :yes
-      { controller: '/home', action: :index }
+      home
     when :no, :unsure
-      { controller: :lateness_reason, action: :edit }
+      edit(:lateness_reason)
     end
-  end
-
-  def before_lateness_reason_step
-    { controller: :in_time, action: :edit }
-  end
-
-  def after_lateness_reason_step
-    { controller: '/home', action: :index }
   end
 end

--- a/spec/services/cost_decision_tree_spec.rb
+++ b/spec/services/cost_decision_tree_spec.rb
@@ -10,24 +10,14 @@ RSpec.describe CostDecisionTree do
     context 'when the step is `challenged_decision`' do
       let(:step) { { challenged_decision: 'anything' } }
 
-      it 'sends the user to the case_type step' do
-        expect(subject.destination).to eq({
-          controller: :case_type,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_destination(:case_type, :edit) }
     end
 
     context 'when the step is `case_type`' do
       context 'and the answer is `vat`' do
         let(:step) { { case_type: 'vat' } }
 
-        it 'sends the user to the dispute_type step' do
-          expect(subject.destination).to eq({
-            controller: :dispute_type,
-            action:     :edit
-          })
-        end
+        it { is_expected.to have_destination(:dispute_type, :edit) }
       end
 
       context 'and the answer is `income_tax`' do
@@ -36,23 +26,13 @@ RSpec.describe CostDecisionTree do
         context 'and the case is challenged' do
           let(:object) { instance_double(TribunalCase, challenged_decision: true) }
 
-          it 'sends the user to the dispute_type step' do
-            expect(subject.destination).to eq({
-              controller: :dispute_type,
-              action:     :edit
-            })
-          end
+          it { is_expected.to have_destination(:dispute_type, :edit) }
         end
 
         context 'and the case is unchallenged' do
           let(:object) { instance_double(TribunalCase, challenged_decision: false) }
 
-          it 'sends the user to the must_challenge_hmrc step' do
-            expect(subject.destination).to eq({
-              controller: :must_challenge_hmrc,
-              action:     :show
-            })
-          end
+          it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
         end
       end
 
@@ -67,12 +47,7 @@ RSpec.describe CostDecisionTree do
         context "and the answer is `#{tax_type}`" do
           let(:step) { { case_type: tax_type } }
 
-          it 'sends the user to the `determine_cost` endpoint' do
-            expect(subject.destination).to eq({
-              controller: :determine_cost,
-              action:     :show
-            })
-          end
+          it { is_expected.to have_destination(:determine_cost, :show) }
         end
       end
     end
@@ -81,46 +56,26 @@ RSpec.describe CostDecisionTree do
       context 'and the answer is `amount_of_tax_owed`' do
         let(:step) { { dispute_type: 'amount_of_tax_owed' } }
 
-        it 'sends the user to the `determine_cost` endpoint' do
-          expect(subject.destination).to eq({
-            controller: :determine_cost,
-            action:     :show
-          })
-        end
+        it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
       context 'and the answer is `paye_coding_notice`' do
         let(:step) { { dispute_type: 'paye_coding_notice' } }
 
-        it 'sends the user to the `determine_cost` endpoint' do
-          expect(subject.destination).to eq({
-            controller: :determine_cost,
-            action:     :show
-          })
-        end
+        it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
       context 'and the answer is `late_return_or_payment`' do
         let(:step) { { dispute_type: 'late_return_or_payment' } }
 
-        it 'sends the user to the `penalty_amount` step' do
-          expect(subject.destination).to eq({
-            controller: :penalty_amount,
-            action:     :edit
-          })
-        end
+        it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
     end
 
     context 'when the step is `penalty_amount`' do
       let(:step) { { penalty_amount: 'anything' } }
 
-      it 'sends the user to the endpoint' do
-        expect(subject.destination).to eq({
-          controller: :determine_cost,
-          action:     :show
-        })
-      end
+      it { is_expected.to have_destination(:determine_cost, :show) }
     end
 
     context 'when the step is invalid' do
@@ -136,45 +91,25 @@ RSpec.describe CostDecisionTree do
     context 'when the step is `challenged_decision`' do
       let(:step) { { challenged_decision: 'anything' } }
 
-      it 'sends the user to the `start` step' do
-        expect(subject.previous).to eq({
-          controller: :start,
-          action:     :show
-        })
-      end
+      it { is_expected.to have_previous(:start, :show) }
     end
 
     context 'when the step is `case_type`' do
       let(:step) { { case_type: 'anything' } }
 
-      it 'sends the user to the `challenged_decision` step' do
-        expect(subject.previous).to eq({
-          controller: :challenged_decision,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_previous(:challenged_decision, :edit) }
     end
 
     context 'when the step is `dispute_type`' do
       let(:step) { { dispute_type: 'anything' } }
 
-      it 'sends the user to the `case_type` step' do
-        expect(subject.previous).to eq({
-          controller: :case_type,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_previous(:case_type, :edit) }
     end
 
     context 'when the step is `penalty_amount`' do
       let(:step) { { penalty_amount: 'anything' } }
 
-      it 'sends the user to the `dispute_type` step' do
-        expect(subject.previous).to eq({
-          controller: :dispute_type,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_previous(:dispute_type, :edit) }
     end
 
     context 'when the step is invalid' do

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -11,46 +11,26 @@ RSpec.describe DetailsDecisionTree do
       context 'and the answer is `individual`' do
         let(:step) { { taxpayer_type: 'individual'  } }
 
-        it 'sends the user to the `individual_details` step' do
-          expect(subject.destination).to eq({
-            controller: :individual_details,
-            action:     :edit
-          })
-        end
+        it { is_expected.to have_destination(:individual_details, :edit) }
       end
 
       context 'and the answer is `company`' do
         let(:step) { { taxpayer_type: 'company'  } }
 
-        it 'sends the user to the `company_details` step' do
-          expect(subject.destination).to eq({
-            controller: :company_details,
-            action:     :edit
-          })
-        end
+        it { is_expected.to have_destination(:company_details, :edit) }
       end
     end
 
     context 'when the step is `individual_details`' do
       let(:step) { { individual_details: 'anything'  } }
 
-      it 'sends the user to the task list' do
-        expect(subject.destination).to eq({
-          controller: '/home',
-          action:     :index
-        })
-      end
+      it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is `company_details`' do
       let(:step) { { company_details: 'anything'  } }
 
-      it 'sends the user to the task list' do
-        expect(subject.destination).to eq({
-          controller: '/home',
-          action:     :index
-        })
-      end
+      it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is invalid' do
@@ -66,34 +46,19 @@ RSpec.describe DetailsDecisionTree do
     context 'when the step is `taxpayer_type`' do
       let(:step) { { taxpayer_type: 'anything'  } }
 
-      it 'sends the user to `start` step' do
-        expect(subject.previous).to eq({
-          controller: :start,
-          action:     :show
-        })
-      end
+      it { is_expected.to have_previous(:start, :show) }
     end
 
     context 'when the step is `individual_details`' do
       let(:step) { { individual_details: 'anything'  } }
 
-      it 'sends the user to `taxpayer_type` step' do
-        expect(subject.previous).to eq({
-          controller: :taxpayer_type,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_previous(:taxpayer_type, :edit) }
     end
 
     context 'when the step is `company_details`' do
       let(:step) { { company_details: 'anything'  } }
 
-      it 'sends the user to `taxpayer_type` step' do
-        expect(subject.previous).to eq({
-          controller: :taxpayer_type,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_previous(:taxpayer_type, :edit) }
     end
 
     context 'when the step is invalid' do

--- a/spec/services/lateness_decision_tree_spec.rb
+++ b/spec/services/lateness_decision_tree_spec.rb
@@ -11,46 +11,26 @@ RSpec.describe LatenessDecisionTree do
       context 'and the answer is `yes`' do
         let(:step) { { in_time: 'yes' } }
 
-        it 'sends the user to the task list' do
-          expect(subject.destination).to eq({
-            controller: '/home',
-            action:     :index
-          })
-        end
+        it { is_expected.to have_destination('/home', :index) }
       end
 
       context 'and the answer is `no`' do
         let(:step) { { in_time: 'no' } }
 
-        it 'sends the user to the `lateness_reason` step' do
-          expect(subject.destination).to eq({
-            controller: :lateness_reason,
-            action:     :edit
-          })
-        end
+        it { is_expected.to have_destination(:lateness_reason, :edit) }
       end
 
       context 'and the answer is `unsure`' do
         let(:step) { { in_time: 'unsure' } }
 
-        it 'sends the user to the `lateness_reason` step' do
-          expect(subject.destination).to eq({
-            controller: :lateness_reason,
-            action:     :edit
-          })
-        end
+        it { is_expected.to have_destination(:lateness_reason, :edit) }
       end
     end
 
     context 'when the step is `lateness_reason`' do
       let(:step) { { lateness_reason: 'anything' } }
 
-      it 'sends the user to the home page' do
-        expect(subject.destination).to eq({
-          controller: '/home',
-          action:     :index
-        })
-      end
+      it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is invalid' do
@@ -66,23 +46,13 @@ RSpec.describe LatenessDecisionTree do
     context 'when the step is `in_time`' do
       let(:step) { { in_time: 'anything' } }
 
-      it 'sends the user to the `start` step' do
-        expect(subject.previous).to eq({
-          controller: :start,
-          action:     :show
-        })
-      end
+      it { is_expected.to have_previous(:start, :show) }
     end
 
     context 'when the step is `lateness_reason`' do
       let(:step) { { lateness_reason: 'anything' } }
 
-      it 'sends the user to the `in_time` step' do
-        expect(subject.previous).to eq({
-          controller: :in_time,
-          action:     :edit
-        })
-      end
+      it { is_expected.to have_previous(:in_time, :edit) }
     end
 
     context 'when the step is invalid' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.minimum_coverage 100
 unless ENV['NOCOVERAGE']
   SimpleCov.start do
     add_filter '.bundle'
+    add_filter 'spec/support'
   end
 end
 

--- a/spec/support/decision_tree_matcher.rb
+++ b/spec/support/decision_tree_matcher.rb
@@ -1,0 +1,35 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_destination do |controller, action|
+  match do |decision_tree|
+    decision_tree.destination == { controller: controller, action: action }
+  end
+
+  failure_message do |decision_tree|
+    if decision_tree.destination.is_a?(Hash) && decision_tree.destination.keys == [:controller, :action]
+			"expected decision tree to have a destination of " +
+      "'#{controller}##{action}', " +
+      "got '#{decision_tree.destination[:controller]}##{decision_tree.destination[:action]}'"
+    else
+			"expected decision tree destination to be an appropriately formatted hash, " +
+      "got '#{decision_tree.destination}'"
+    end
+  end
+end
+
+RSpec::Matchers.define :have_previous do |controller, action|
+  match do |decision_tree|
+    decision_tree.previous == { controller: controller, action: action }
+  end
+
+  failure_message do |decision_tree|
+    if decision_tree.previous.is_a?(Hash) && decision_tree.previous.keys == [:controller, :action]
+			"expected decision tree to have a previous step of " +
+      "'#{controller}##{action}', " +
+      "got '#{decision_tree.previous[:controller]}##{decision_tree.previous[:action]}'"
+    else
+			"expected decision tree previous step to be an appropriately formatted hash, " +
+      "got '#{decision_tree.previous}'"
+    end
+  end
+end


### PR DESCRIPTION
- Add `show(step)`, `edit(step)`, and `home` helper methods to
  avoid writing out repetitive route hashes
- Remove `before_*` and `after_*` methods that just have one fixed
  outcome and move their outcome into the case statement. Only keep
  the separate methods when there is actually logic in them.