### PR TITLE
Add TAX_TRIBUNALS_DOWNLOADER_URL env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 
 ENV PUMA_PORT 3000
 
-ENV DATABASE_URL      replace_this_at_build_time
-ENV GLIMR_API_URL     replace_this_at_build_time
-ENV MOJ_FILE_UPLOADER replace_this_at_build_time
-ENV PAYMENT_ENDPOINT  replace_this_at_build_time
+ENV DATABASE_URL                 replace_this_at_build_time
+ENV GLIMR_API_URL                replace_this_at_build_time
+ENV MOJ_FILE_UPLOADER            replace_this_at_build_time
+ENV PAYMENT_ENDPOINT             replace_this_at_build_time
+ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 
 RUN touch /etc/inittab
 


### PR DESCRIPTION
The datacapture application needs to know the base URL of the
downloader application, from the GLiMR user's point of view, so
that it can build the documentsUrl value that the GLiMR user will
need, in order to download the case's documents