### PR TITLE
Override choices for ChallengedDecision form

### DIFF
--- a/app/forms/steps/cost/challenged_decision_form.rb
+++ b/app/forms/steps/cost/challenged_decision_form.rb
@@ -2,7 +2,11 @@ module Steps::Cost
   class ChallengedDecisionForm < BaseForm
     attribute :challenged_decision, Boolean
 
-    validates_inclusion_of :challenged_decision, in: [true, false]
+    def self.choices
+      [true, false]
+    end
+
+    validates_inclusion_of :challenged_decision, in: choices
 
     private
 

--- a/app/views/steps/cost/challenged_decision/edit.html.erb
+++ b/app/views/steps/cost/challenged_decision/edit.html.erb
@@ -7,7 +7,7 @@
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :challenged_decision, inline: true %>
+      <%= f.radio_button_fieldset :challenged_decision, inline: true, choices: Steps::Cost::ChallengedDecisionForm.choices %>
       <%= f.submit class: 'button' %>
     <% end %>
 

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -182,6 +182,10 @@ en:
       steps_cost_penalty_amount_form:
         penalty_amount: What is the penalty or surcharge amount?
     label:
+      steps_cost_challenged_decision_form:
+        challenged_decision:
+          'true': 'Yes'
+          'false': 'No'
       steps_cost_case_type_form:
         case_type:
           income_tax_html: <strong>Income Tax</strong><br>for example, Pay As You Earn (PAYE), self-assessment


### PR DESCRIPTION
We were using the default choices from the GOV.UK form builder for the
ChallengedDecision form, which implicitly work for yes/no radio buttons
but break when you navigate back to the page (the previously selected
item is no longer selected).

This changes the form to use `true`/`false` instead of `:yes`/`:no` and
also brings it in line with the other forms.