### PR TITLE
Documents upload bugfixes

### DIFF
--- a/app/assets/stylesheets/local/dropzone.scss
+++ b/app/assets/stylesheets/local/dropzone.scss
@@ -6,7 +6,7 @@
   margin-bottom: 20px;
 
   .arrow-icon::before {
-    content: url('drag-drop-upload-ico.svg');
+    content: image-url('drag-drop-upload-ico.svg');
     float: right;
     width: 90px;
     height: 90px;
@@ -14,7 +14,7 @@
   &.dz-drag-hover {
     border-color: $yellow;
     .drag-helptext::before {
-      content: url('drag-drop-upload-hover-ico.svg');
+      content: image-url('drag-drop-upload-hover-ico.svg');
       float: left;
       width: 90px;
       height: 90px;
@@ -25,7 +25,7 @@
     text-align: center;
     display: inline-block;
     &::before {
-      content: url('drag-drop-upload-ico.svg');
+      content: image-url('drag-drop-upload-ico.svg');
       float: left;
       width: 90px;
       height: 90px;

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -21,7 +21,7 @@ class DocumentsController < ApplicationController
   def destroy
     MojFileUploaderApiClient::DeleteFile.new(
       collection_ref: collection_ref,
-      filename: filename_param
+      filename: filename
     ).call
 
     if grounds_for_appeal_filename?
@@ -45,11 +45,19 @@ class DocumentsController < ApplicationController
   end
 
   def grounds_for_appeal_filename?
-    filename_param == current_tribunal_case.grounds_for_appeal_file_name
+    decoded_filename == current_tribunal_case.grounds_for_appeal_file_name
+  end
+
+  def filename
+    URI.encode(decoded_filename)
+  end
+
+  def decoded_filename
+    Base64.decode64(filename_param)
   end
 
   def filename_param
-    URI.encode(Base64.decode64(document_params[:id]))
+    document_params[:id]
   end
 
   def document_param

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -7,7 +7,6 @@ class BaseForm
   def save
     if valid?
       persist!
-      true
     else
       false
     end

--- a/app/forms/steps/cost/case_type_form.rb
+++ b/app/forms/steps/cost/case_type_form.rb
@@ -33,7 +33,7 @@ module Steps::Cost
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return unless case_type_value? && changed?
+      return true unless case_type_value? && changed?
 
       tribunal_case.update(
         case_type: case_type_value,

--- a/app/forms/steps/cost/case_type_show_more_form.rb
+++ b/app/forms/steps/cost/case_type_show_more_form.rb
@@ -21,7 +21,7 @@ module Steps::Cost
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return unless changed?
+      return true unless changed?
 
       tribunal_case.update(
         case_type: case_type_value,

--- a/app/forms/steps/cost/challenged_decision_form.rb
+++ b/app/forms/steps/cost/challenged_decision_form.rb
@@ -20,7 +20,7 @@ module Steps::Cost
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return unless changed?
+      return true unless changed?
 
       tribunal_case.update(
         challenged_decision: challenged_decision_value,

--- a/app/forms/steps/cost/dispute_type_form.rb
+++ b/app/forms/steps/cost/dispute_type_form.rb
@@ -28,7 +28,7 @@ module Steps::Cost
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return unless changed?
+      return true unless changed?
 
       tribunal_case.update(
         dispute_type: dispute_type_value,

--- a/app/forms/steps/details/taxpayer_type_form.rb
+++ b/app/forms/steps/details/taxpayer_type_form.rb
@@ -19,7 +19,7 @@ module Steps::Details
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return unless changed?
+      return true unless changed?
 
       tribunal_case.update(
         taxpayer_type: taxpayer_type_value

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -15,7 +15,7 @@
           <%= f.text_area :grounds_for_appeal, size: '40x4', class: 'form-control form-control-3-4 form-control-large' %>
 
           <% if uploaded_document.nil? %>
-              <p><%= t '.attach_document_html' %></p>
+              <p><%= f.label :grounds_for_appeal_document, t('.attach_document_html') %></p>
               <%= f.file_field :grounds_for_appeal_document %>
           <% end %>
 

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -146,6 +146,7 @@ en:
               blank: You must enter the reasons or attach a document
               file_size: The attached file exceeds the maximum allowed size
               content_type: The attached file is not a supported type
+              response_error: There was an error uploading the file. Please try again
         steps/details/individual_details_form:
           blank: You must enter the taxpayer's %{attribute}
         steps/details/company_details_form:

--- a/lib/generators/step/templates/form.rb
+++ b/lib/generators/step/templates/form.rb
@@ -34,7 +34,7 @@ module Steps::<%= task_name.camelize %>
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return unless changed?
+      return true unless changed?
 
       # TODO: Update this to persist your form object
       tribunal_case.update(

--- a/lib/generators/step/templates/form_spec.rb
+++ b/lib/generators/step/templates/form_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form d
   #     it 'saves the record' do
   #       expect(tribunal_case).to receive(:update).with(
   #         # TODO: What's in the update?
-  #       )
+  #       ).and_return(true)
   #       expect(subject.save).to be(true)
   #     end
   #   end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -5,9 +5,9 @@ include ActionDispatch::TestProcess
 RSpec.describe DocumentsController, type: :controller do
 
   let(:collection_ref) { '12345' }
-  let(:filename) { 'dGVzdA==\n' } # 'test' - base64 encoded
+  let(:filename) { 'dGVzdCBmaWxlLnR4dA==\n' } # 'test file.txt' - base64 encoded
   let(:another_filename) { 'YW5vdGhlcg==\n' } # 'another' - base64 encoded
-  let(:current_tribunal_case) { instance_double(TribunalCase, grounds_for_appeal_file_name: 'test', files_collection_ref: collection_ref) }
+  let(:current_tribunal_case) { instance_double(TribunalCase, grounds_for_appeal_file_name: 'test file.txt', files_collection_ref: collection_ref) }
   let(:file) { fixture_file_upload('files/image.jpg', 'image/jpeg') }
 
   let(:upload_response) { double(code: 200, body: {}, error?: false) }
@@ -129,7 +129,7 @@ RSpec.describe DocumentsController, type: :controller do
 
       before do
         expect(MojFileUploaderApiClient::DeleteFile).to receive(:new).with(
-            collection_ref: collection_ref, filename: 'test').and_return(double(call: true))
+            collection_ref: collection_ref, filename: 'test%20file.txt').and_return(double(call: true))
 
         expect(current_tribunal_case).to receive(:update).with(grounds_for_appeal_file_name: nil)
       end

--- a/spec/forms/steps/cost/case_type_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_form_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Steps::Cost::CaseTypeForm do
           case_type: case_type_object,
           dispute_type: nil,
           penalty_amount: nil
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/cost/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_show_more_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Steps::Cost::CaseTypeShowMoreForm do
           case_type: case_type_object,
           dispute_type: nil,
           penalty_amount: nil
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/cost/challenged_decision_form_spec.rb
+++ b/spec/forms/steps/cost/challenged_decision_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Steps::Cost::ChallengedDecisionForm do
           case_type: nil,
           dispute_type: nil,
           penalty_amount: nil
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/cost/dispute_type_form_spec.rb
+++ b/spec/forms/steps/cost/dispute_type_form_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
         expect(tribunal_case).to receive(:update).with(
           dispute_type: DisputeType::PENALTY,
           penalty_amount: nil
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/cost/penalty_amount_form_spec.rb
+++ b/spec/forms/steps/cost/penalty_amount_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Steps::Cost::PenaltyAmountForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           penalty_amount: PenaltyAmount::PENALTY_LEVEL_1
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/details/company_details_form_spec.rb
+++ b/spec/forms/steps/details/company_details_form_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Steps::Details::CompanyDetailsForm do
           taxpayer_contact_postcode:            taxpayer_contact_postcode,
           taxpayer_contact_email:               taxpayer_contact_email,
           taxpayer_contact_phone:               taxpayer_contact_phone
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/details/documents_checklist_form_spec.rb
+++ b/spec/forms/steps/details/documents_checklist_form_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
           additional_documents_provided:        additional_documents_provided,
           additional_documents_info:            additional_documents_info,
           having_problems_uploading_documents:  having_problems_uploading_documents
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
+++ b/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
         it 'saves the record' do
           expect(tribunal_case).to receive(:update).with(
             grounds_for_appeal: 'I disagree with HMRC.',
-            grounds_for_appeal_file_name: nil)
+            grounds_for_appeal_file_name: nil
+          ).and_return(true)
           expect(subject.save).to be(true)
         end
       end
@@ -71,14 +72,25 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
         let(:grounds_for_appeal_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
         let(:upload_response) { double(code: 200, body: {}, error?: false) }
 
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            grounds_for_appeal: nil,
-            grounds_for_appeal_file_name: 'image.jpg')
+        context 'document upload successful' do
+          it 'saves the record' do
+            expect(tribunal_case).to receive(:update).with(
+              grounds_for_appeal: nil,
+              grounds_for_appeal_file_name: 'image.jpg'
+            ).and_return(true)
 
-          expect(MojFileUploaderApiClient::AddFile).to receive(:new).and_return(double(call: upload_response))
+            expect(MojFileUploaderApiClient::AddFile).to receive(:new).and_return(double(call: upload_response))
 
-          expect(subject.save).to be(true)
+            expect(subject.save).to be(true)
+          end
+        end
+
+        context 'document upload unsuccessful' do
+          it 'doesn\'t save the record' do
+            expect(tribunal_case).not_to receive(:update)
+            expect(subject).to receive(:upload_document_if_present).and_return(false)
+            expect(subject.save).to be(false)
+          end
         end
       end
 
@@ -90,7 +102,8 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
         it 'saves the record' do
           expect(tribunal_case).to receive(:update).with(
             grounds_for_appeal: 'I disagree with HMRC.',
-            grounds_for_appeal_file_name: 'image.jpg')
+            grounds_for_appeal_file_name: 'image.jpg'
+          ).and_return(true)
 
           expect(MojFileUploaderApiClient::AddFile).to receive(:new).and_return(double(call: upload_response))
 

--- a/spec/forms/steps/details/individual_details_form_spec.rb
+++ b/spec/forms/steps/details/individual_details_form_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Steps::Details::IndividualDetailsForm do
           taxpayer_contact_postcode: taxpayer_contact_postcode,
           taxpayer_contact_email:    taxpayer_contact_email,
           taxpayer_contact_phone:    taxpayer_contact_phone
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/details/taxpayer_type_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_type_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Steps::Details::TaxpayerTypeForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           taxpayer_type: TaxpayerType::INDIVIDUAL
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/lateness/in_time_form_spec.rb
+++ b/spec/forms/steps/lateness/in_time_form_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Steps::Lateness::InTimeForm do
         expect(tribunal_case).to receive(:update).with(
           in_time:         InTime::UNSURE,
           lateness_reason: nil
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/lateness/lateness_reason_form_spec.rb
+++ b/spec/forms/steps/lateness/lateness_reason_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Steps::Lateness::LatenessReasonForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           lateness_reason: lateness_reason
-        )
+        ).and_return(true)
         expect(subject.save).to be(true)
       end
     end


### PR DESCRIPTION
This fixes some bugs found related to the documents uploader:

* Missing dropzone CSS images.
* Unable to delete `grounds for appeal` document if contained spaces.
* If the `grounds for appeal` upload failed, the form would progress to the next step and the name of the filename was still saved in the record.

More details in the individual commits.