### PR TITLE
Implement hardship steps

### DIFF
--- a/app/controllers/steps/hardship/disputed_tax_paid_controller.rb
+++ b/app/controllers/steps/hardship/disputed_tax_paid_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Hardship
+  class DisputedTaxPaidController < Steps::HardshipStepController
+    def edit
+      super
+      @form_object = DisputedTaxPaidForm.new(
+        tribunal_case: current_tribunal_case,
+        disputed_tax_paid: current_tribunal_case.disputed_tax_paid
+      )
+    end
+
+    def update
+      update_and_advance(DisputedTaxPaidForm)
+    end
+  end
+end

--- a/app/controllers/steps/hardship/hardship_review_requested_controller.rb
+++ b/app/controllers/steps/hardship/hardship_review_requested_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Hardship
+  class HardshipReviewRequestedController < Steps::HardshipStepController
+    def edit
+      super
+      @form_object = HardshipReviewRequestedForm.new(
+        tribunal_case: current_tribunal_case,
+        hardship_review_requested: current_tribunal_case.hardship_review_requested
+      )
+    end
+
+    def update
+      update_and_advance(HardshipReviewRequestedForm)
+    end
+  end
+end

--- a/app/controllers/steps/hardship/hardship_review_status_controller.rb
+++ b/app/controllers/steps/hardship/hardship_review_status_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Hardship
+  class HardshipReviewStatusController < Steps::HardshipStepController
+    def edit
+      super
+      @form_object = HardshipReviewStatusForm.new(
+        tribunal_case: current_tribunal_case,
+        hardship_review_status: current_tribunal_case.hardship_review_status
+      )
+    end
+
+    def update
+      update_and_advance(HardshipReviewStatusForm)
+    end
+  end
+end

--- a/app/controllers/steps/hardship_step_controller.rb
+++ b/app/controllers/steps/hardship_step_controller.rb
@@ -1,0 +1,7 @@
+class Steps::HardshipStepController < StepController
+  private
+
+  def decision_tree_class
+    HardshipDecisionTree
+  end
+end

--- a/app/forms/steps/hardship/disputed_tax_paid_form.rb
+++ b/app/forms/steps/hardship/disputed_tax_paid_form.rb
@@ -1,0 +1,32 @@
+module Steps::Hardship
+  class DisputedTaxPaidForm < BaseForm
+    attribute :disputed_tax_paid, String
+
+    def choices
+      DisputedTaxPaid.values.map(&:to_s)
+    end
+    validates_inclusion_of :disputed_tax_paid, in: proc { |record| record.choices }
+
+    private
+
+    def disputed_tax_paid_value
+      DisputedTaxPaid.new(disputed_tax_paid)
+    end
+
+    def changed?
+      tribunal_case.disputed_tax_paid != disputed_tax_paid_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return true unless changed?
+
+      tribunal_case.update(
+        disputed_tax_paid: disputed_tax_paid_value,
+        # The following are dependent attributes that need to be reset
+        hardship_review_requested: nil,
+        hardship_review_status: nil
+      )
+    end
+  end
+end

--- a/app/forms/steps/hardship/hardship_review_requested_form.rb
+++ b/app/forms/steps/hardship/hardship_review_requested_form.rb
@@ -1,0 +1,31 @@
+module Steps::Hardship
+  class HardshipReviewRequestedForm < BaseForm
+    attribute :hardship_review_requested, String
+
+    def self.choices
+      HardshipReviewRequested.values.map(&:to_s)
+    end
+    validates_inclusion_of :hardship_review_requested, in: choices
+
+    private
+
+    def hardship_review_requested_value
+      HardshipReviewRequested.new(hardship_review_requested)
+    end
+
+    def changed?
+      tribunal_case.hardship_review_requested != hardship_review_requested_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return true unless changed?
+
+      tribunal_case.update(
+        hardship_review_requested: hardship_review_requested_value,
+        # The following are dependent attributes that need to be reset
+        hardship_review_status: nil
+      )
+    end
+  end
+end

--- a/app/forms/steps/hardship/hardship_review_status_form.rb
+++ b/app/forms/steps/hardship/hardship_review_status_form.rb
@@ -1,0 +1,29 @@
+module Steps::Hardship
+  class HardshipReviewStatusForm < BaseForm
+    attribute :hardship_review_status, String
+
+    def self.choices
+      HardshipReviewStatus.values.map(&:to_s)
+    end
+    validates_inclusion_of :hardship_review_status, in: choices
+
+    private
+
+    def hardship_review_status_value
+      HardshipReviewStatus.new(hardship_review_status)
+    end
+
+    def changed?
+      tribunal_case.hardship_review_status != hardship_review_status_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return true unless changed?
+
+      tribunal_case.update(
+        hardship_review_status: hardship_review_status_value
+      )
+    end
+  end
+end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -6,6 +6,11 @@ class TribunalCase < ApplicationRecord
   has_value_object :penalty_amount
   has_value_object :lodgement_fee
 
