### PR TITLE
Reintroduce old Online Mapping Codes

### DIFF
--- a/app/services/glimr_fees.rb
+++ b/app/services/glimr_fees.rb
@@ -3,21 +3,15 @@ class GlimrFees
   #   Hardcoded here until we have fully functional API access.
   def self.lodgement_fee_amount(tribunal_case)
     case tribunal_case.mapping_code
-    when MappingCode::APPL_PENALTY_LOW
+    when MappingCode::TAXPENALTYLOW
       20_00
-    when MappingCode::APPL_PENALTY_MED
+    when MappingCode::TAXPENALTYMED,
+         MappingCode::PAYECODING,
+         MappingCode::APPNTOCLOSE
       50_00
-    when MappingCode::APPL_PENALTY_HIGH
-      200_00
-    when MappingCode::APPL_PAYECODING
-      50_00
-    when MappingCode::APPL_INFONOTICE
-      50_00
-    when MappingCode::APPL_OTHER
-      200_00
-    when MappingCode::APPN_CLOSEENQUIRY
-      50_00
-    when MappingCode::APPN_OTHER
+    when MappingCode::TAXPENALTYHIGH,
+         MappingCode::OTHERAPPEAL,
+         MappingCode::OTHERAPPLICATION
       200_00
     else
       raise ArgumentError, 'Unknown mapping code'

--- a/app/services/mapping_code_determiner.rb
+++ b/app/services/mapping_code_determiner.rb
@@ -27,35 +27,38 @@ class MappingCodeDeterminer
   end
 
   def penalty_mapping_code
+    # TODO: Replace with correct mapping codes once they have been agreed on
     case tribunal_case.penalty_amount
     when PenaltyAmount::PENALTY_LEVEL_1
-      MappingCode::APPL_PENALTY_LOW
+      MappingCode::TAXPENALTYLOW
     when PenaltyAmount::PENALTY_LEVEL_2
-      MappingCode::APPL_PENALTY_MED
+      MappingCode::TAXPENALTYMED
     when PenaltyAmount::PENALTY_LEVEL_3
-      MappingCode::APPL_PENALTY_HIGH
+      MappingCode::TAXPENALTYHIGH
     end
   end
 
   def dispute_type_mapping_code
+    # TODO: Replace with correct mapping codes once they have been agreed on
     case tribunal_case.dispute_type
     when DisputeType::DECISION_ON_ENQUIRY
-      MappingCode::APPN_CLOSEENQUIRY
+      MappingCode::APPNTOCLOSE
     when DisputeType::PAYE_CODING_NOTICE
-      MappingCode::APPL_PAYECODING
+      MappingCode::PAYECODING
     when DisputeType::INFORMATION_NOTICE
-      MappingCode::APPL_INFONOTICE
+      MappingCode::TAXPENALTYMED
     when DisputeType::AMOUNT_OF_TAX,
          DisputeType::AMOUNT_AND_PENALTY,
          DisputeType::OTHER
-      MappingCode::APPL_OTHER
+      MappingCode::OTHERAPPLICATION
     end
   end
 
   def case_type_mapping_code
+    # TODO: Replace with correct mapping codes once they have been agreed on
     case tribunal_case.case_type
     when CaseType::OTHER
-      MappingCode::APPL_OTHER
+      MappingCode::OTHERAPPEAL
     end
   end
 end

