### PR TITLE
Add "Information Notice" as case and dispute type

### DIFF
--- a/app/forms/steps/cost/case_type_form.rb
+++ b/app/forms/steps/cost/case_type_form.rb
@@ -11,6 +11,7 @@ module Steps::Cost
         CaseType::CAPITAL_GAINS_TAX,
         CaseType::CORPORATION_TAX,
         CaseType::INACCURATE_RETURN_PENALTY,
+        CaseType::INFORMATION_NOTICE,
         SHOW_MORE
       ].map(&:to_s)
     end

--- a/app/forms/steps/cost/dispute_type_form.rb
+++ b/app/forms/steps/cost/dispute_type_form.rb
@@ -5,7 +5,13 @@ module Steps::Cost
     validates_inclusion_of :dispute_type, in: proc { |record| record.choices }
 
     def choices
-      if include_paye_coding_notice?
+      case tribunal_case&.case_type
+      when CaseType::INFORMATION_NOTICE
+        [
+          DisputeType::PENALTY,
+          DisputeType::INFORMATION_NOTICE
+        ]
+      when CaseType::INCOME_TAX
         DisputeType.values
       else
         DisputeType.values - [DisputeType::PAYE_CODING_NOTICE]
@@ -16,10 +22,6 @@ module Steps::Cost
 
     def dispute_type_value
       DisputeType.new(dispute_type)
-    end
-
-    def include_paye_coding_notice?
-      tribunal_case&.case_type == CaseType::INCOME_TAX
     end
 
     def changed?

--- a/app/services/cost_determiner.rb
+++ b/app/services/cost_determiner.rb
@@ -37,7 +37,7 @@ class CostDeterminer
 
   def dispute_type_lodgement_fee
     case tribunal_case.dispute_type
-    when DisputeType::DECISION_ON_ENQUIRY, DisputeType::PAYE_CODING_NOTICE
+    when DisputeType::DECISION_ON_ENQUIRY, DisputeType::PAYE_CODING_NOTICE, DisputeType::INFORMATION_NOTICE
       LodgementFee::FEE_LEVEL_2
     else
       LodgementFee::FEE_LEVEL_3

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -40,6 +40,7 @@ class CaseType < ValueObject
     HYDROCARBON_OIL_DUTIES       = new(:hydrocarbon_oil_duties,       indirect_tax_properties),
     INACCURATE_RETURN_PENALTY    = new(:inaccurate_return_penalty,    direct_tax: false, ask_dispute_type: false, ask_penalty: true,  ask_hardship: false),
     INCOME_TAX                   = new(:income_tax,                   direct_tax_properties),
+    INFORMATION_NOTICE           = new(:information_notice,           direct_tax: false, ask_dispute_type: true,  ask_penalty: true,  ask_hardship: false),
     INHERITANCE_TAX              = new(:inheritance_tax,              direct_tax_properties),
     INSURANCE_PREMIUM_TAX        = new(:insurance_premium_tax,        indirect_tax_properties),
     LANDFILL_TAX                 = new(:landfill_tax,                 indirect_tax_properties),

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -1,9 +1,10 @@
 class DisputeType < ValueObject
   VALUES = [
-    PAYE_CODING_NOTICE  = new(:paye_coding_notice),
     PENALTY             = new(:penalty),
     AMOUNT_OF_TAX       = new(:amount_of_tax),
     AMOUNT_AND_PENALTY  = new(:amount_and_penalty),
+    PAYE_CODING_NOTICE  = new(:paye_coding_notice),
+    INFORMATION_NOTICE  = new(:information_notice),
     DECISION_ON_ENQUIRY = new(:decision_on_enquiry),
     OTHER               = new(:other)
   ].freeze

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -146,6 +146,7 @@ en:
               income_tax: Income Tax
               inheritance_tax: Inheritance Tax
               insurance_premium_tax: Insurance Premium Tax
+              information_notice: Information notices
               landfill_tax: Landfill Tax
               lottery_duty: Lottery Duty
               ni_contributions: National Insurance (NI) contributions
@@ -163,6 +164,7 @@ en:
               penalty: Penalty or surcharge
               amount_of_tax: Amount of tax
               amount_and_penalty: Amount of tax and a penalty or surcharge
+              information_notice: Appeal against an information notice
               decision_on_enquiry: Apply for a decision on an enquiry
               other: Other
             penalty_amount:
