### PR TITLE
convert onlineMappingCode to a string, for GLiMR

### DIFF
--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -18,7 +18,7 @@ class GlimrNewCase
   def params
     params = {
       jurisdictionId: jurisdiction_id,
-      onlineMappingCode: tc.mapping_code,
+      onlineMappingCode: tc.mapping_code.to_glimr_str,
       contactPhone: tc.taxpayer_contact_phone,
       contactEmail: tc.taxpayer_contact_email,
       contactPostalCode: tc.taxpayer_contact_postcode,

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe GlimrNewCase do
     let(:glimr_params) do
       {
         jurisdictionId: 8,
-        onlineMappingCode: 'APPL_FOOBAR',
+        onlineMappingCode: 'APPL_PENALTY_LOW',
         documentsURL: 'http://downloader.com/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
         contactFirstName: 'Filomena',
         contactLastName: 'Keebler',
@@ -56,7 +56,7 @@ RSpec.describe GlimrNewCase do
     before do
       allow(GlimrApiClient::RegisterNewCase).to receive(:call).
           with(hash_including(glimr_params)).and_return(glimr_response_double)
-      allow(tribunal_case).to receive(:mapping_code).and_return('APPL_FOOBAR')
+      allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::APPL_PENALTY_LOW,)
     end
 
     context 'registering the case into glimr' do


### PR DESCRIPTION
bugfix: The system was sending the onlineMappingCode
value object, but GLiMR needs a string value