--- a/app/value_objects/mapping_code.rb
+++ b/app/value_objects/mapping_code.rb
@@ -1,13 +1,18 @@
 class MappingCode < ValueObject
   VALUES = [
-    APPL_PENALTY_LOW  = new(:appl_penalty_low),
-    APPL_PENALTY_MED  = new(:appl_penalty_med),
-    APPL_PENALTY_HIGH = new(:appl_penalty_high),
-    APPL_PAYECODING   = new(:appl_payecoding),
-    APPL_INFONOTICE   = new(:appl_infonotice),
-    APPL_OTHER        = new(:appl_other),
-    APPN_CLOSEENQUIRY = new(:appn_closeenquiry),
-    APPN_OTHER        = new(:appn_other)
+    TAXAMOUNTDISPUTE    = new(:taxamountdispute),
+    TAXPENALTYLOW       = new(:taxpenaltylow),
+    TAXPENALTYMED       = new(:taxpenaltymed),
+    TAXPENALTYHIGH      = new(:taxpenaltyhigh),
+    PAYECODING          = new(:payecoding),
+    ADVPAYNOTICEPENALTY = new(:advpaynoticepenalty),
+    INFONOTICEPENALTY   = new(:infonoticepenalty),
+    INACCURATERETURN    = new(:inaccuratereturn),
+    APPNTOCLOSE         = new(:appntoclose),
+    REQUESTREVIEW       = new(:requestreview),
+    APPNINFONOTICE      = new(:appninfonotice),
+    OTHERAPPEAL         = new(:otherappeal),
+    OTHERAPPLICATION    = new(:otherapplication)
   ].freeze
 
   def to_glimr_str

--- a/spec/services/glimr_fees_spec.rb
+++ b/spec/services/glimr_fees_spec.rb
@@ -5,50 +5,44 @@ RSpec.describe GlimrFees do
     let(:tribunal_case) { instance_double(TribunalCase, mapping_code: mapping_code) }
     subject { described_class.lodgement_fee_amount(tribunal_case) }
 
-    context 'with mapping code appl_penalty_low' do
-      let(:mapping_code) { MappingCode::APPL_PENALTY_LOW }
+    context 'with mapping code taxpenaltylow' do
+      let(:mapping_code) { MappingCode::TAXPENALTYLOW }
 
       it { is_expected.to eq(20_00) }
     end
 
-    context 'with mapping code appl_penalty_med' do
-      let(:mapping_code) { MappingCode::APPL_PENALTY_MED }
+    context 'with mapping code taxpenaltymed' do
+      let(:mapping_code) { MappingCode::TAXPENALTYMED }
 
       it { is_expected.to eq(50_00) }
     end
 
-    context 'with mapping code appl_penalty_high' do
-      let(:mapping_code) { MappingCode::APPL_PENALTY_HIGH }
+    context 'with mapping code payecoding' do
+      let(:mapping_code) { MappingCode::PAYECODING }
+
+      it { is_expected.to eq(50_00) }
+    end
+
+    context 'with mapping code appntoclose' do
+      let(:mapping_code) { MappingCode::APPNTOCLOSE }
+
+      it { is_expected.to eq(50_00) }
+    end
+
+    context 'with mapping code taxpenaltyhigh' do
+      let(:mapping_code) { MappingCode::TAXPENALTYHIGH }
 
       it { is_expected.to eq(200_00) }
     end
 
-    context 'with mapping code appl_payecoding' do
-      let(:mapping_code) { MappingCode::APPL_PAYECODING }
-
-      it { is_expected.to eq(50_00) }
-    end
-
-    context 'with mapping code appl_infonotice' do
-      let(:mapping_code) { MappingCode::APPL_INFONOTICE }
-
-      it { is_expected.to eq(50_00) }
-    end
-
-    context 'with mapping code appl_other' do
-      let(:mapping_code) { MappingCode::APPL_OTHER }
+    context 'with mapping code otherappeal' do
+      let(:mapping_code) { MappingCode::OTHERAPPEAL }
 
       it { is_expected.to eq(200_00) }
     end
 
-    context 'with mapping code appn_closeenquiry' do
-      let(:mapping_code) { MappingCode::APPN_CLOSEENQUIRY }
-
-      it { is_expected.to eq(50_00) }
-    end
-
-    context 'with mapping code appn_other' do
-      let(:mapping_code) { MappingCode::APPN_OTHER }
+    context 'with mapping code otherapplication' do
+      let(:mapping_code) { MappingCode::OTHERAPPLICATION }
 
       it { is_expected.to eq(200_00) }
     end

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe GlimrNewCase do
     let(:glimr_params) do
       {
         jurisdictionId: 8,
-        onlineMappingCode: 'APPL_PENALTY_LOW',
+        onlineMappingCode: 'TAXPENALTYLOW',
         documentsURL: 'http://downloader.com/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
         contactFirstName: 'Filomena',
         contactLastName: 'Keebler',
@@ -58,7 +58,7 @@ RSpec.describe GlimrNewCase do
       before do
         expect(GlimrApiClient::RegisterNewCase).to receive(:call).
           with(hash_including(glimr_params)).and_return(glimr_response_double)
-        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::APPL_PENALTY_LOW,)
+        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::TAXPENALTYLOW)
       end
 
       context 'registering the case into glimr' do
