### PR TITLE
prevent fees api call returning HTML

### DIFF
--- a/app/services/payment_url.rb
+++ b/app/services/payment_url.rb
@@ -21,7 +21,7 @@ class PaymentUrl
   end
 
   def execute_request
-    resp = RestClient.post(endpoint, payload.to_json, content_type: :json)
+    resp = RestClient.post(endpoint, payload.to_json, content_type: :json, accept: :json)
     body = JSON.parse(resp.body, symbolize_names: true)
 
     raise Exception.new(body[:error]) if body[:error]

--- a/spec/services/payment_url_spec.rb
+++ b/spec/services/payment_url_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PaymentUrl do
 
   describe '#call!' do
     let(:endpoint) { 'http://payments.com/case_requests' }
-    let(:headers) { {content_type: :json} }
+    let(:headers) { {content_type: :json, accept: :json} }
     let(:payload) {
       {case_request: {case_reference: 'TC/12345', confirmation_code: 'ABCDEF'}}.to_json
     }


### PR DESCRIPTION
Without this change, the following code will get a page of HTML in
the response;

PaymentUrl.new(case_reference: "TC/2016/00064", confirmation_code: "CAPFXY").call!

With this change, the same call gets a string containing a URL,
which is the desired behaviour.