+  # Hardship task
+  has_value_object :disputed_tax_paid
+  has_value_object :hardship_review_requested
+  has_value_object :hardship_review_status
+
   # Lateness task
   has_value_object :in_time
 

--- a/app/presenters/change_cost_answers_presenter.rb
+++ b/app/presenters/change_cost_answers_presenter.rb
@@ -4,7 +4,10 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       challenged_decision_question,
       case_type_question,
       dispute_type_question,
-      penalty_amount_question
+      penalty_amount_question,
+      disputed_tax_paid_question,
+      hardship_review_requested_question,
+      hardship_review_status_question
     ].compact
   end
 
@@ -39,6 +42,30 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       tribunal_case.penalty_amount,
       as: :penalty_amount,
       change_path: edit_steps_cost_penalty_amount_path
+    )
+  end
+
+  def disputed_tax_paid_question
+    row(
+      tribunal_case.disputed_tax_paid,
+      as: :disputed_tax_paid,
+      change_path: edit_steps_hardship_disputed_tax_paid_path
+    )
+  end
+
+  def hardship_review_requested_question
+    row(
+      tribunal_case.hardship_review_requested,
+      as: :hardship_review_requested,
+      change_path: edit_steps_hardship_hardship_review_requested_path
+    )
+  end
+
+  def hardship_review_status_question
+    row(
+      tribunal_case.hardship_review_status,
+      as: :hardship_review_status,
+      change_path: edit_steps_hardship_hardship_review_status_path
     )
   end
 end

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -10,7 +10,7 @@ class CostDecisionTree < DecisionTree
     when :dispute_type
       after_dispute_type_step
     when :penalty_amount
-      show(:determine_cost)
+      hardship_or_determine_cost_step
     else
       raise "Invalid step '#{step_params}'"
     end
@@ -55,8 +55,16 @@ class CostDecisionTree < DecisionTree
   end
 
   def after_dispute_type_step
-    if tribunal_case.dispute_type == DisputeType::PENALTY
+    if tribunal_case.dispute_type.ask_penalty?
       edit(:penalty_amount)
+    else
+      hardship_or_determine_cost_step
+    end
+  end
+
+  def hardship_or_determine_cost_step
+    if tribunal_case.case_type.ask_hardship? && tribunal_case.dispute_type.ask_hardship?
+      edit('/steps/hardship/disputed_tax_paid')
     else
       show(:determine_cost)
     end

--- a/app/services/hardship_decision_tree.rb
+++ b/app/services/hardship_decision_tree.rb
@@ -1,0 +1,57 @@
+class HardshipDecisionTree < DecisionTree
+  def destination
+    return next_step if next_step
+
+    case step_name.to_sym
+    when :disputed_tax_paid
+      after_disputed_tax_paid_step
+    when :hardship_review_requested
+      after_hardship_review_requested_step
+    when :hardship_review_status
+      { controller: '/steps/cost/determine_cost', action: :show }
+    else
+      raise "Invalid step '#{step_params}'"
+    end
+  end
+
+  def previous
+    case step_name.to_sym
+    when :disputed_tax_paid
+      before_disputed_tax_paid_step
+    when :hardship_review_requested
+      { controller: :disputed_tax_paid, action: :edit }
+    when :hardship_review_status
+      { controller: :hardship_review_requested, action: :edit }
+    else
+      raise "Invalid step '#{step_params}'"
+    end
+  end
+
+  private
+
+  def after_disputed_tax_paid_step
+    case tribunal_case.disputed_tax_paid
+    when DisputedTaxPaid::YES
+      { controller: '/steps/cost/determine_cost', action: :show }
+    when DisputedTaxPaid::NO
+      { controller: :hardship_review_requested, action: :edit }
+    end
+  end
+
+  def after_hardship_review_requested_step
+    case tribunal_case.hardship_review_requested
+    when HardshipReviewRequested::YES
+      { controller: :hardship_review_status, action: :edit }
+    when HardshipReviewRequested::NO
+      { controller: '/steps/cost/determine_cost', action: :show }
+    end
+  end
+
+  def before_disputed_tax_paid_step
+    if tribunal_case.penalty_amount?
+      { controller: '/steps/cost/penalty_amount', action: :edit }
+    else
+      { controller: '/steps/cost/dispute_type', action: :edit }
+    end
+  end
+end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -10,10 +10,9 @@ class CaseType < ValueObject
   end
 
   def initialize(raw_value, direct_tax: false, ask_dispute_type: false, ask_penalty: false, ask_hardship: false)