@@ -124,7 +124,7 @@ RSpec.describe GlimrNewCase do
       before do
         allow(GlimrApiClient::RegisterNewCase).to receive(:call).
           with(hash_including(glimr_params)).and_return(glimr_response_double)
-        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::APPL_PENALTY_LOW,)
+        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::TAXPENALTYLOW)
       end
 
       context 'when taxpayer_type is a company' do

--- a/spec/services/mapping_code_determiner_spec.rb
+++ b/spec/services/mapping_code_determiner_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe MappingCodeDeterminer do
   context 'when there is a penalty and it is level 1' do
     let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_1 }
 
-    it { is_expected.to have_mapping_code(:appl_penalty_low) }
+    it { is_expected.to have_mapping_code(:taxpenaltylow) }
   end
 
   context 'when there is a penalty and it is level 2' do
     let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_2 }
 
-    it { is_expected.to have_mapping_code(:appl_penalty_med) }
+    it { is_expected.to have_mapping_code(:taxpenaltymed) }
   end
 
   context 'when there is a penalty and it is level 3' do
     let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_3 }
 
-    it { is_expected.to have_mapping_code(:appl_penalty_high) }
+    it { is_expected.to have_mapping_code(:taxpenaltyhigh) }
   end
 
   context 'when there is a penalty but it is an unhandled value' do
@@ -49,37 +49,37 @@ RSpec.describe MappingCodeDeterminer do
   context 'when the dispute is an appeal against a PAYE coding notice' do
     let(:dispute_type) { DisputeType::PAYE_CODING_NOTICE }
 
-    it { is_expected.to have_mapping_code(:appl_payecoding) }
+    it { is_expected.to have_mapping_code(:payecoding) }
   end
 
   context 'when the dispute is an application for a decision on an enquiry' do
     let(:dispute_type) { DisputeType::DECISION_ON_ENQUIRY }
 
-    it { is_expected.to have_mapping_code(:appn_closeenquiry) }
+    it { is_expected.to have_mapping_code(:appntoclose) }
   end
 
   context 'when the dispute is an appeal against an information notice' do
     let(:dispute_type) { DisputeType::INFORMATION_NOTICE }
 
-    it { is_expected.to have_mapping_code(:appl_infonotice) }
+    it { is_expected.to have_mapping_code(:taxpenaltymed) }
   end
 
   context 'when the dispute is about amount of tax' do
     let(:dispute_type) { DisputeType::AMOUNT_OF_TAX }
 
-    it { is_expected.to have_mapping_code(:appl_other) }
+    it { is_expected.to have_mapping_code(:otherapplication) }
   end
 
   context 'when the dispute is about amount of tax and a penalty' do
     let(:dispute_type) { DisputeType::AMOUNT_AND_PENALTY }
 
-    it { is_expected.to have_mapping_code(:appl_other) }
+    it { is_expected.to have_mapping_code(:otherapplication) }
   end
 
   context 'when the dispute is about something else' do
     let(:dispute_type) { DisputeType::OTHER }
 
-    it { is_expected.to have_mapping_code(:appl_other) }
+    it { is_expected.to have_mapping_code(:otherapplication) }
   end
 
   context 'when the dispute is about penalty but there is no penalty amount' do
@@ -97,7 +97,7 @@ RSpec.describe MappingCodeDeterminer do
   context 'when the case type is about something else' do
     let(:case_type) { CaseType::OTHER }
 
-    it { is_expected.to have_mapping_code(:appl_other) }
+    it { is_expected.to have_mapping_code(:otherappeal) }
   end
 
   context 'when there is a case type but it is an unhandled value' do


### PR DESCRIPTION
We need to use the old versions of the mapping codes for now (despite
them being partly wrong and not exhaustive), because the new ones
haven't been loaded into GLiMR yet.