### PR TITLE
add dummy env vars to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 
 ENV PUMA_PORT 3000
 
+ENV MOJ_FILE_UPLOADER replace_this_at_build_time
+ENV GLIMR_API_URL replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN apt-get update && apt-get install -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 ENV PUMA_PORT 3000
 
 ENV MOJ_FILE_UPLOADER replace_this_at_build_time
-ENV GLIMR_API_URL replace_this_at_build_time
+ENV GLIMR_API_URL     replace_this_at_build_time
+ENV DATABASE_URL      replace_this_at_build_time
 
 RUN touch /etc/inittab
 


### PR DESCRIPTION
Without values for some env vars, it is not possible to build a
docker image for the application. Having dummy values means an
image can be built, with real values supplied at deployment time.