### PR TITLE
Remove DecisionTree code from generator

### DIFF
--- a/lib/generators/step/USAGE
+++ b/lib/generators/step/USAGE
@@ -21,8 +21,6 @@ Example:
     This will update:
         config/routes.rb
           (adds an `edit_step` route for the step)
-        app/services/cost_decision_tree.rb
-          (adds the step to the decision tree)
 
     You will have to do yourself:
         - Change `@back_link_path` in the controller

--- a/lib/generators/step/step_generator.rb
+++ b/lib/generators/step/step_generator.rb
@@ -22,16 +22,4 @@ class StepGenerator < Rails::Generators::Base
       "  edit_step :#{step_name.underscore}\n    "
     end
   end
-
-  def add_to_decision_tree
-    tree_file = "app/services/#{task_name.underscore}_decision_tree.rb"
-
-    insert_into_file tree_file, before: "else\n      raise"do
-      "when :#{step_name.underscore}\n      after_#{step_name.underscore}_step\n    "
-    end
-
-    insert_into_file tree_file, before: /^end/ do
-      "  def after_#{step_name.underscore}_step\n    raise 'TODO: Implement me'\n  end\n"
-    end
-  end
 end


### PR DESCRIPTION
So far the step generator added some code into the `DecisionTree`
object, however that's very finicky and isn't working properly anymore
with the new "previous step" logic.

This removes the decision tree related code from the generator until we
can spend some time on implementing it properly.