### PR TITLE
Fix small bug with CaseCreator service object.

### DIFF
--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -12,6 +12,7 @@ class GlimrNewCase
     response = GlimrApiClient::RegisterNewCase.call(params)
     @case_reference = response.response_body[:tribunalCaseNumber]
     @confirmation_code = response.response_body[:confirmationCode]
+    self
   end
 
   def params

--- a/app/services/payment_url.rb
+++ b/app/services/payment_url.rb
@@ -8,6 +8,7 @@ class PaymentUrl
 
   def call!
     @payment_url = execute_request
+    self
   end
 
   private

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe GlimrNewCase do
     end
 
     context 'registering the case into glimr' do
+      it 'returns a GlimrNewCase instance' do
+        result = subject.call!
+        expect(result).to be_an_instance_of(described_class)
+      end
+
       it 'retrieves the tc_number and conf_code' do
         subject.call!
         expect(subject.case_reference).to eq('TC/12345')

--- a/spec/services/payment_url_spec.rb
+++ b/spec/services/payment_url_spec.rb
@@ -30,7 +30,12 @@ RSpec.describe PaymentUrl do
     context 'for a successful request' do
       let(:response) { double('Response', body: {return_url: 'http://www.example.com/payment'}.to_json) }
 
-      it 'retrieves the payment URL' do
+      it 'returns a PaymentUrl instance' do
+        result = subject.call!
+        expect(result).to be_an_instance_of(described_class)
+      end
+
+      it 'assigns the payment URL' do
         subject.call!
         expect(subject.payment_url).to eq('http://www.example.com/payment')
       end


### PR DESCRIPTION
The secondary service objects being called to create the case in GLiMR and to retrieve
the payment URL where not returning an instance as expected originally.