### PR TITLE
Update challenged_decision and dispute_type values

### DIFF
--- a/app/forms/steps/cost/challenged_decision_form.rb
+++ b/app/forms/steps/cost/challenged_decision_form.rb
@@ -1,17 +1,21 @@
 module Steps::Cost
   class ChallengedDecisionForm < BaseForm
-    attribute :challenged_decision, Boolean
+    attribute :challenged_decision, String
 
     def self.choices
-      [true, false]
+      ChallengedDecision.values.map(&:to_s)
     end
 
     validates_inclusion_of :challenged_decision, in: choices
 
     private
 
+    def challenged_decision_value
+      ChallengedDecision.new(challenged_decision)
+    end
+
     def changed?
-      tribunal_case.challenged_decision != challenged_decision
+      tribunal_case.challenged_decision != challenged_decision_value
     end
 
     def persist!
@@ -19,7 +23,7 @@ module Steps::Cost
       return unless changed?
 
       tribunal_case.update(
-        challenged_decision: challenged_decision,
+        challenged_decision: challenged_decision_value,
         # The following are dependent attributes that need to be reset
         case_type: nil,
         dispute_type: nil,

--- a/app/forms/steps/cost/dispute_type_form.rb
+++ b/app/forms/steps/cost/dispute_type_form.rb
@@ -6,16 +6,9 @@ module Steps::Cost
 
     def choices
       if include_paye_coding_notice?
-        [
-          DisputeType::LATE_RETURN_OR_PAYMENT,
-          DisputeType::AMOUNT_OF_TAX_OWED,
-          DisputeType::PAYE_CODING_NOTICE
-        ]
+        DisputeType.values
       else
-        [
-          DisputeType::LATE_RETURN_OR_PAYMENT,
-          DisputeType::AMOUNT_OF_TAX_OWED
-        ]
+        DisputeType.values - [DisputeType::PAYE_CODING_NOTICE]
       end.map(&:to_s)
     end
 

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,5 +1,6 @@
 class TribunalCase < ApplicationRecord
   # Cost task
+  has_value_object :challenged_decision
   has_value_object :case_type
   has_value_object :dispute_type
   has_value_object :penalty_amount

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -36,9 +36,9 @@ class CostDecisionTree < DecisionTree
   def after_case_type_step
     case answer
     when :income_tax
-      if tribunal_case.challenged_decision
+      if tribunal_case.challenged_decision == ChallengedDecision::YES
         edit(:dispute_type)
-      else
+      elsif tribunal_case.challenged_decision == ChallengedDecision::NO
         show(:must_challenge_hmrc)
       end
     when :vat
@@ -50,9 +50,9 @@ class CostDecisionTree < DecisionTree
 
   def after_dispute_type_step
     case answer
-    when :late_return_or_payment
+    when :penalty
       edit(:penalty_amount)
-    when :amount_of_tax_owed, :paye_coding_notice
+    when :amount_of_tax, :amount_and_penalty, :decision_on_enquiry, :paye_coding_notice, :other
       show(:determine_cost)
     end
   end

--- a/app/services/cost_determiner.rb
+++ b/app/services/cost_determiner.rb
@@ -9,10 +9,8 @@ class CostDeterminer
 
   def lodgement_fee
     case tribunal_case.case_type
-    when CaseType::INCOME_TAX
-      income_tax_lodgement_fee
-    when CaseType::VAT
-      vat_lodgement_fee
+    when CaseType::INCOME_TAX, CaseType::VAT
+      tax_lodgement_fee
     when CaseType::APN_PENALTY,
          CaseType::CLOSURE_NOTICE,
          CaseType::INFORMATION_NOTICE,
@@ -27,31 +25,24 @@ class CostDeterminer
 
   private
 
-  def vat_lodgement_fee
+  def tax_lodgement_fee
     case tribunal_case.dispute_type
-    when DisputeType::AMOUNT_OF_TAX_OWED
+    when DisputeType::AMOUNT_OF_TAX, DisputeType::AMOUNT_AND_PENALTY
       LodgementFee::FEE_LEVEL_3
-    when DisputeType::LATE_RETURN_OR_PAYMENT
-      penalty_amount_tribunal_case_cost
-    else
-      raise "Unable to determine cost of VAT tribunal_case"
-    end
-  end
-
-  def income_tax_lodgement_fee
-    case tribunal_case.dispute_type
+    when DisputeType::PENALTY
+      penalty_lodgement_fee
+    when DisputeType::DECISION_ON_ENQUIRY
+      LodgementFee::FEE_LEVEL_2
     when DisputeType::PAYE_CODING_NOTICE
       LodgementFee::FEE_LEVEL_2
-    when DisputeType::AMOUNT_OF_TAX_OWED
+    when DisputeType::OTHER
       LodgementFee::FEE_LEVEL_3
-    when DisputeType::LATE_RETURN_OR_PAYMENT
-      penalty_amount_tribunal_case_cost
     else
-      raise "Unable to determine cost of income tax tribunal_case"
+      raise "Unable to determine cost of tribunal_case"
     end
   end
 
-  def penalty_amount_tribunal_case_cost
+  def penalty_lodgement_fee
     case tribunal_case.penalty_amount
     when PenaltyAmount::PENALTY_LEVEL_1
       LodgementFee::FEE_LEVEL_1
@@ -60,7 +51,7 @@ class CostDeterminer
     when PenaltyAmount::PENALTY_LEVEL_3
       LodgementFee::FEE_LEVEL_3
     else
-      raise "Unable to determine cost of penalty tribunal_case"
+      raise "Unable to determine cost of tribunal_case"
     end
   end
 end

--- a/app/value_objects/challenged_decision.rb
+++ b/app/value_objects/challenged_decision.rb
@@ -1,0 +1,15 @@
+class ChallengedDecision < ValueObject
+  VALUES = [
+    YES                = new(:yes),
+    NO                 = new(:no),
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+
+  def initialize(raw_value)
+    raise ArgumentError.new('Challenged decision must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    super(raw_value.to_sym)
+  end
+end

--- a/app/value_objects/challenged_decision.rb
+++ b/app/value_objects/challenged_decision.rb
@@ -1,7 +1,7 @@
 class ChallengedDecision < ValueObject
   VALUES = [
-    YES                = new(:yes),
-    NO                 = new(:no),
+    YES = new(:yes),
+    NO  = new(:no),
   ].freeze
 
   def self.values

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -1,9 +1,16 @@
 class DisputeType < ValueObject
   VALUES = [
-    PAYE_CODING_NOTICE     = new(:paye_coding_notice),
-    LATE_RETURN_OR_PAYMENT = new(:late_return_or_payment),
-    AMOUNT_OF_TAX_OWED     = new(:amount_of_tax_owed)
+    PAYE_CODING_NOTICE  = new(:paye_coding_notice),
+    PENALTY             = new(:penalty),
+    AMOUNT_OF_TAX       = new(:amount_of_tax),
+    AMOUNT_AND_PENALTY  = new(:amount_and_penalty),
+    DECISION_ON_ENQUIRY = new(:decision_on_enquiry),
+    OTHER               = new(:other)
   ].freeze
+
+  def self.values
+    VALUES
+  end
 
   def initialize(raw_value)
     raise ArgumentError.new('Dispute type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)

--- a/app/views/steps/cost/challenged_decision/edit.html.erb
+++ b/app/views/steps/cost/challenged_decision/edit.html.erb
@@ -7,7 +7,7 @@
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :challenged_decision, inline: true, choices: Steps::Cost::ChallengedDecisionForm.choices %>
+      <%= f.radio_button_fieldset :challenged_decision, choices: Steps::Cost::ChallengedDecisionForm.choices %>
       <%= f.submit class: 'button' %>
     <% end %>
 

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -124,8 +124,8 @@ en:
             penalty_amount: What is the penalty or surcharge amount?
           answers:
             challenged_decision:
-              'true': 'Yes'
-              'false': 'No'
+              'yes': 'Yes'
+              'no': 'No'
             case_type:
               income_tax: Income Tax
               vat: Value Added Tax (VAT)
@@ -136,9 +136,12 @@ en:
               request_permission_for_review: Request permission for a review
               other_html: Other
             dispute_type:
-              late_return_or_payment: Late return or payment
-              amount_of_tax_owed: Amount of tax owed
               paye_coding_notice: Pay As You Earn (PAYE) coding notice
+              penalty: Penalty or surcharge
+              amount_of_tax: Amount of tax
+              amount_and_penalty: Amount of tax and a penalty or surcharge
+              decision_on_enquiry: Apply for a decision on an enquiry
+              other: Other
             penalty_amount:
               penalty_level_1: £100 or less
               penalty_level_2: £101 – £20,000
@@ -184,8 +187,8 @@ en:
     label:
       steps_cost_challenged_decision_form:
         challenged_decision:
-          'true': 'Yes'
-          'false': 'No'
+          'yes': 'Yes'
+          'no': 'No'
       steps_cost_case_type_form:
         case_type:
           income_tax_html: <strong>Income Tax</strong><br>for example, Pay As You Earn (PAYE), self-assessment
@@ -198,9 +201,12 @@ en:
           other_html: <strong>Other</strong>
       steps_cost_dispute_type_form:
         dispute_type:
-          late_return_or_payment_html: <strong>Late return or payment</strong><br>penalty or surcharge for late filing of returns and documents or late payment of duties
-          amount_of_tax_owed_html: <strong>Amount of tax owed</strong>
           paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
+          penalty_html: <strong>Penalty or surcharge</strong><br>for late filing of returns and documents, late payment of duties, inaccuracies, or non-compliance with information notices or Schedule 41
+          amount_of_tax_html: <strong>Amount of tax</strong><br>either tax you owe or money that HMRC should pay to you
+          amount_and_penalty_html: <strong>Amount of tax and a penalty or surcharge</strong><br>both of these disputes will be stated on either the original notice letter from HMRC or the review conclusion letter
+          decision_on_enquiry_html: <strong>Apply for a decision on an enquiry</strong><br>force HMRC to issue a counteraction notice
+          other_html: <strong>None of the above</strong>
       steps_cost_penalty_amount_form:
         penalty_amount:
           penalty_level_1: £100 or less

--- a/db/migrate/20161212140942_change_decision_challenged_to_value_object.rb
+++ b/db/migrate/20161212140942_change_decision_challenged_to_value_object.rb
@@ -1,0 +1,6 @@
+class ChangeDecisionChallengedToValueObject < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :tribunal_cases, :challenged_decision
+    add_column :tribunal_cases, :challenged_decision, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161205154426) do
+ActiveRecord::Schema.define(version: 20161212140942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.boolean  "challenged_decision"
     t.datetime "created_at",                                                                 null: false
     t.datetime "updated_at",                                                                 null: false
     t.string   "case_type"
@@ -43,6 +42,7 @@ ActiveRecord::Schema.define(version: 20161205154426) do
     t.boolean  "additional_documents_provided",        default: false
     t.text     "additional_documents_info"
     t.boolean  "having_problems_uploading_documents",  default: false
+    t.string   "challenged_decision"
   end
 
 end

--- a/spec/features/cost_decisions_spec.rb
+++ b/spec/features/cost_decisions_spec.rb
@@ -16,33 +16,34 @@ RSpec.feature 'Cost decisions', :type => :feature do
   scenario 'Challenged income tax appeal on the basis of amount of tax owed' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'Yes'
     answer_question 'What is your appeal about?', with: 'Income Tax'
-    answer_question 'What is your dispute about?', with: 'Amount of tax owed'
+    # Need to have full text because another option also starts with 'Amount of tax'
+    answer_question 'What is your dispute about?', with: 'Amount of taxeither tax you owe or money that HMRC should pay to you'
 
     expect_amount_on page, gbp: 200
   end
 
-  scenario 'Challenged income tax appeal on the basis of amount of late return/payment (< £101)' do
+  scenario 'Challenged income tax appeal on the basis of amount of penalty or surcharge (< £101)' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'Yes'
     answer_question 'What is your appeal about?', with: 'Income Tax'
-    answer_question 'What is your dispute about?', with: 'Late return or payment'
+    answer_question 'What is your dispute about?', with: 'Penalty or surcharge'
     answer_question 'What is the penalty or surcharge amount?', with: '£100 or less'
 
     expect_amount_on page, gbp: 20
   end
 
-  scenario 'Challenged income tax appeal on the basis of amount of late return/payment (£101 to £20,000)' do
+  scenario 'Challenged income tax appeal on the basis of amount of penalty or surcharge (£101 to £20,000)' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'Yes'
     answer_question 'What is your appeal about?', with: 'Income Tax'
-    answer_question 'What is your dispute about?', with: 'Late return or payment'
+    answer_question 'What is your dispute about?', with: 'Penalty or surcharge'
     answer_question 'What is the penalty or surcharge amount?', with: '£101 – £20,000'
 
     expect_amount_on page, gbp: 50
   end
 
-  scenario 'Challenged income tax appeal on the basis of amount of late return/payment (> £20,000)' do
+  scenario 'Challenged income tax appeal on the basis of amount of penalty or surcharge (> £20,000)' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'Yes'
     answer_question 'What is your appeal about?', with: 'Income Tax'
-    answer_question 'What is your dispute about?', with: 'Late return or payment'
+    answer_question 'What is your dispute about?', with: 'Penalty or surcharge'
     answer_question 'What is the penalty or surcharge amount?', with: '£20,001 or more'
 
     expect_amount_on page, gbp: 200
@@ -51,15 +52,16 @@ RSpec.feature 'Cost decisions', :type => :feature do
   scenario 'unchallenged VAT appeal on the basis of amount of tax owed' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
     answer_question 'What is your appeal about?', with: 'Value Added Tax (VAT)'
-    answer_question 'What is your dispute about?', with: 'Amount of tax owed'
+    # Need to have full text because another option also starts with 'Amount of tax'
+    answer_question 'What is your dispute about?', with: 'Amount of taxeither tax you owe or money that HMRC should pay to you'
 
     expect_amount_on page, gbp: 200
   end
 
-  scenario 'unchallenged VAT appeal on the basis of late return/payment' do
+  scenario 'unchallenged VAT appeal on the basis of penalty or surcharge' do
     answer_question 'Did you challenge the decision with HMRC first?', with: 'No'
     answer_question 'What is your appeal about?', with: 'Value Added Tax (VAT)'
-    answer_question 'What is your dispute about?', with: 'Late return or payment'
+    answer_question 'What is your dispute about?', with: 'Penalty or surcharge'
     answer_question 'What is the penalty or surcharge amount?', with: '£100 or less'
 
     expect_amount_on page, gbp: 20

--- a/spec/forms/steps/cost/case_type_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_form_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Steps::Cost::CaseTypeForm do
   let(:arguments) { {
-    tribunal_case:        tribunal_case,
-    case_type: case_type
+    tribunal_case: tribunal_case,
+    case_type:     case_type
   } }
   let(:tribunal_case)        { instance_double(TribunalCase, case_type: nil) }
   let(:case_type) { nil }
@@ -12,8 +12,8 @@ RSpec.describe Steps::Cost::CaseTypeForm do
 
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)        { nil }
-      let(:case_type) { 'vat' }
+      let(:tribunal_case) { nil }
+      let(:case_type)     { 'vat' }
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(RuntimeError)

--- a/spec/forms/steps/cost/challenged_decision_form_spec.rb
+++ b/spec/forms/steps/cost/challenged_decision_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Steps::Cost::ChallengedDecisionForm do
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
       let(:tribunal_case) { nil }
-      let(:challenged_decision) { true }
+      let(:challenged_decision) { 'yes' }
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(RuntimeError)
@@ -45,11 +45,11 @@ RSpec.describe Steps::Cost::ChallengedDecisionForm do
     end
 
     context 'when challenged_decision is valid' do
-      let(:challenged_decision) { true }
+      let(:challenged_decision) { 'no' }
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          challenged_decision: true,
+          challenged_decision: ChallengedDecision::NO,
           case_type: nil,
           dispute_type: nil,
           penalty_amount: nil
@@ -59,8 +59,8 @@ RSpec.describe Steps::Cost::ChallengedDecisionForm do
     end
 
     context 'when challenged_decision is already the same on the model' do
-      let(:tribunal_case)      { instance_double(TribunalCase, challenged_decision: true) }
-      let(:challenged_decision) { true }
+      let(:tribunal_case)      { instance_double(TribunalCase, challenged_decision: ChallengedDecision::YES) }
+      let(:challenged_decision) { 'yes' }
 
       it 'does not save the record but returns true' do
         expect(tribunal_case).to_not receive(:update)

--- a/spec/forms/steps/cost/dispute_type_form_spec.rb
+++ b/spec/forms/steps/cost/dispute_type_form_spec.rb
@@ -22,11 +22,7 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
       let(:case_type) { CaseType::INCOME_TAX }
 
       it 'includes PAYE coding notice' do
-        expect(subject.choices).to eq(%w(
-          late_return_or_payment
-          amount_of_tax_owed
-          paye_coding_notice
-        ))
+        expect(subject.choices).to include('paye_coding_notice')
       end
     end
 
@@ -34,18 +30,15 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
       let(:case_type) { CaseType::VAT }
 
       it 'does not include PAYE coding notice' do
-        expect(subject.choices).to eq(%w(
-          late_return_or_payment
-          amount_of_tax_owed
-        ))
+        expect(subject.choices).to_not include('paye_coding_notice')
       end
     end
   end
 
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)         { nil }
-      let(:dispute_type) { 'amount_of_tax_owed' }
+      let(:tribunal_case) { nil }
+      let(:dispute_type)  { 'penalty' }
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(RuntimeError)
@@ -77,11 +70,11 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
     end
 
     context 'when dispute_type is valid' do
-      let(:dispute_type) { 'amount_of_tax_owed' }
+      let(:dispute_type) { 'penalty' }
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          dispute_type: DisputeType::AMOUNT_OF_TAX_OWED,
+          dispute_type: DisputeType::PENALTY,
           penalty_amount: nil
         )
         expect(subject.save).to be(true)

--- a/spec/services/cost_decision_tree_spec.rb
+++ b/spec/services/cost_decision_tree_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe CostDecisionTree do
         let(:step_params) { { case_type: 'income_tax' } }
 
         context 'and the case is challenged' do
-          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: true) }
+          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: ChallengedDecision::YES) }
 
           it { is_expected.to have_destination(:dispute_type, :edit) }
         end
 
         context 'and the case is unchallenged' do
