### PR TITLE
Refactor DecisionTree to be more simple and clear

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -5,8 +5,8 @@ class StepController < ApplicationController
 
   def previous_step_path
     decision_tree = decision_tree_class.new(
-      object: current_tribunal_case,
-      step:   { controller_name => {} },
+      tribunal_case: current_tribunal_case,
+      as:            controller_name
     )
 
     url_for(decision_tree.previous)
@@ -14,7 +14,7 @@ class StepController < ApplicationController
 
   private
 
-  def update_and_advance(attr, form_class, opts={})
+  def update_and_advance(form_class, opts={})
     hash = permitted_params(form_class).to_h
 
     @next_step   = params[:next_step].presence
@@ -22,20 +22,14 @@ class StepController < ApplicationController
       hash.merge(tribunal_case: current_tribunal_case)
     )
 
-    if opts[:as]
-      # Allow renaming of the attribute if the attribute name in the
-      # form does not match the step name in the decision tree.
-      #   e.g. We might have an attribute `case_type` in
-      #   a form `case_type_challenged` - in which case
-      #   we need to rename the key in the params hash.
-      hash = { opts[:as] => hash[attr] }
-    end
-
     if @form_object.save
       destination = decision_tree_class.new(
-        object:    current_tribunal_case,
-        step:      hash,
-        next_step: @next_step
+        tribunal_case: current_tribunal_case,
+        step_params:   hash,
+        # Used when the step name in the decision tree is not the same as the first
+        # (and usually only) attribute in the form.
+        as:            opts[:as],
+        next_step:     @next_step
       ).destination
 
       redirect_to destination

--- a/app/controllers/steps/cost/case_type_controller.rb
+++ b/app/controllers/steps/cost/case_type_controller.rb
@@ -9,7 +9,7 @@ module Steps::Cost
     end
 
     def update
-      update_and_advance(:case_type, CaseTypeForm)
+      update_and_advance(CaseTypeForm)
     end
   end
 end

--- a/app/controllers/steps/cost/challenged_decision_controller.rb
+++ b/app/controllers/steps/cost/challenged_decision_controller.rb
@@ -9,7 +9,7 @@ module Steps::Cost
     end
 
     def update
-      update_and_advance(:challenged_decision, ChallengedDecisionForm)
+      update_and_advance(ChallengedDecisionForm)
     end
 
     private

--- a/app/controllers/steps/cost/dispute_type_controller.rb
+++ b/app/controllers/steps/cost/dispute_type_controller.rb
@@ -9,7 +9,7 @@ module Steps::Cost
     end
 
     def update
-      update_and_advance(:dispute_type, DisputeTypeForm)
+      update_and_advance(DisputeTypeForm)
     end
   end
 end

--- a/app/controllers/steps/cost/penalty_amount_controller.rb
+++ b/app/controllers/steps/cost/penalty_amount_controller.rb
@@ -9,7 +9,7 @@ module Steps::Cost
     end
 
     def update
-      update_and_advance(:penalty_amount, PenaltyAmountForm, as: :penalty_amount)
+      update_and_advance(PenaltyAmountForm)
     end
   end
 end

--- a/app/controllers/steps/details/company_details_controller.rb
+++ b/app/controllers/steps/details/company_details_controller.rb
@@ -15,7 +15,7 @@ module Steps::Details
     end
 
     def update
-      update_and_advance(:company_details, CompanyDetailsForm, as: :company_details)
+      update_and_advance(CompanyDetailsForm, as: :company_details)
     end
   end
 end

--- a/app/controllers/steps/details/documents_checklist_controller.rb
+++ b/app/controllers/steps/details/documents_checklist_controller.rb
@@ -15,7 +15,7 @@ module Steps::Details
     end
 
     def update
-      update_and_advance(:documents_checklist, DocumentsChecklistForm, as: :documents_checklist)
+      update_and_advance(DocumentsChecklistForm, as: :documents_checklist)
     end
 
     private

--- a/app/controllers/steps/details/grounds_for_appeal_controller.rb
+++ b/app/controllers/steps/details/grounds_for_appeal_controller.rb
@@ -9,7 +9,7 @@ module Steps::Details
     end
 
     def update