-    raise ArgumentError.new('Case type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
     @direct_tax, @ask_dispute_type, @ask_penalty, @ask_hardship = direct_tax, ask_dispute_type, ask_penalty, ask_hardship
 
-    super(raw_value.to_sym)
+    super(raw_value)
   end
 
   def self.direct_tax_properties
@@ -53,7 +52,7 @@ class CaseType < ValueObject
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),
     TOBACCO_PRODUCTS_DUTY        = new(:tobacco_products_duty,        indirect_tax_properties),
     VAT                          = new(:vat,                          indirect_tax_properties),
-    OTHER                        = new(:other,                        direct_tax: false, ask_dispute_type: false, ask_penalty: false, ask_hardship: true)
+    OTHER                        = new(:other,                        direct_tax: false, ask_dispute_type: false, ask_penalty: false, ask_hardship: false)
   ].freeze
 
   def self.values

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -13,8 +13,11 @@ class DisputeType < ValueObject
     VALUES
   end
 
-  def initialize(raw_value)
-    raise ArgumentError.new('Dispute type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
-    super(raw_value.to_sym)
+  def ask_penalty?
+    self == PENALTY
+  end
+
+  def ask_hardship?
+    [AMOUNT_OF_TAX, AMOUNT_AND_PENALTY].include?(self)
   end
 end

--- a/app/value_objects/disputed_tax_paid.rb
+++ b/app/value_objects/disputed_tax_paid.rb
@@ -1,8 +1,8 @@
-class ChallengedDecision < ValueObject
+class DisputedTaxPaid < ValueObject
   VALUES = [
     YES = new(:yes),
-    NO  = new(:no),
-  ].freeze
+    NO  = new(:no)
+  ]
 
   def self.values
     VALUES

--- a/app/value_objects/fee.rb
+++ b/app/value_objects/fee.rb
@@ -1,9 +1,4 @@
 class Fee < ValueObject
-  def initialize(raw_value)
-    raise ArgumentError.new('Fee value must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
-    super(raw_value.to_sym)
-  end
-
   def to_gbp
     GlimrFees.fee_amount(self) / 100.0
   end

--- a/app/value_objects/hardship_review_requested.rb
+++ b/app/value_objects/hardship_review_requested.rb
@@ -1,8 +1,8 @@
-class ChallengedDecision < ValueObject
+class HardshipReviewRequested < ValueObject
   VALUES = [
     YES = new(:yes),
-    NO  = new(:no),
-  ].freeze
+    NO  = new(:no)
+  ]
 
   def self.values
     VALUES

--- a/app/value_objects/hardship_review_status.rb
+++ b/app/value_objects/hardship_review_status.rb
@@ -1,0 +1,11 @@
+class HardshipReviewStatus < ValueObject
+  VALUES = [
+    GRANTED = new(:granted),
+    PENDING = new(:pending),
+    REFUSED = new(:refused)
+  ]
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/value_objects/in_time.rb
+++ b/app/value_objects/in_time.rb
@@ -5,11 +5,6 @@ class InTime < ValueObject
     UNSURE = new(:unsure)
   ].freeze
 
-  def initialize(raw_value)
-    raise ArgumentError.new('In time must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
-    super(raw_value.to_sym)
-  end
-
   def self.values
     VALUES
   end

--- a/app/value_objects/lodgement_fee.rb
+++ b/app/value_objects/lodgement_fee.rb
@@ -3,5 +3,5 @@ class LodgementFee < Fee
     FEE_LEVEL_1 = new(:fee_level_1),
     FEE_LEVEL_2 = new(:fee_level_2),
     FEE_LEVEL_3 = new(:fee_level_3)
-  ]
+  ].freeze
 end

--- a/app/value_objects/penalty_amount.rb
+++ b/app/value_objects/penalty_amount.rb
@@ -5,11 +5,6 @@ class PenaltyAmount < ValueObject
     PENALTY_LEVEL_3 = new(:penalty_level_3)
   ].freeze
 