-          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: false) }
+          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: ChallengedDecision::NO) }
 
           it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
         end
@@ -53,22 +53,40 @@ RSpec.describe CostDecisionTree do
     end
 
     context 'when the step is `dispute_type`' do
-      context 'and the answer is `amount_of_tax_owed`' do
-        let(:step_params) { { dispute_type: 'amount_of_tax_owed' } }
-
-        it { is_expected.to have_destination(:determine_cost, :show) }
-      end
-
       context 'and the answer is `paye_coding_notice`' do
         let(:step_params) { { dispute_type: 'paye_coding_notice' } }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the answer is `late_return_or_payment`' do
-        let(:step_params) { { dispute_type: 'late_return_or_payment' } }
+      context 'and the answer is `penalty`' do
+        let(:step_params) { { dispute_type: 'penalty' } }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
+      end
+
+      context 'and the answer is `amount_of_tax`' do
+        let(:step_params) { { dispute_type: 'amount_of_tax' } }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the answer is `amount_and_penalty`' do
+        let(:step_params) { { dispute_type: 'amount_and_penalty' } }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the answer is `decision_on_enquiry`' do
+        let(:step_params) { { dispute_type: 'decision_on_enquiry' } }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the answer is `other`' do
+        let(:step_params) { { dispute_type: 'other' } }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
       end
     end
 

