### PR TITLE
Make CaseType a richer value object

### DIFF
--- a/app/forms/steps/cost/case_type_form.rb
+++ b/app/forms/steps/cost/case_type_form.rb
@@ -22,7 +22,7 @@ module Steps::Cost
     end
 
     def case_type_value
-      CaseType.new(case_type)
+      CaseType.find_constant(case_type)
     end
 
     def changed?

--- a/app/forms/steps/cost/case_type_show_more_form.rb
+++ b/app/forms/steps/cost/case_type_show_more_form.rb
@@ -12,7 +12,7 @@ module Steps::Cost
     private
 
     def case_type_value
-      CaseType.new(case_type)
+      CaseType.find_constant(case_type)
     end
 
     def changed?

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,9 +1,10 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  def self.has_value_object(value_object)
+  def self.has_value_object(value_object, constructor: nil)
     composed_of value_object,
-      allow_nil:  true,
-      mapping:    [[value_object.to_s, 'value']]
+      allow_nil:   true,
+      mapping:     [[value_object.to_s, 'value']],
+      constructor: constructor
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,7 +1,7 @@
 class TribunalCase < ApplicationRecord
   # Cost task
   has_value_object :challenged_decision
-  has_value_object :case_type
+  has_value_object :case_type, constructor: :find_constant
   has_value_object :dispute_type
   has_value_object :penalty_amount
   has_value_object :lodgement_fee

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -36,29 +36,23 @@ class CostDecisionTree < DecisionTree
   private
 
   def after_case_type_step
-    case answer
-    when :income_tax
-      if tribunal_case.challenged_decision == ChallengedDecision::YES
-        edit(:dispute_type)
-      elsif tribunal_case.challenged_decision == ChallengedDecision::NO
-        show(:must_challenge_hmrc)
-      end
-    when :air_passenger_duty, :bingo_duty, :vat
-      edit(:dispute_type)
-    when :inaccurate_return_penalty
-      edit(:penalty_amount)
-    when :other
-      show(:determine_cost)
-    when Steps::Cost::CaseTypeForm::SHOW_MORE
+    if answer == Steps::Cost::CaseTypeForm::SHOW_MORE
       edit(:case_type_show_more)
+    elsif tribunal_case.case_type.direct_tax? && tribunal_case.challenged_decision == ChallengedDecision::NO
+      show(:must_challenge_hmrc)
+    elsif tribunal_case.case_type.ask_dispute_type?
+      edit(:dispute_type)
+    elsif tribunal_case.case_type.ask_penalty?
+      edit(:penalty_amount)
+    else
+      show(:determine_cost)
     end
   end
 
   def after_dispute_type_step
-    case answer
-    when :penalty
+    if tribunal_case.dispute_type == DisputeType::PENALTY
       edit(:penalty_amount)
-    when :amount_of_tax, :amount_and_penalty, :decision_on_enquiry, :paye_coding_notice, :other
+    else
       show(:determine_cost)
     end
   end

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -35,10 +35,15 @@ class CostDecisionTree < DecisionTree
 
   private
 
+  def tribunal_case_is_unchallenged_direct_tax
+    tribunal_case.case_type.direct_tax? &&
+      tribunal_case.challenged_decision == ChallengedDecision::NO
+  end
+
   def after_case_type_step
     if answer == Steps::Cost::CaseTypeForm::SHOW_MORE
       edit(:case_type_show_more)
-    elsif tribunal_case.case_type.direct_tax? && tribunal_case.challenged_decision == ChallengedDecision::NO
+    elsif tribunal_case_is_unchallenged_direct_tax
       show(:must_challenge_hmrc)
     elsif tribunal_case.case_type.ask_dispute_type?
       edit(:dispute_type)

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -1,17 +1,29 @@
 class CaseType < ValueObject
-  VALUES = [
-    AIR_PASSENGER_DUTY         = new(:air_passenger_duty),
-    BINGO_DUTY                 = new(:bingo_duty),
-    INACCURATE_RETURN_PENALTY  = new(:inaccurate_return_penalty),
-    INCOME_TAX                 = new(:income_tax),
-    VAT                        = new(:vat),
-    OTHER                      = new(:other)
-  ].freeze
+  attr_reader :direct_tax, :ask_dispute_type, :ask_penalty, :ask_hardship
+  alias_method :direct_tax?, :direct_tax
+  alias_method :ask_dispute_type?, :ask_dispute_type
+  alias_method :ask_penalty?, :ask_penalty
+  alias_method :ask_hardship?, :ask_hardship
 