-  def initialize(raw_value)
-    raise ArgumentError.new('Penalty amount must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
-    super(raw_value.to_sym)
-  end
-
   def self.values
     VALUES
   end

--- a/app/value_objects/taxpayer_type.rb
+++ b/app/value_objects/taxpayer_type.rb
@@ -7,9 +7,4 @@ class TaxpayerType < ValueObject
   def self.values
     VALUES
   end
-
-  def initialize(raw_value)
-    raise ArgumentError.new('Taxpayer type must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
-    super(raw_value.to_sym)
-  end
 end

--- a/app/value_objects/value_object.rb
+++ b/app/value_objects/value_object.rb
@@ -2,7 +2,8 @@ class ValueObject
   attr_reader :value
 
   def initialize(raw_value)
-    @value = raw_value
+    raise ArgumentError.new('Raw value must be symbol or implicitly convertible') unless raw_value.respond_to?(:to_sym)
+    @value = raw_value.to_sym
     freeze
   end
 

--- a/app/views/steps/hardship/disputed_tax_paid/edit.html.erb
+++ b/app/views/steps/hardship/disputed_tax_paid/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:hardship, 6) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :disputed_tax_paid,
+        choices: @form_object.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/hardship/hardship_review_requested/edit.html.erb
+++ b/app/views/steps/hardship/hardship_review_requested/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:hardship, 7) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :hardship_review_requested,
+        choices: Steps::Hardship::HardshipReviewRequestedForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/hardship/hardship_review_status/edit.html.erb
+++ b/app/views/steps/hardship/hardship_review_status/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:hardship, 8) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :hardship_review_status,
+        choices: Steps::Hardship::HardshipReviewStatusForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -1,7 +1,7 @@
 en:
   steps:
     cost:
-      step_header: Question %{step} of 5
+      step_header: Question %{step} of 8
       start:
         show:
           heading: 1. Find out the cost of your appeal
@@ -126,6 +126,9 @@ en:
             case_type: What is your appeal about?
             dispute_type: What is your dispute about?
             penalty_amount: What is the penalty or surcharge amount?
+            disputed_tax_paid: Have you paid the amount of tax involved in the dispute?
+            hardship_review_requested: Did you apply for financial hardship?
+            hardship_review_status: What is the status of your hardship application?
           answers:
             challenged_decision:
               'yes': 'Yes'
@@ -171,6 +174,16 @@ en:
               penalty_level_1: £100 or less
               penalty_level_2: £101 – £20,000
               penalty_level_3: £20,001 or more
+            disputed_tax_paid:
+              'no': 'No'
+              'yes': 'Yes'
+            hardship_review_requested:
+              'no': 'No'
+              'yes': 'Yes'
+            hardship_review_status:
+              granted: Granted
+              pending: Pending HMRC review
+              refused: Refused
       must_challenge_hmrc:
         show:
           heading: You must challenge HMRC before you can appeal

--- a/config/locales/hardship.yml
+++ b/config/locales/hardship.yml
@@ -1,0 +1,53 @@
+en:
+  steps:
+    hardship:
+      step_header: Question %{step} of 8
+      disputed_tax_paid:
+        edit:
+          heading: Have you paid the amount of tax involved in the dispute?
+          lead_text: If you have paid or deposited the amount of tax involved in the dispute, select 'Yes'. If you can't pay because it will cause you financial difficulties, you can still continue your appeal.
+      hardship_review_requested:
+        edit:
+          heading: Did you apply for financial hardship?
+          lead_text: You can still continue if you select 'No'. The tax tribunal will keep your appeal as pending until you ask HMRC to defer paying the tax because of financial hardship.
+      hardship_review_status:
+        edit:
+          heading: What is the status of your hardship application?
+          lead_text: If hardship is refused, you can still continue your appeal and ask the judge to consider your reasons.
+  activemodel:
+    errors:
+      models:
+        steps/hardship/disputed_tax_paid_form:
+          attributes:
+            disputed_tax_paid:
+              inclusion: Select whether you have paid the amount of tax involved in the dispute
+        steps/hardship/hardship_review_requested_form:
+          attributes:
+            hardship_review_requested:
+              inclusion: Select whether you have applied for financial hardship
+        steps/hardship/hardship_review_status_form:
+          attributes:
+            hardship_review_status:
+              inclusion: Select the status of your hardship application
+  helpers:
+    fieldset:
+      steps_hardship_disputed_tax_paid_form:
+        disputed_tax_paid: Have you paid the amount of tax involved in the dispute?
+      steps_hardship_hardship_review_requested_form:
+        hardship_review_requested: Did you apply for financial hardship?
+      steps_hardship_hardship_review_status_form:
+        hardship_review_status: What is the status of your hardship application?
+    label:
+      steps_hardship_disputed_tax_paid_form:
+        disputed_tax_paid:
+          'yes': 'Yes'
+          'no': 'No'
+      steps_hardship_hardship_review_requested_form:
+        hardship_review_requested:
+          'yes': 'Yes'
+          'no': 'No'
+      steps_hardship_hardship_review_status_form:
+        hardship_review_status:
+          granted: Granted
+          pending: Pending HMRC decision
+          refused: Refused

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,12 @@ Rails.application.routes.draw do
       show_step :must_challenge_hmrc
     end
 