--- a/spec/services/cost_determiner_spec.rb
+++ b/spec/services/cost_determiner_spec.rb
@@ -1,176 +1,140 @@
 require 'spec_helper'
 
+shared_examples "any tax" do
+  context "when dispute is about an unhandled value" do
+    let(:dispute_type) { DisputeType.new('$^&%*') }
+
+    it { is_expected.to fail_to_determine_lodgement_fee }
+  end
+
+  context "when dispute is about a penalty or surcharge" do
+    let(:dispute_type) { DisputeType::PENALTY }
+
+    context "and the penalty is level 1" do
+      let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_1 }
+
+      it { is_expected.to have_lodgement_fee(:fee_level_1) }
+    end
+
+    context "and the penalty is level 2" do
+      let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_2 }
+
+      it { is_expected.to have_lodgement_fee(:fee_level_2) }
+    end
+
+    context "and the penalty is level 3" do
+      let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_3 }
+
+      it { is_expected.to have_lodgement_fee(:fee_level_3) }
+    end
+
+    context "when penalty amount is an unhandled value" do
+      let(:penalty_amount) { PenaltyAmount.new('$^&%*') }
+
+      it { is_expected.to fail_to_determine_lodgement_fee }
+    end
+  end
+
+  context "when dispute is about amount of tax" do
+    let(:dispute_type) { DisputeType::AMOUNT_OF_TAX }
+
+    it { is_expected.to have_lodgement_fee(:fee_level_3) }
+  end
+
+  context "when dispute is about amount of tax and a penalty or surcharge" do
+    let(:dispute_type) { DisputeType::AMOUNT_AND_PENALTY }
+
+    it { is_expected.to have_lodgement_fee(:fee_level_3) }
+  end
+
+  context "when dispute is about applying for a decision on an inquiry" do
+    let(:dispute_type) { DisputeType::DECISION_ON_ENQUIRY }
+
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
+  end
+
+  context "when dispute is about something else" do
+    let(:dispute_type) { DisputeType::OTHER }
+
+    it { is_expected.to have_lodgement_fee(:fee_level_3) }
+  end
+end
+
 RSpec.describe CostDeterminer do
   let(:case_attrs)    { {} }
