### PR TITLE
add a development Dockerfile, for docker-compose

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,14 +1,19 @@
 FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 
+ENV PUMA_PORT 3000
+
+ENV DATABASE_URL                 replace_this_at_build_time
+ENV GLIMR_API_URL                replace_this_at_build_time
+ENV PAYMENT_ENDPOINT             replace_this_at_build_time
+ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
+ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN apt-get update && apt-get install -y
 
-# Make sure we install development and test gems
-# (the FROM Dockerfile sets them as --without options which get cached
-# in Bundler configuration)
-RUN rm /usr/local/bundle/config
-RUN bundle config --delete without
-RUN bundle install
+EXPOSE $PUMA_PORT
+
+RUN bundle install --with development
 
 CMD bundle exec puma -p $PUMA_PORT


### PR DESCRIPTION
add a development Dockerfile, for docker-compose

The docker compose project;

https://github.com/ministryofjustice/tax-tribunals-docker-compose

...is being updated to support running the system components in
development mode, so that any local code changes are immediately
reflected in the behaviour of the system. This change is a
pre-requisite for that. See the docker-compose repo. for more
information.
