### PR TITLE
Send online mapping code to GLiMR

### DIFF
--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -17,7 +17,7 @@ class GlimrNewCase
   def params
     params = {
       jurisdictionId: jurisdiction_id,
-      onlineMappingCode: tc.case_type,
+      onlineMappingCode: tc.mapping_code,
       contactPhone: tc.taxpayer_contact_phone,
       contactEmail: tc.taxpayer_contact_email,
       contactPostalCode: tc.taxpayer_contact_postcode,

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe GlimrNewCase do
-
   let!(:tribunal_case)   { TribunalCase.create(case_attributes) }
   let(:taxpayer_type)    { TaxpayerType::INDIVIDUAL }
   let(:taxpayer_name)    { 'Filomena Keebler' }
@@ -42,6 +41,7 @@ RSpec.describe GlimrNewCase do
     let(:glimr_params) do
       {
         jurisdictionId: 8,
+        onlineMappingCode: 'APPL_FOOBAR',
         documentsURL: 'http://downloader.com/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
         contactFirstName: 'Filomena',
         contactLastName: 'Keebler',
@@ -56,6 +56,7 @@ RSpec.describe GlimrNewCase do
     before do
       allow(GlimrApiClient::RegisterNewCase).to receive(:call).
           with(hash_including(glimr_params)).and_return(glimr_response_double)
+      allow(tribunal_case).to receive(:mapping_code).and_return('APPL_FOOBAR')
     end
 
     context 'registering the case into glimr' do


### PR DESCRIPTION
Now that we are determining an online mapping code, it should be
included in the payload we send to GLiMR.