-  let(:tribunal_case) { instance_double(TribunalCase, case_attrs) }
+  let(:tribunal_case) {
+    instance_double(TribunalCase,
+      challenged_decision: challenged_decision,
+      case_type:           case_type,
+      dispute_type:        dispute_type,
+      penalty_amount:      penalty_amount
+    )
+  }
+
+  let(:challenged_decision) { nil }
+  let(:case_type)           { nil }
+  let(:dispute_type)        { nil }
+  let(:penalty_amount)      { nil }
 
   subject { described_class.new(tribunal_case) }
 
   context "when tribunal_case#case_type is nil" do
-    let(:case_attrs) { super().merge(case_type: nil) }
+    let(:case_type) { nil }
 
-    specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of tribunal_case") }
+    it { is_expected.to fail_to_determine_lodgement_fee }
   end
 
   context "when tribunal_case is about an unhandled value" do
-    let(:case_attrs) { super().merge(case_type: CaseType.new('^&@*$@')) }
+    let(:case_type) { CaseType.new('^&@*$@') }
 
-    specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of tribunal_case") }
+    it { is_expected.to fail_to_determine_lodgement_fee }
   end
 
-  context "when hmrc challenged is true" do
-    let(:case_attrs) { super().merge(challenged_decision: true) }
+  context "when tribunal_case is about income tax" do
+    let(:case_type) { CaseType::INCOME_TAX }
 