+    namespace :hardship do
+      edit_step :disputed_tax_paid
+      edit_step :hardship_review_requested
+      edit_step :hardship_review_status
+    end
+
     namespace :lateness do
       show_step :start
       edit_step :in_time

--- a/db/migrate/20161220125616_add_hardship_fields_to_tribunal_case.rb
+++ b/db/migrate/20161220125616_add_hardship_fields_to_tribunal_case.rb
@@ -1,0 +1,7 @@
+class AddHardshipFieldsToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :disputed_tax_paid, :string
+    add_column :tribunal_cases, :hardship_review_requested, :string
+    add_column :tribunal_cases, :hardship_review_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161212140942) do
+ActiveRecord::Schema.define(version: 20161220125616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,9 @@ ActiveRecord::Schema.define(version: 20161212140942) do
     t.text     "additional_documents_info"
     t.boolean  "having_problems_uploading_documents",  default: false
     t.string   "challenged_decision"
+    t.string   "disputed_tax_paid"
+    t.string   "hardship_review_requested"
+    t.string   "hardship_review_status"
   end
 
 end

--- a/spec/controllers/steps/hardship/disputed_tax_paid_controller_spec.rb
+++ b/spec/controllers/steps/hardship/disputed_tax_paid_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Hardship::DisputedTaxPaidController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Hardship::DisputedTaxPaidForm, HardshipDecisionTree
+end

--- a/spec/controllers/steps/hardship/hardship_review_requested_controller_spec.rb
+++ b/spec/controllers/steps/hardship/hardship_review_requested_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Hardship::HardshipReviewRequestedController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Hardship::HardshipReviewRequestedForm, HardshipDecisionTree
+end

--- a/spec/controllers/steps/hardship/hardship_review_status_controller_spec.rb
+++ b/spec/controllers/steps/hardship/hardship_review_status_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Hardship::HardshipReviewStatusController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Hardship::HardshipReviewStatusForm, HardshipDecisionTree
+end

--- a/spec/forms/steps/hardship/disputed_tax_paid_form_spec.rb
+++ b/spec/forms/steps/hardship/disputed_tax_paid_form_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Hardship::DisputedTaxPaidForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    disputed_tax_paid: disputed_tax_paid
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, disputed_tax_paid: nil, dispute_type: dispute_type) }
+  let(:dispute_type) { nil }
+  let(:disputed_tax_paid) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#choices' do
+    it 'gets its options from the value object' do
+      expect(DisputedTaxPaid).to receive(:values).and_return([DisputedTaxPaid.new(:foo)])
+      expect(subject.choices).to eq(['foo'])
+    end
+  end
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)     { nil }
+      let(:disputed_tax_paid) { 'yes' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when disputed_tax_paid is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:disputed_tax_paid]).to_not be_empty
+      end
+    end
+
+    context 'when disputed_tax_paid is not valid' do
+      let(:disputed_tax_paid) { 'sort_of' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:disputed_tax_paid]).to_not be_empty
+      end
+    end
+
+    context 'when disputed_tax_paid is valid' do
+      let(:disputed_tax_paid) { 'no' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          disputed_tax_paid: DisputedTaxPaid::NO,
+          hardship_review_requested: nil,
+          hardship_review_status: nil
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when disputed_tax_paid is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          dispute_type: DisputeType.new(:anything),
+          disputed_tax_paid: DisputedTaxPaid::NO
+        )
+      }
+      let(:disputed_tax_paid) { 'no' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/hardship/hardship_review_requested_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_review_requested_form_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Hardship::HardshipReviewRequestedForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    hardship_review_requested: hardship_review_requested
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, hardship_review_requested: nil) }
+  let(:hardship_review_requested) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case) { nil }
+      let(:hardship_review_requested) { 'no' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when hardship_review_requested is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:hardship_review_requested]).to_not be_empty
+      end
+    end
+
+    context 'when hardship_review_requested is not valid' do
+      let(:hardship_review_requested) { 'kinda' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:hardship_review_requested]).to_not be_empty
+      end
+    end
+
+    context 'when hardship_review_requested is valid' do
+      let(:hardship_review_requested) { 'yes' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          hardship_review_requested: HardshipReviewRequested::YES,
+          hardship_review_status: nil
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when hardship_review_requested is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          hardship_review_requested: HardshipReviewRequested::NO
+        )
+      }
+      let(:hardship_review_requested) { 'no' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end
+

--- a/spec/forms/steps/hardship/hardship_review_status_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_review_status_form_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Hardship::HardshipReviewStatusForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    hardship_review_status: hardship_review_status
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, hardship_review_status: nil) }
+  let(:hardship_review_status) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case) { nil }
+      let(:hardship_review_status) { 'pending' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when hardship_review_status is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:hardship_review_status]).to_not be_empty
+      end
+    end
+
+    context 'when hardship_review_status is not valid' do
+      let(:hardship_review_status) { 'i_ve_been_waiting_all_night' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:hardship_review_status]).to_not be_empty
+      end
+    end
+
+    context 'when hardship_review_status is valid' do
+      let(:hardship_review_status) { 'granted' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          hardship_review_status: HardshipReviewStatus::GRANTED
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when hardship_review_status is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          hardship_review_status: HardshipReviewStatus::REFUSED
+        )
+      }
+      let(:hardship_review_status) { 'refused' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end
+

--- a/spec/presenters/change_cost_answers_presenter_spec.rb
+++ b/spec/presenters/change_cost_answers_presenter_spec.rb
@@ -5,18 +5,24 @@ RSpec.describe ChangeCostAnswersPresenter do
   let(:tribunal_case) {
     instance_double(
       TribunalCase,
-      challenged_decision:                  challenged_decision,
-      case_type:                case_type,
-      dispute_type:               dispute_type,
-      penalty_amount: penalty_amount
+      challenged_decision: challenged_decision,
+      case_type: case_type,
+      dispute_type: dispute_type,
+      penalty_amount: penalty_amount,
+      disputed_tax_paid: disputed_tax_paid,
+      hardship_review_requested: hardship_review_requested,
+      hardship_review_status: hardship_review_status
     )
   }
   let(:paths) { Rails.application.routes.url_helpers }
 
-  let(:challenged_decision) { true }
-  let(:case_type)           { 'foo' }
-  let(:dispute_type)        { nil }
-  let(:penalty_amount)      { nil }
+  let(:challenged_decision)       { true }
+  let(:case_type)                 { 'foo' }
+  let(:dispute_type)              { nil }
+  let(:penalty_amount)            { nil }
+  let(:disputed_tax_paid)         { nil }
+  let(:hardship_review_requested) { nil }
+  let(:hardship_review_status)    { nil }
 
   describe '#rows' do
     describe '`challenged_decision` row' do
@@ -93,7 +99,7 @@ RSpec.describe ChangeCostAnswersPresenter do
 
       # Needed so that the row is in the correct position
       let(:dispute_type) { 'foo' }
-      let(:case_type)  { 'bar' }
+      let(:case_type) { 'bar' }
 
       context 'when `penalty_amount` is nil' do
         let(:penalty_amount) { nil }
@@ -110,6 +116,87 @@ RSpec.describe ChangeCostAnswersPresenter do
           expect(row.question).to    eq('.questions.penalty_amount')
           expect(row.answer).to      eq('.answers.penalty_amount.foo')
           expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
+        end
+      end
+    end
+
+    describe '`disputed_tax_paid` row' do
+      let(:row) { subject.rows[3] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+
+      context 'when `disputed_tax_paid` is nil' do
+        let(:disputed_tax_paid) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `disputed_tax_paid` is given' do
+        let(:disputed_tax_paid)  { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.disputed_tax_paid')
+          expect(row.answer).to      eq('.answers.disputed_tax_paid.foo')
+          expect(row.change_path).to eq(paths.edit_steps_hardship_disputed_tax_paid_path)
+        end
+      end
+    end
+
+    describe '`hardship_review_requested` row' do
+      let(:row) { subject.rows[4] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+      let(:disputed_tax_paid) { 'baz' }
+
+      context 'when `hardship_review_requested` is nil' do
+        let(:hardship_review_requested) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `hardship_review_requested` is given' do
+        let(:hardship_review_requested)  { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.hardship_review_requested')
+          expect(row.answer).to      eq('.answers.hardship_review_requested.foo')
+          expect(row.change_path).to eq(paths.edit_steps_hardship_hardship_review_requested_path)
+        end
+      end
+    end
+
+    describe '`hardship_review_status` row' do
+      let(:row) { subject.rows[5] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+      let(:disputed_tax_paid) { 'baz' }
+      let(:hardship_review_requested) { 'bam' }
+
+      context 'when `hardship_review_status` is nil' do
+        let(:hardship_review_status) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `hardship_review_status` is given' do
+        let(:hardship_review_status) { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.hardship_review_status')
+          expect(row.answer).to      eq('.answers.hardship_review_status.foo')
+          expect(row.change_path).to eq(paths.edit_steps_hardship_hardship_review_status_path)
         end
       end
     end

--- a/spec/services/cost_decision_tree_spec.rb
+++ b/spec/services/cost_decision_tree_spec.rb
@@ -62,40 +62,31 @@ RSpec.describe CostDecisionTree do
 
     context 'when the step is `dispute_type`' do
       let(:step_params)   { { dispute_type: 'anything' } }
-      let(:tribunal_case) { instance_double(TribunalCase, dispute_type: dispute_type) }
+      let(:case_type)     { CaseType.new(:anything) }
+      let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type, dispute_type: dispute_type) }
 
-      context 'and the dispute type is PAYE coding notice' do
-        let(:dispute_type) { DisputeType::PAYE_CODING_NOTICE }
-
-        it { is_expected.to have_destination(:determine_cost, :show) }
-      end
-
-      context 'and the dispute type is penalty or surcharge' do
-        let(:dispute_type) { DisputeType::PENALTY }
+      context 'and the dispute type should ask for a penalty amount' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: true) }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
 
-      context 'and the dispute type is amount of tax' do
-        let(:dispute_type) { DisputeType::AMOUNT_OF_TAX }
+      context 'and the dispute type should not ask for a penalty amount but the dispute_type asks hardship and the case_type asks hardship' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_hardship?: true) }
+        let(:case_type)     { CaseType.new(:anything, ask_hardship: true) }
+
+        it { is_expected.to have_destination('/steps/hardship/disputed_tax_paid', :edit) }
+      end
+
+      context 'and the dispute type should not ask for a penalty amount but the dispute_type asks hardship but the case_type does not ask hardship' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_hardship?: true) }
+        let(:case_type)     { CaseType.new(:anything, ask_hardship: false) }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the dispute type is amount of tax and penalty' do
-        let(:dispute_type) { DisputeType::AMOUNT_AND_PENALTY }
-
-        it { is_expected.to have_destination(:determine_cost, :show) }
-      end
-
-      context 'and the dispute type is ask for a decision on an enquiry' do
-        let(:dispute_type) { DisputeType::DECISION_ON_ENQUIRY }
-
-        it { is_expected.to have_destination(:determine_cost, :show) }
-      end
-
-      context 'and the dispute type is other' do
-        let(:dispute_type) { DisputeType::OTHER }
+      context 'and the dispute type should not ask for a penalty amount and not ask hardship' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_hardship?: false) }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
@@ -103,8 +94,35 @@ RSpec.describe CostDecisionTree do
 
     context 'when the step is `penalty_amount`' do
       let(:step_params) { { penalty_amount: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type, dispute_type: dispute_type) }
 