-      update_and_advance(:grounds_for_appeal, GroundsForAppealForm, as: :grounds_for_appeal)
+      update_and_advance(GroundsForAppealForm, as: :grounds_for_appeal)
     end
   end
 end

--- a/app/controllers/steps/details/individual_details_controller.rb
+++ b/app/controllers/steps/details/individual_details_controller.rb
@@ -13,7 +13,7 @@ module Steps::Details
     end
 
     def update
-      update_and_advance(:individual_details, IndividualDetailsForm, as: :individual_details)
+      update_and_advance(IndividualDetailsForm, as: :individual_details)
     end
   end
 end

--- a/app/controllers/steps/details/taxpayer_type_controller.rb
+++ b/app/controllers/steps/details/taxpayer_type_controller.rb
@@ -9,7 +9,7 @@ module Steps::Details
     end
 
     def update
-      update_and_advance(:taxpayer_type, TaxpayerTypeForm)
+      update_and_advance(TaxpayerTypeForm)
     end
   end
 end

--- a/app/controllers/steps/lateness/in_time_controller.rb
+++ b/app/controllers/steps/lateness/in_time_controller.rb
@@ -9,7 +9,7 @@ module Steps::Lateness
     end
 
     def update
-      update_and_advance(:in_time, InTimeForm)
+      update_and_advance(InTimeForm)
     end
   end
 end

--- a/app/controllers/steps/lateness/lateness_reason_controller.rb
+++ b/app/controllers/steps/lateness/lateness_reason_controller.rb
@@ -9,7 +9,7 @@ module Steps::Lateness
     end
 
     def update
-      update_and_advance(:lateness_reason, LatenessReasonForm)
+      update_and_advance(LatenessReasonForm)
     end
   end
 end

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -1,8 +1,8 @@
 class CostDecisionTree < DecisionTree
   def destination
-    return @next_step if @next_step
+    return next_step if next_step
 
-    case step.to_sym
+    case step_name.to_sym
     when :challenged_decision
       edit(:case_type)
     when :case_type
@@ -12,12 +12,12 @@ class CostDecisionTree < DecisionTree
     when :penalty_amount
       show(:determine_cost)
     else
-      raise "Invalid step '#{step}'"
+      raise "Invalid step '#{step_params}'"
     end
   end
 
   def previous
-    case step.to_sym
+    case step_name.to_sym
     when :challenged_decision
       show(:start)
     when :case_type
@@ -27,7 +27,7 @@ class CostDecisionTree < DecisionTree
     when :penalty_amount
       edit(:dispute_type)
     else
-      raise "Invalid step '#{step}'"
+      raise "Invalid step '#{step_params}'"
     end
   end
 
@@ -36,7 +36,7 @@ class CostDecisionTree < DecisionTree
   def after_case_type_step
     case answer
     when :income_tax
-      if @object.challenged_decision
+      if tribunal_case.challenged_decision
         edit(:dispute_type)
       else
         show(:must_challenge_hmrc)

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -1,28 +1,31 @@
 class DecisionTree
   include ApplicationHelper
 
-  def initialize(object:, step:, next_step: nil)
-    @object    = object
-    @step      = step
-    @next_step = next_step
+  attr_reader :tribunal_case, :step_params, :as, :next_step
+
+  def initialize(tribunal_case:, step_params: {}, as: nil, next_step: nil)
+    @tribunal_case = tribunal_case
+    @step_params   = step_params
+    @as            = as
+    @next_step     = next_step
   end
 
   private
 
-  def step
-    @step.keys.first
+  def step_name
+    as || step_params.keys.first
   end
 
   def answer
-    @step.values.first.to_sym
+    step_params.values.first.to_sym
   end
 
-  def show(step)
-    { controller: step, action: :show }
+  def show(step_controller)
+    { controller: step_controller, action: :show }
   end
 
-  def edit(step)
-    { controller: step, action: :edit }
+  def edit(step_controller)
+    { controller: step_controller, action: :edit }
   end
 
   def home

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -1,8 +1,8 @@
 class DetailsDecisionTree < DecisionTree
   def destination
-    return @next_step if @next_step
+    return next_step if next_step
 
-    case step.to_sym
+    case step_name.to_sym
     when :taxpayer_type
       after_taxpayer_type_step
     when :individual_details, :company_details
@@ -12,12 +12,12 @@ class DetailsDecisionTree < DecisionTree
     when :documents_checklist
       home
     else