-    context "when tribunal_case is about VAT" do
-      let(:case_attrs) { super().merge(case_type: CaseType::VAT) }
+    it_behaves_like "any tax"
 
-      context "when dispute is about an unhandled value" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType.new('$^&%*')) }
+    context "when dispute is about PAYE coding notice" do
+      let(:dispute_type) { DisputeType::PAYE_CODING_NOTICE }
 
-        specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of VAT tribunal_case") }
-      end
-
-      context "when dispute is about late return/payment" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType::LATE_RETURN_OR_PAYMENT) }
-
-        context "when dispute is about an unhandled fee level" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount.new('ALL THE MONEYS')) }
-
-          specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of penalty tribunal_case") }
-        end
-
-        context "when the penalty/surcharge amounts is £100" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_1) }
-
-          it "has £20 lodgement fee" do
-            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_1)
-          end
-        end
-
-        context "when the penalty/surcharge amounts is £200" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_2) }
-
-          it "has £50 lodgement fee" do
-            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-          end
-        end
-
-        context "when the penalty/surcharge amounts is £20001" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_3) }
-
-          it "has £200 lodgement fee" do
-            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
-          end
-        end
-      end
-
-      context "when dispute is about amount of tax owed" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType::AMOUNT_OF_TAX_OWED) }
-
-        it "has £200 lodgement fee" do
-          expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
-        end
-      end
+      it { is_expected.to have_lodgement_fee(:fee_level_2) }
     end