-  def initialize(raw_value)
+  def self.find_constant(raw_value)
+    const_get(raw_value.upcase)
+  end
+
+  def initialize(raw_value, direct_tax: false, ask_dispute_type: false, ask_penalty: false, ask_hardship: false)
     raise ArgumentError.new('Case type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    @direct_tax, @ask_dispute_type, @ask_penalty, @ask_hardship = direct_tax, ask_dispute_type, ask_penalty, ask_hardship
+
     super(raw_value.to_sym)
   end
+
+  VALUES = [
+    AIR_PASSENGER_DUTY         = new(:air_passenger_duty,        direct_tax: false, ask_dispute_type: true,  ask_penalty: true,  ask_hardship: true),
+    BINGO_DUTY                 = new(:bingo_duty,                direct_tax: false, ask_dispute_type: true,  ask_penalty: true,  ask_hardship: true),
+    INACCURATE_RETURN_PENALTY  = new(:inaccurate_return_penalty, direct_tax: false, ask_dispute_type: false, ask_penalty: true,  ask_hardship: false),
+    INCOME_TAX                 = new(:income_tax,                direct_tax: true,  ask_dispute_type: true,  ask_penalty: true,  ask_hardship: false),
+    VAT                        = new(:vat,                       direct_tax: false, ask_dispute_type: true,  ask_penalty: true,  ask_hardship: true),
+    OTHER                      = new(:other,                     direct_tax: false, ask_dispute_type: false, ask_penalty: false, ask_hardship: true)
+  ].freeze
 
   def self.values
     VALUES

--- a/spec/forms/steps/cost/case_type_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_form_spec.rb
@@ -46,10 +46,12 @@ RSpec.describe Steps::Cost::CaseTypeForm do
 
     context 'when case_type is valid' do
       let(:case_type) { 'income_tax' }
+      let(:case_type_object) { instance_double(CaseType) }
 
       it 'saves the record' do
+        allow(CaseType).to receive(:find_constant).with('income_tax').and_return(case_type_object)
         expect(tribunal_case).to receive(:update).with(
-          case_type: an_instance_of(CaseType),
+          case_type: case_type_object,
           dispute_type: nil,
           penalty_amount: nil
         )

--- a/spec/forms/steps/cost/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_show_more_form_spec.rb
@@ -52,11 +52,13 @@ RSpec.describe Steps::Cost::CaseTypeShowMoreForm do
     end
 
     context 'when case_type is valid' do
-      let(:case_type) { 'air_passenger_duty' }
+      let(:case_type) { 'bingo_duty' }
+      let(:case_type_object) { instance_double(CaseType) }
 
       it 'saves the record' do
+        allow(CaseType).to receive(:find_constant).with('bingo_duty').and_return(case_type_object)
         expect(tribunal_case).to receive(:update).with(
-          case_type: an_instance_of(CaseType),
+          case_type: case_type_object,
           dispute_type: nil,
           penalty_amount: nil
         )

--- a/spec/services/cost_decision_tree_spec.rb
+++ b/spec/services/cost_decision_tree_spec.rb
@@ -14,92 +14,88 @@ RSpec.describe CostDecisionTree do
     end
 
     context 'when the step is `case_type`' do
-      context 'and the answer is `air_passenger_duty`' do
-        let(:step_params) { { case_type: 'air_passenger_duty' } }
+      let(:step_params)         { { case_type: 'anything' } }
+      let(:tribunal_case)       { instance_double(TribunalCase, case_type: case_type, challenged_decision: challenged_decision) }
+      let(:challenged_decision) { nil }
 
-        it { is_expected.to have_destination(:dispute_type, :edit) }
-      end
+      context 'and the case type is a direct tax' do
+        let(:case_type) { CaseType.new(:dummy, direct_tax: true, ask_dispute_type: true) }
 
-      context 'and the answer is `bingo_duty`' do
-        let(:step_params) { { case_type: 'bingo_duty' } }
-
-        it { is_expected.to have_destination(:dispute_type, :edit) }
-      end
-
-      context 'and the answer is `vat`' do
-        let(:step_params) { { case_type: 'vat' } }
-
-        it { is_expected.to have_destination(:dispute_type, :edit) }
-      end
-
-      context 'and the answer is `income_tax`' do
-        let(:step_params) { { case_type: 'income_tax' } }
-
-        context 'and the case is challenged' do
-          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: ChallengedDecision::YES) }
+        context 'and the case has been challenged' do
+          let(:challenged_decision) { ChallengedDecision::YES }
 
           it { is_expected.to have_destination(:dispute_type, :edit) }
         end
 