-      it { is_expected.to have_destination(:determine_cost, :show) }
+      context 'and the case type should ask hardship and the dispute_type should ask hardship' do
+        let(:case_type)    { CaseType.new(:anything, ask_hardship: true) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: true) }
+
+        it { is_expected.to have_destination('/steps/hardship/disputed_tax_paid', :edit) }
+      end
+
+      context 'and the case type should ask the hardship questions but the dispute_type should not' do
+        let(:case_type) { CaseType.new(:anything, ask_hardship: true) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: false) }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the case type should not ask the hardship questions but the dispute_type is one that otherwise should' do
+        let(:case_type) { CaseType.new(:anything, ask_hardship: false) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: true) }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the case type should not ask the hardship questions and the dispute_type should not either' do
+        let(:case_type) { CaseType.new(:anything, ask_hardship: false) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: false) }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
     end
 
     context 'when the step is invalid' do

--- a/spec/services/hardship_decision_tree_spec.rb
+++ b/spec/services/hardship_decision_tree_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+RSpec.describe HardshipDecisionTree do
+  let(:tribunal_case) { double('TribunalCase') }
+  let(:step_params)   { double('Step') }
+  let(:next_step)     { nil }
+  subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
+
+  describe '#destination' do
+    context 'when the step is `disputed_tax_paid`' do
+      let(:step_params)   { { disputed_tax_paid: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, disputed_tax_paid: disputed_tax_paid) }
+
+      context 'and the disputed tax has been paid' do
+        let(:disputed_tax_paid) { DisputedTaxPaid::YES }
+
+        it { is_expected.to have_destination('/steps/cost/determine_cost', :show) }
+      end
+
+      context 'and the disputed tax has not been paid' do
+        let(:disputed_tax_paid) { DisputedTaxPaid::NO }
+
+        it { is_expected.to have_destination(:hardship_review_requested, :edit) }
+      end
+    end
+
+    context 'when the step is `hardship_review_requested`' do
+      let(:step_params) { { hardship_review_requested: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, hardship_review_requested: hardship_review_requested) }
+
+      context 'and a hardship review has been requested' do
+        let(:hardship_review_requested) { HardshipReviewRequested::YES }
+
+        it { is_expected.to have_destination(:hardship_review_status, :edit) }
+      end
+
+      context 'and a hardship review has not been requested' do
+        let(:hardship_review_requested) { HardshipReviewRequested::NO }
+
+        it { is_expected.to have_destination('/steps/cost/determine_cost', :show) }
+      end
+    end
+
+    context 'when the step is `hardship_review_status`' do
+      let(:step_params) { { hardship_review_status: 'anything' } }
+
+      it { is_expected.to have_destination('/steps/cost/determine_cost', :show) }
+    end
+
+    context 'when the step is invalid' do
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
+
+      it 'raises an error' do
+        expect { subject.destination }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe '#previous' do
+    context 'when the step is `disputed_tax_paid`' do
+      let(:step_params) { { disputed_tax_paid: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, penalty_amount?: has_penalty_amount) }
+
+      context 'when the tribunal_case has a penalty' do
+        let(:has_penalty_amount) { true }
+
+        it { is_expected.to have_previous('/steps/cost/penalty_amount', :edit) }
+      end
+
+      context 'when the tribunal_case does not have a penalty' do
+        let(:has_penalty_amount) { false }
+
+        it { is_expected.to have_previous('/steps/cost/dispute_type', :edit) }
+      end
+    end
+
+    context 'when the step is `hardship_review_requested`' do
+      let(:step_params) { { hardship_review_requested: 'anything' } }
+
+      it { is_expected.to have_previous(:disputed_tax_paid, :edit) }
+    end
+
+    context 'when the step is `hardship_review_status`' do
+      let(:step_params) { { hardship_review_status: 'anything' } }
+
+      it { is_expected.to have_previous(:hardship_review_requested, :edit) }
+    end
+
+    context 'when the step is invalid' do
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
+
+      it 'raises an error' do
+        expect { subject.previous }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/value_objects/dispute_type_spec.rb
+++ b/spec/value_objects/dispute_type_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe DisputeType do
+  let(:type) { :foo }
+  subject    { described_class.new(type) }
+
+  describe '#ask_penalty?' do
+    it 'returns false by default' do
+      expect(subject.ask_penalty?).to be(false)
+    end
+
+    context 'when the dispute type is PENALTY' do
+      let(:type) { :penalty }
+
+      it 'returns true' do
+        expect(subject.ask_penalty?).to be(true)
+      end
+    end
+  end
+
+  describe '#ask_hardship?' do
+    it 'returns false by default' do
+      expect(subject.ask_hardship?).to be(false)
+    end
+
+    context 'when the dispute type is AMOUNT_OF_TAX' do
+      let(:type) { :amount_of_tax }
+
+      it 'returns true' do
+        expect(subject.ask_hardship?).to be(true)
+      end
+    end
+
+    context 'when the dispute type is AMOUNT_AND_PENALTY' do
+      let(:type) { :amount_and_penalty }
+
+      it 'returns true' do
+        expect(subject.ask_hardship?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hardship questions are asked during cost determination if you're
appealing an indirect tax on the basis of amount of tax (or amount of
tax and penalty). Implemented as a separate task because it might get
moved around eventually.

- Add a `HardshipDecisionTree`
- Add a `DisputedTaxPaid` step
- Add a `HardshipReviewRequested` step
- Add a `HardshipReviewStatus` step
- Add appropriate value objects
- Update `CostAnswersPresenter` to reflect new questions
- Remove individual initializers from value objects (they're all taking
  symbol raw values anyway)