@@ -225,6 +227,7 @@ en:
           capital_gains_tax_html: <strong>Capital Gains Tax</strong>
           corporation_tax_html: <strong>Corporation Tax</strong>
           inaccurate_return_penalty_html: <strong>Inaccurate return penalty</strong>
+          information_notice_html: <strong>Information notices</strong><br>including penalties for non-compliance with information notices
           _show_more_html: <strong>Other type of tax, appeal or application</strong>
       steps_cost_case_type_show_more_form:
         case_type:
@@ -258,6 +261,7 @@ en:
           penalty_html: <strong>Penalty or surcharge</strong><br>for late filing of returns and documents, late payment of duties, inaccuracies, or non-compliance with information notices or Schedule 41
           amount_of_tax_html: <strong>Amount of tax</strong><br>either tax you owe or money that HMRC should pay to you
           amount_and_penalty_html: <strong>Amount of tax and a penalty or surcharge</strong><br>both of these disputes will be stated on either the original notice letter from HMRC or the review conclusion letter
+          information_notice_html: <strong>Appeal against an information notice</strong>
           decision_on_enquiry_html: <strong>Apply for a decision on an enquiry</strong><br>force HMRC to issue a counteraction notice
           other_html: <strong>None of the above</strong>
       steps_cost_penalty_amount_form:

--- a/spec/forms/steps/cost/dispute_type_form_spec.rb
+++ b/spec/forms/steps/cost/dispute_type_form_spec.rb
@@ -21,16 +21,42 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
     context 'when the appeal is about income tax' do
       let(:case_type) { CaseType::INCOME_TAX }
 
-      it 'includes PAYE coding notice' do
-        expect(subject.choices).to include('paye_coding_notice')
+      it 'shows all choices (including PAYE coding notice)' do
+        expect(subject.choices).to eq(%w(
+          penalty
+          amount_of_tax
+          amount_and_penalty
+          paye_coding_notice
+          information_notice
+          decision_on_enquiry
+          other
+        ))
       end
     end
 
-    context 'when the appeal is not about income tax' do
-      let(:case_type) { CaseType::VAT }
+    context 'when the appeal is about an information notice' do
+      let(:case_type) { CaseType::INFORMATION_NOTICE }
 
-      it 'does not include PAYE coding notice' do
-        expect(subject.choices).to_not include('paye_coding_notice')
+      it 'shows only the relevant choices' do
+        expect(subject.choices).to eq(%w(
+          penalty
+          information_notice
+        ))
+      end
+    end
+
+    context 'when the appeal is about anything else' do
+      let(:case_type) { CaseType.new(:anything) }
+
+      it 'shows all relevant choices (excluding PAYE coding notice)' do
+        expect(subject.choices).to eq(%w(
+          penalty
+          amount_of_tax
+          amount_and_penalty
+          information_notice
+          decision_on_enquiry
+          other
+        ))
       end
     end
   end

--- a/spec/services/cost_determiner_spec.rb
+++ b/spec/services/cost_determiner_spec.rb
@@ -52,14 +52,20 @@ RSpec.describe CostDeterminer do
     it { is_expected.to fail_to_determine_lodgement_fee }
   end
 
-  context "when the case is an appeal against a PAYE coding notice" do
+  context "when the dispute is an appeal against a PAYE coding notice" do
     let(:dispute_type) { DisputeType::PAYE_CODING_NOTICE }
 
     it { is_expected.to have_lodgement_fee(:fee_level_2) }
   end
 
-  context "when the case is an application for a decision on an enquiry" do
+  context "when the dispute is an application for a decision on an enquiry" do
     let(:dispute_type) { DisputeType::DECISION_ON_ENQUIRY }
+
+    it { is_expected.to have_lodgement_fee(:fee_level_2) }
+  end
+
+  context "when the dispute is an appeal against an information notice" do
+    let(:dispute_type) { DisputeType::INFORMATION_NOTICE }
 
     it { is_expected.to have_lodgement_fee(:fee_level_2) }
   end


### PR DESCRIPTION
A taxpayer can use the service to appeal an information notice (section
36) in two different ways: Either they choose "information notice" on
the "What is your appeal about?" question (after which they are
presented with a reduced set of applicable dispute types), or they
choose it on the "What is your dispute about?" step, after having
chosen a specific tax on the previous step.

- Add 'information notice' to `CaseType` value object
- Show 'information notice' on the first of the two case type forms
- Add 'information notice' to `DisputeType` value object
- Ensure `DisputeTypeForm` only shows relevant options if case type is
  'information notice'
- Add correct fee calculation for 'information notice' dispute type
- Add I18n for information notice