-        context 'and the case is unchallenged' do
-          let(:tribunal_case) { instance_double(TribunalCase, challenged_decision: ChallengedDecision::NO) }
+        context 'and the case has not been challenged' do
+          let(:challenged_decision) { ChallengedDecision::NO }
 
           it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
         end
       end
 
-      context 'and the answer is `inaccurate_return_penalty`' do
-        let(:step_params) { { case_type: 'inaccurate_return_penalty' } }
+      context 'and the case type is one that should ask dispute type' do
+        let(:case_type) { CaseType.new(:dummy, ask_dispute_type: true) }
+
+        it { is_expected.to have_destination(:dispute_type, :edit) }
+      end
+
+      context 'and the case type is one that should only ask penalty' do
+        let(:case_type) { CaseType.new(:dummy, ask_dispute_type: false, ask_penalty: true) }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
 
-      context 'and the answer is `other`' do
-        let(:step_params) { { case_type: 'other' } }
+      context 'and the case type is one that should ask neither dispute type nor penalty' do
+        let(:case_type) { CaseType.new(:dummy, ask_dispute_type: false, ask_penalty: false) }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
       context 'and the answer is show more' do
         let(:step_params) { { case_type: '_show_more' } }
+        let(:case_type)   { nil }
 
         it { is_expected.to have_destination(:case_type_show_more, :edit) }
       end
     end
 
     context 'when the step is `dispute_type`' do
-      context 'and the answer is `paye_coding_notice`' do
-        let(:step_params) { { dispute_type: 'paye_coding_notice' } }
+      let(:step_params)   { { dispute_type: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, dispute_type: dispute_type) }
+
+      context 'and the dispute type is PAYE coding notice' do
+        let(:dispute_type) { DisputeType::PAYE_CODING_NOTICE }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the answer is `penalty`' do
-        let(:step_params) { { dispute_type: 'penalty' } }
+      context 'and the dispute type is penalty or surcharge' do
+        let(:dispute_type) { DisputeType::PENALTY }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
 
-      context 'and the answer is `amount_of_tax`' do
-        let(:step_params) { { dispute_type: 'amount_of_tax' } }
+      context 'and the dispute type is amount of tax' do
+        let(:dispute_type) { DisputeType::AMOUNT_OF_TAX }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the answer is `amount_and_penalty`' do
-        let(:step_params) { { dispute_type: 'amount_and_penalty' } }
+      context 'and the dispute type is amount of tax and penalty' do
+        let(:dispute_type) { DisputeType::AMOUNT_AND_PENALTY }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the answer is `decision_on_enquiry`' do
-        let(:step_params) { { dispute_type: 'decision_on_enquiry' } }
+      context 'and the dispute type is ask for a decision on an enquiry' do
+        let(:dispute_type) { DisputeType::DECISION_ON_ENQUIRY }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the answer is `other`' do
-        let(:step_params) { { dispute_type: 'other' } }
+      context 'and the dispute type is other' do
+        let(:dispute_type) { DisputeType::OTHER }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end


### PR DESCRIPTION
- Add additional properties to the `CaseType` value object to represent
  whether or not:
  - it is a direct tax
  - we need to ask what the dispute type is
  - we need to ask what the penalty amount is
  - we need to ask about hardship
- Refactor the `CostDecisionTree` to check for these properties instead
  of checking for inclusion in a list of hardcoded case type strings
- Update the `CaseType` constants to have these properties set
- Ensure that wherever we convert form data or a database value into a
  `CaseType` object, we fetch the relevant constant instead of creating
  a new value object