### PR TITLE
Link to payment app.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DATABASE_URL=postgresql://postgres@db/tax-tribunals-datacapture
 PAYMENT_ENDPOINT=http://localhost:4500
-PAYMENT_EXTERNAL_URL=http://localhost:3003/case_requests
+FEES_EXTERNAL_URL=http://localhost:3003/case_requests
 MOJ_FILE_UPLOADER_ENDPOINT=http://localhost:9292
 TAX_TRIBUNALS_DOWNLOADER_URL=http://localhost:9393
 GLIMR_API_URL=https://[hostname]/Live_API/api/tdsapi

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DATABASE_URL=postgresql://postgres@db/tax-tribunals-datacapture
 PAYMENT_ENDPOINT=http://localhost:4500
+PAYMENT_EXTERNAL_URL=http://localhost:3003/case_requests
 MOJ_FILE_UPLOADER_ENDPOINT=http://localhost:9292
 TAX_TRIBUNALS_DOWNLOADER_URL=http://localhost:9393
 GLIMR_API_URL=https://[hostname]/Live_API/api/tdsapi

--- a/.env.test.example
+++ b/.env.test.example
@@ -2,5 +2,6 @@
 DATABASE_URL=postgresql://postgres@db/tax-tribunals-datacapture_test
 
 PAYMENT_ENDPOINT=not-used-in-tests
+PAYMENT_EXTERNAL_URL=not-used-in-tests
 MOJ_FILE_UPLOADER_ENDPOINT=not-used-in-tests
 TAX_TRIBUNALS_DOWNLOADER_URL=not-used-in-tests

--- a/.env.test.example
+++ b/.env.test.example
@@ -2,6 +2,6 @@
 DATABASE_URL=postgresql://postgres@db/tax-tribunals-datacapture_test
 
 PAYMENT_ENDPOINT=not-used-in-tests
-PAYMENT_EXTERNAL_URL=not-used-in-tests
+FEES_EXTERNAL_URL=not-used-in-tests
 MOJ_FILE_UPLOADER_ENDPOINT=not-used-in-tests
 TAX_TRIBUNALS_DOWNLOADER_URL=not-used-in-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PUMA_PORT 3000
 ENV DATABASE_URL                 replace_this_at_build_time
 ENV GLIMR_API_URL                replace_this_at_build_time
 ENV PAYMENT_ENDPOINT             replace_this_at_build_time
+ENV PAYMENT_EXTERNAL_URL         replace_this_at_build_time
 ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PUMA_PORT 3000
 ENV DATABASE_URL                 replace_this_at_build_time
 ENV GLIMR_API_URL                replace_this_at_build_time
 ENV PAYMENT_ENDPOINT             replace_this_at_build_time
-ENV PAYMENT_EXTERNAL_URL         replace_this_at_build_time
+ENV FEES_EXTERNAL_URL            replace_this_at_build_time
 ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -5,6 +5,7 @@ ENV PUMA_PORT 3000
 ENV DATABASE_URL                 replace_this_at_build_time
 ENV GLIMR_API_URL                replace_this_at_build_time
 ENV PAYMENT_ENDPOINT             replace_this_at_build_time
+ENV PAYMENT_EXTERNAL_URL         replace_this_at_build_time
 ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -5,7 +5,7 @@ ENV PUMA_PORT 3000
 ENV DATABASE_URL                 replace_this_at_build_time
 ENV GLIMR_API_URL                replace_this_at_build_time
 ENV PAYMENT_ENDPOINT             replace_this_at_build_time
-ENV PAYMENT_EXTERNAL_URL         replace_this_at_build_time
+ENV FEES_EXTERNAL_URL            replace_this_at_build_time
 ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,16 @@
 class HomeController < ApplicationController
   def index
+    @link_sections = link_sections
+  end
+
+  private
+
+  # [task name, estimated time to complete this task, path to the task]
+  def link_sections
+    [
+      [:appeal, 30, task_list_path],
+      [:close, 15, '#'],
+      [:pay, 5, ENV.fetch('PAYMENT_EXTERNAL_URL')]
+    ]
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,12 +5,12 @@ class HomeController < ApplicationController
 
   private
 
-  # [task name, estimated time to complete this task, path to the task]
+  # [task name (used for i18n), estimated minutes to complete this task, path/url to the task]
   def link_sections
     [
       [:appeal, 30, task_list_path],
       [:close, 15, '#'],
-      [:pay, 5, ENV.fetch('PAYMENT_EXTERNAL_URL')]
+      [:pay, 5, ENV.fetch('FEES_EXTERNAL_URL')]
     ]
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,7 +6,7 @@
     <h1 class="heading-large"><%= t '.heading' %></h1>
 
     <ul class="list task-list">
-      <% [[:appeal, 30, task_list_path], [:close, 15, '#'], [:pay, 5, '#']].each do |(type, minutes, path)| %>
+      <% @link_sections.each do |(type, minutes, path)| %>
         <li>
           <%= link_to t('.link_titles.%s' % type), path, class: 'task-link' %>
           <p><%= t('.link_descriptions.%s' % type) %></p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,10 +6,10 @@
     <h1 class="heading-large"><%= t '.heading' %></h1>
 
     <ul class="list task-list">
-      <% @link_sections.each do |(type, minutes, path)| %>
+      <% @link_sections.each do |(name, minutes, path)| %>
         <li>
-          <%= link_to t('.link_titles.%s' % type), path, class: 'task-link' %>
-          <p><%= t('.link_descriptions.%s' % type) %></p>
+          <%= link_to t('.link_titles.%s' % name), path, class: 'task-link' %>
+          <p><%= t('.link_descriptions.%s' % name) %></p>
           <p>(<%= t('.link_time_estimate', minutes: minutes) %>)</p>
         </li>
       <% end %>

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe HomeController do
+  describe '#index' do
+    before do
+      expect(ENV).to receive(:fetch).with('PAYMENT_EXTERNAL_URL').and_return('http://payments.url')
+    end
+
+    it 'assigns the expected link sections' do
+      get :index
+
+      name, time, link = assigns[:link_sections][0]
+      expect(name).to eq(:appeal)
+      expect(time).to eq(30)
+      expect(link).to eq('/task_list')
+
+      name, time, link = assigns[:link_sections][1]
+      expect(name).to eq(:close)
+      expect(time).to eq(15)
+      expect(link).to eq('#')
+
+      name, time, link = assigns[:link_sections][2]
+      expect(name).to eq(:pay)
+      expect(time).to eq(5)
+      expect(link).to eq('http://payments.url')
+    end
+  end
+end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe HomeController do
   describe '#index' do
     before do
-      expect(ENV).to receive(:fetch).with('PAYMENT_EXTERNAL_URL').and_return('http://payments.url')
+      expect(ENV).to receive(:fetch).with('FEES_EXTERNAL_URL').and_return('http://payments.url')
     end
 
     it 'assigns the expected link sections' do


### PR DESCRIPTION
A new env variable FEES_EXTERNAL_URL has been exposed to store the URL
to the fees payment app page where the user will land when clicking in the
`pay for an existing appeal` link in the datacapture Home page.