-      raise "Invalid step '#{step}'"
+      raise "Invalid step '#{step_params}'"
     end
   end
 
   def previous
-    case step.to_sym
+    case step_name.to_sym
     when :taxpayer_type
       show(:start)
     when :individual_details, :company_details
@@ -27,14 +27,14 @@ class DetailsDecisionTree < DecisionTree
     when :documents_checklist
       edit(:grounds_for_appeal)
     else
-      raise "Invalid step '#{step}'"
+      raise "Invalid step '#{step_params}'"
     end
   end
 
   private
 
   def before_grounds_for_appeal_step
-    case @object.taxpayer_type
+    case tribunal_case.taxpayer_type
     when TaxpayerType::INDIVIDUAL
       edit(:individual_details)
     when TaxpayerType::COMPANY

--- a/app/services/lateness_decision_tree.rb
+++ b/app/services/lateness_decision_tree.rb
@@ -1,25 +1,25 @@
 class LatenessDecisionTree < DecisionTree
   def destination
-    return @next_step if @next_step
+    return next_step if next_step
 
-    case step.to_sym
+    case step_name.to_sym
     when :in_time
       after_in_time_step
     when :lateness_reason
       home
     else
-      raise "Invalid step '#{step}'"
+      raise "Invalid step '#{step_params}'"
     end
   end
 
   def previous
-    case step.to_sym
+    case step_name.to_sym
     when :in_time
       show(:start)
     when :lateness_reason
       edit(:in_time)
     else
-      raise "Invalid step '#{step}'"
+      raise "Invalid step '#{step_params}'"
     end
   end
 

--- a/spec/services/cost_decision_tree_spec.rb
+++ b/spec/services/cost_decision_tree_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
 RSpec.describe CostDecisionTree do
-  let(:object)    { double('Object') }
-  let(:step)      { double('Step') }
-  let(:next_step) { nil }
-  subject { described_class.new(object: object, step: step, next_step: next_step) }
+  let(:tribunal_case) { double('TribunalCase') }
+  let(:step_params)   { double('Step') }
+  let(:next_step)     { nil }
+  subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
   describe '#destination' do
     context 'when the step is `challenged_decision`' do
-      let(:step) { { challenged_decision: 'anything' } }
+      let(:step_params) { { challenged_decision: 'anything' } }
 
       it { is_expected.to have_destination(:case_type, :edit) }
     end
 
     context 'when the step is `case_type`' do
       context 'and the answer is `vat`' do
-        let(:step) { { case_type: 'vat' } }
+        let(:step_params) { { case_type: 'vat' } }
 
         it { is_expected.to have_destination(:dispute_type, :edit) }
       end
 
       context 'and the answer is `income_tax`' do
-        let(:step) { { case_type: 'income_tax' } }
+        let(:step_params) { { case_type: 'income_tax' } }
 
         context 'and the case is challenged' do
-          let(:object) { instance_double(TribunalCase, challenged_decision: true) }
+          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: true) }
 
           it { is_expected.to have_destination(:dispute_type, :edit) }
         end
 
         context 'and the case is unchallenged' do
-          let(:object) { instance_double(TribunalCase, challenged_decision: false) }
+          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: false) }
 
           it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
         end
@@ -45,7 +45,7 @@ RSpec.describe CostDecisionTree do
         other
       ).each do |tax_type|
         context "and the answer is `#{tax_type}`" do
-          let(:step) { { case_type: tax_type } }
+          let(:step_params) { { case_type: tax_type } }
 
           it { is_expected.to have_destination(:determine_cost, :show) }
         end
@@ -54,32 +54,32 @@ RSpec.describe CostDecisionTree do
 
     context 'when the step is `dispute_type`' do
       context 'and the answer is `amount_of_tax_owed`' do
-        let(:step) { { dispute_type: 'amount_of_tax_owed' } }
+        let(:step_params) { { dispute_type: 'amount_of_tax_owed' } }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
       context 'and the answer is `paye_coding_notice`' do
-        let(:step) { { dispute_type: 'paye_coding_notice' } }
+        let(:step_params) { { dispute_type: 'paye_coding_notice' } }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
       context 'and the answer is `late_return_or_payment`' do
