### PR TITLE
add a placeholder for the GLIMR_API_URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DATABASE_URL=postgresql://postgres@db/tax-tribunals-datacapture
 PAYMENT_ENDPOINT=http://localhost:4500
 MOJ_FILE_UPLOADER_ENDPOINT=http://localhost:9292
 TAX_TRIBUNALS_DOWNLOADER_URL=http://localhost:9393
+GLIMR_API_URL=https://[hostname]/Live_API/api/tdsapi


### PR DESCRIPTION
In .env.example, show that GLIMR_API_URL is a required env var