+  end
 
-    context "when tribunal_case is about advance payment notice penalty" do
-      let(:case_attrs) { super().merge(case_type: CaseType::APN_PENALTY) }
+  context "when tribunal_case is about VAT" do
+    let(:case_type) { CaseType::VAT }
 
-      it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-      end
-    end
+    it_behaves_like "any tax"
+  end
 
-    context "when tribunal_case is about a closure notice" do
-      let(:case_attrs) { super().merge(case_type: CaseType::CLOSURE_NOTICE) }
+  context "when tribunal_case is about advance payment notice penalty" do
+    let(:case_type) { CaseType::APN_PENALTY }
 
-      it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-      end
-    end
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
+  end
 
-    context "when tribunal_case is about an information notice" do
-      let(:case_attrs) { super().merge(case_type: CaseType::INFORMATION_NOTICE) }
+  context "when tribunal_case is about a closure notice" do
+    let(:case_type) { CaseType::CLOSURE_NOTICE }
 
-      it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-      end
-    end
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
+  end
 
-    context "when tribunal_case is about request for review" do
-      let(:case_attrs) { super().merge(case_type: CaseType::REQUEST_PERMISSION_FOR_REVIEW) }
+  context "when tribunal_case is about an information notice" do
+    let(:case_type) { CaseType::INFORMATION_NOTICE }
 