-        let(:step) { { dispute_type: 'late_return_or_payment' } }
+        let(:step_params) { { dispute_type: 'late_return_or_payment' } }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
     end
 
     context 'when the step is `penalty_amount`' do
-      let(:step) { { penalty_amount: 'anything' } }
+      let(:step_params) { { penalty_amount: 'anything' } }
 
       it { is_expected.to have_destination(:determine_cost, :show) }
     end
 
     context 'when the step is invalid' do
-      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.destination }.to raise_error(RuntimeError)
@@ -89,31 +89,31 @@ RSpec.describe CostDecisionTree do
 
   describe '#previous' do
     context 'when the step is `challenged_decision`' do
-      let(:step) { { challenged_decision: 'anything' } }
+      let(:step_params) { { challenged_decision: 'anything' } }
 
       it { is_expected.to have_previous(:start, :show) }
     end
 
     context 'when the step is `case_type`' do
-      let(:step) { { case_type: 'anything' } }
+      let(:step_params) { { case_type: 'anything' } }
 
       it { is_expected.to have_previous(:challenged_decision, :edit) }
     end
 
     context 'when the step is `dispute_type`' do
-      let(:step) { { dispute_type: 'anything' } }
+      let(:step_params) { { dispute_type: 'anything' } }
 
       it { is_expected.to have_previous(:case_type, :edit) }
     end
 
     context 'when the step is `penalty_amount`' do
-      let(:step) { { penalty_amount: 'anything' } }
+      let(:step_params) { { penalty_amount: 'anything' } }
 
       it { is_expected.to have_previous(:dispute_type, :edit) }
     end
 
     context 'when the step is invalid' do
-      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.previous }.to raise_error(RuntimeError)

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -1,52 +1,52 @@
 require 'spec_helper'
 
 RSpec.describe DetailsDecisionTree do
-  let(:object)    { double('Object') }
-  let(:step)      { double('Step') }
-  let(:next_step) { nil }
-  subject { described_class.new(object: object, step: step, next_step: next_step) }
+  let(:tribunal_case) { double('Object') }
+  let(:step_params)   { double('Step') }
+  let(:next_step)     { nil }
+  subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
   describe '#destination' do
     context 'when the step is `taxpayer_type`' do
       context 'and the answer is `individual`' do
-        let(:step) { { taxpayer_type: 'individual'  } }
+        let(:step_params) { { taxpayer_type: 'individual'  } }
 
         it { is_expected.to have_destination(:individual_details, :edit) }
       end
 
       context 'and the answer is `company`' do
-        let(:step) { { taxpayer_type: 'company'  } }
+        let(:step_params) { { taxpayer_type: 'company'  } }
 
         it { is_expected.to have_destination(:company_details, :edit) }
       end
     end
 
     context 'when the step is `individual_details`' do
-      let(:step) { { individual_details: 'anything'  } }
+      let(:step_params) { { individual_details: 'anything'  } }
 
       it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
     end
 
     context 'when the step is `company_details`' do
-      let(:step) { { company_details: 'anything'  } }
+      let(:step_params) { { company_details: 'anything'  } }
 
       it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
     end
 
     context 'when the step is `grounds_for_appeal`' do
-      let(:step) { { grounds_for_appeal: 'anything'  } }
+      let(:step_params) { { grounds_for_appeal: 'anything'  } }
 
       it { is_expected.to have_destination(:documents_checklist, :edit) }
     end
 
     context 'when the step is `documents_checklist`' do
-      let(:step) { { documents_checklist: 'anything'  } }
+      let(:step_params) { { documents_checklist: 'anything'  } }
 
       it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is invalid' do
-      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.destination }.to raise_error(RuntimeError)
@@ -56,41 +56,41 @@ RSpec.describe DetailsDecisionTree do
 
   describe '#previous' do
     context 'when the step is `taxpayer_type`' do
-      let(:step) { { taxpayer_type: 'anything'  } }
+      let(:step_params) { { taxpayer_type: 'anything'  } }
 
       it { is_expected.to have_previous(:start, :show) }
     end
 
     context 'when the step is `individual_details`' do
-      let(:step) { { individual_details: 'anything'  } }
+      let(:step_params) { { individual_details: 'anything'  } }
 
       it { is_expected.to have_previous(:taxpayer_type, :edit) }
     end
 
     context 'when the step is `company_details`' do
-      let(:step) { { company_details: 'anything'  } }
+      let(:step_params) { { company_details: 'anything'  } }
 
       it { is_expected.to have_previous(:taxpayer_type, :edit) }
     end
 
     context 'when the step is `grounds_for_appeal`' do
-      let(:step) { { grounds_for_appeal: 'anything'  } }
+      let(:step_params) { { grounds_for_appeal: 'anything'  } }
 
       context 'when the tax payer type is individual' do
-        let(:object) { instance_double(TribunalCase, taxpayer_type: TaxpayerType::INDIVIDUAL) }
+        let(:tribunal_case) { instance_double(TribunalCase, taxpayer_type: TaxpayerType::INDIVIDUAL) }
 
         it { is_expected.to have_previous(:individual_details, :edit) }
       end
 
       context 'when the tax payer type is company' do
-        let(:object) { instance_double(TribunalCase, taxpayer_type: TaxpayerType::COMPANY) }
+        let(:tribunal_case) { instance_double(TribunalCase, taxpayer_type: TaxpayerType::COMPANY) }
 
         it { is_expected.to have_previous(:company_details, :edit) }
       end
     end
 
     context 'when the step is invalid' do
-      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.previous }.to raise_error(RuntimeError)

--- a/spec/services/lateness_decision_tree_spec.rb
+++ b/spec/services/lateness_decision_tree_spec.rb
@@ -1,40 +1,40 @@
 require 'spec_helper'
 
 RSpec.describe LatenessDecisionTree do
-  let(:object)    { double('Object') }
-  let(:step)      { double('Step') }
-  let(:next_step) { nil }
-  subject { described_class.new(object: object, step: step, next_step: next_step) }
+  let(:tribunal_case) { double('TribunalCase') }
+  let(:step_params)   { double('Step') }
+  let(:next_step)     { nil }
+  subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
   describe '#destination' do
     context 'when the step is `in_time`' do
       context 'and the answer is `yes`' do
-        let(:step) { { in_time: 'yes' } }
+        let(:step_params) { { in_time: 'yes' } }
 
         it { is_expected.to have_destination('/home', :index) }
       end
 
       context 'and the answer is `no`' do
-        let(:step) { { in_time: 'no' } }
+        let(:step_params) { { in_time: 'no' } }
 
         it { is_expected.to have_destination(:lateness_reason, :edit) }
       end
 
       context 'and the answer is `unsure`' do
-        let(:step) { { in_time: 'unsure' } }
+        let(:step_params) { { in_time: 'unsure' } }
 
         it { is_expected.to have_destination(:lateness_reason, :edit) }
       end
     end
 
     context 'when the step is `lateness_reason`' do
-      let(:step) { { lateness_reason: 'anything' } }
+      let(:step_params) { { lateness_reason: 'anything' } }
 
       it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is invalid' do
-      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.destination }.to raise_error(RuntimeError)
@@ -44,19 +44,19 @@ RSpec.describe LatenessDecisionTree do
 
   describe '#previous' do
     context 'when the step is `in_time`' do
-      let(:step) { { in_time: 'anything' } }
+      let(:step_params) { { in_time: 'anything' } }
 
       it { is_expected.to have_previous(:start, :show) }
     end
 
     context 'when the step is `lateness_reason`' do
-      let(:step) { { lateness_reason: 'anything' } }
+      let(:step_params) { { lateness_reason: 'anything' } }
 
       it { is_expected.to have_previous(:in_time, :edit) }
     end
 
     context 'when the step is invalid' do
-      let(:step) { { ungueltig: { waschmaschine: 'nein' } } }
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
 
       it 'raises an error' do
         expect { subject.previous }.to raise_error(RuntimeError)


### PR DESCRIPTION
This adds better names for the parameters and internals of the
`DecisionTree` class. It also moves the concept of using `as` to
"rename" a step into the decision tree to make it clearer what is
going on, and simplifies the `update_and_advance` signature.

- Rename `object` parameter to `decision_tree`
- Rename `step` parameter to `step_params`
- Rename `step` private method to `step_name`
- Move `as` to be a first-class citizen of the `DecisionTree` rather
  than just renaming the first key in the hash
- Remove superfluous `attr` parameter in
  `StepController#update_and_advance`