-      it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-      end
-    end
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
+  end
 
-    context "when tribunal_case is about something else" do
-      let(:case_attrs) { super().merge(case_type: CaseType::OTHER) }
+  context "when tribunal_case is about request for review" do
+    let(:case_type) { CaseType::REQUEST_PERMISSION_FOR_REVIEW }
 
-      it "has £50 lodgement fee" do
-        expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-      end
-    end
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
+  end
 
-    context "when tribunal_case is about income tax" do
-      let(:case_attrs) { super().merge(case_type: CaseType::INCOME_TAX) }
+  context "when tribunal_case is about something else" do
+    let(:case_type) { CaseType::OTHER }
 
-      context "when dispute is about an unhandled value" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType.new('%$^&*@')) }
-
-        specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of income tax tribunal_case") }
-      end
-
-      context "when dispute is about amount of tax owed" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType::AMOUNT_OF_TAX_OWED) }
-
-        it "has £200 lodgement fee" do
-          expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
-        end
-      end
-
-      context "when dispute is about paye coding" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType::PAYE_CODING_NOTICE) }
-
-        it "has £50 lodgement fee" do
-          expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-        end
-      end
-
-      context "when dispute is about late return/payment" do
-        let(:case_attrs) { super().merge(dispute_type: DisputeType::LATE_RETURN_OR_PAYMENT) }
-
-        context "when dispute is about an unhandled fee level" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount.new('ALL THE MONEYS')) }
-
-          specify { expect{ subject.lodgement_fee }.to raise_error("Unable to determine cost of penalty tribunal_case") }
-        end
-
-        context "when the penalty/surcharge amounts is £100" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_1) }
-
-          it "has £20 lodgement fee" do
-            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_1)
-          end
-        end
-
-        context "when the penalty/surcharge amounts is £200" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_2) }
-
-          it "has £50 lodgement fee" do
-            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_2)
-          end
-        end
-
-        context "when the penalty/surcharge amounts is £20001" do
-          let(:case_attrs) { super().merge(penalty_amount: PenaltyAmount::PENALTY_LEVEL_3) }
-
-          it "has £200 lodgement fee" do
-            expect(subject.lodgement_fee).to eq(LodgementFee::FEE_LEVEL_3)
-          end
-        end
-      end
-    end
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
   end
 end

--- a/spec/support/cost_determiner_matcher.rb
+++ b/spec/support/cost_determiner_matcher.rb
@@ -1,0 +1,26 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_lodgement_fee do |fee_level|
+  match do |cost_determiner|
+    cost_determiner.lodgement_fee == LodgementFee.new(fee_level)
+  end
+
+  failure_message do |cost_determiner|
+    "expected cost determiner to have a lodgement fee of #{fee_level}, got #{cost_determiner.lodgement_fee}"
+  end
+end
+
+RSpec::Matchers.define :fail_to_determine_lodgement_fee do
+  match do |cost_determiner|
+    begin
+      cost_determiner.lodgement_fee
+      false
+    rescue
+      true
+    end
+  end
+
+  failure_message do |cost_determiner|
+    "expected cost determiner to raise an error when determining lodgement fee, but got '#{cost_determiner.lodgement_fee}'."
+  end
+end


### PR DESCRIPTION
- Update `challenged_decision` to be a value object instead of a boolean
  in order to prepare for the "My case is not with HMRC" option
- Update the possible values for `dispute_type` to match the state of
  the prototype decision tree
- Clean up `CostDeterminer` specs