### PR TITLE
Rename penalty_amount DB attribute to penalty_level.

### DIFF
--- a/app/controllers/steps/cost/penalty_amount_controller.rb
+++ b/app/controllers/steps/cost/penalty_amount_controller.rb
@@ -4,12 +4,12 @@ module Steps::Cost
       super
       @form_object = PenaltyAmountForm.new(
         tribunal_case: current_tribunal_case,
-        penalty_amount: current_tribunal_case.penalty_amount
+        penalty_level: current_tribunal_case.penalty_level
       )
     end
 
     def update
-      update_and_advance(PenaltyAmountForm)
+      update_and_advance(PenaltyAmountForm, as: :penalty_amount)
     end
   end
 end

--- a/app/forms/steps/cost/case_type_form.rb
+++ b/app/forms/steps/cost/case_type_form.rb
@@ -40,7 +40,7 @@ module Steps::Cost
         case_type: case_type_value,
         # The following are dependent attributes that need to be reset
         dispute_type: nil,
-        penalty_amount: nil
+        penalty_level: nil
       )
     end
   end

--- a/app/forms/steps/cost/case_type_show_more_form.rb
+++ b/app/forms/steps/cost/case_type_show_more_form.rb
@@ -27,7 +27,7 @@ module Steps::Cost
         case_type: case_type_value,
         # The following are dependent attributes that need to be reset
         dispute_type: nil,
-        penalty_amount: nil
+        penalty_level: nil
       )
     end
   end

--- a/app/forms/steps/cost/challenged_decision_form.rb
+++ b/app/forms/steps/cost/challenged_decision_form.rb
@@ -27,7 +27,7 @@ module Steps::Cost
         # The following are dependent attributes that need to be reset
         case_type: nil,
         dispute_type: nil,
-        penalty_amount: nil
+        penalty_level: nil
       )
     end
   end

--- a/app/forms/steps/cost/dispute_type_form.rb
+++ b/app/forms/steps/cost/dispute_type_form.rb
@@ -35,7 +35,7 @@ module Steps::Cost
       tribunal_case.update(
         dispute_type: dispute_type_value,
         # The following are dependent attributes that need to be reset
-        penalty_amount: nil
+        penalty_level: nil
       )
     end
   end

--- a/app/forms/steps/cost/penalty_amount_form.rb
+++ b/app/forms/steps/cost/penalty_amount_form.rb
@@ -1,21 +1,21 @@
 module Steps::Cost
   class PenaltyAmountForm < BaseForm
-    attribute :penalty_amount, String
+    attribute :penalty_level, String
 
     def self.choices
-      PenaltyAmount.values.map(&:to_s)
+      PenaltyLevel.values.map(&:to_s)
     end
-    validates_inclusion_of :penalty_amount, in: choices
+    validates_inclusion_of :penalty_level, in: choices
 
     private
 
-    def penalty_amount_value
-      PenaltyAmount.new(penalty_amount)
+    def penalty_level_value
+      PenaltyLevel.new(penalty_level)
     end
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      tribunal_case.update(penalty_amount: penalty_amount_value)
+      tribunal_case.update(penalty_level: penalty_level_value)
     end
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -3,7 +3,7 @@ class TribunalCase < ApplicationRecord
   has_value_object :challenged_decision
   has_value_object :case_type, constructor: :find_constant
   has_value_object :dispute_type
-  has_value_object :penalty_amount
+  has_value_object :penalty_level
 
   # Hardship task
   has_value_object :disputed_tax_paid

--- a/app/presenters/change_cost_answers_presenter.rb
+++ b/app/presenters/change_cost_answers_presenter.rb
@@ -4,7 +4,7 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       challenged_decision_question,
       case_type_question,
       dispute_type_question,
-      penalty_amount_question,
+      penalty_level_question,
       disputed_tax_paid_question,
       hardship_review_requested_question,
       hardship_review_status_question
@@ -37,10 +37,10 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
     )
   end
 
-  def penalty_amount_question
+  def penalty_level_question
     row(
-      tribunal_case.penalty_amount,
-      as: :penalty_amount,
+      tribunal_case.penalty_level,
+      as: :penalty_level,
       change_path: edit_steps_cost_penalty_amount_path
     )
   end

--- a/app/presenters/fee_details_answers_presenter.rb
+++ b/app/presenters/fee_details_answers_presenter.rb
@@ -6,7 +6,7 @@ class FeeDetailsAnswersPresenter < BaseAnswersPresenter
       challenged_decision_question,
       case_type_question,
       dispute_type_question,
-      penalty_amount_question,
+      penalty_level_question,
       fee_amount_question
     ].compact
   end
@@ -35,10 +35,10 @@ class FeeDetailsAnswersPresenter < BaseAnswersPresenter
     )
   end
 
-  def penalty_amount_question
+  def penalty_level_question
     row(
-      tribunal_case.penalty_amount,
-      as: :penalty_amount
+      tribunal_case.penalty_level,
+      as: :penalty_level
     )
   end
 

--- a/app/services/hardship_decision_tree.rb
+++ b/app/services/hardship_decision_tree.rb
@@ -48,7 +48,7 @@ class HardshipDecisionTree < DecisionTree
   end
 
   def before_disputed_tax_paid_step
-    if tribunal_case.penalty_amount?
+    if tribunal_case.penalty_level?
       { controller: '/steps/cost/penalty_amount', action: :edit }
     else
       { controller: '/steps/cost/dispute_type', action: :edit }

--- a/app/services/mapping_code_determiner.rb
+++ b/app/services/mapping_code_determiner.rb
@@ -17,7 +17,7 @@ class MappingCodeDeterminer
   private
 
   def mapping_code_or_nil
-    if tribunal_case.penalty_amount
+    if tribunal_case.penalty_level
       penalty_mapping_code
     elsif tribunal_case.dispute_type
       dispute_type_mapping_code
@@ -28,12 +28,12 @@ class MappingCodeDeterminer
 
   def penalty_mapping_code
     # TODO: Replace with correct mapping codes once they have been agreed on
-    case tribunal_case.penalty_amount
-    when PenaltyAmount::PENALTY_LEVEL_1
+    case tribunal_case.penalty_level
+    when PenaltyLevel::PENALTY_LEVEL_1
       MappingCode::TAXPENALTYLOW
-    when PenaltyAmount::PENALTY_LEVEL_2
+    when PenaltyLevel::PENALTY_LEVEL_2
       MappingCode::TAXPENALTYMED
-    when PenaltyAmount::PENALTY_LEVEL_3
+    when PenaltyLevel::PENALTY_LEVEL_3
       MappingCode::TAXPENALTYHIGH
     end
   end

--- a/app/value_objects/penalty_level.rb
+++ b/app/value_objects/penalty_level.rb
@@ -1,4 +1,4 @@
-class PenaltyAmount < ValueObject
+class PenaltyLevel < ValueObject
   VALUES = [
     PENALTY_LEVEL_1 = new(:penalty_level_1),
     PENALTY_LEVEL_2 = new(:penalty_level_2),

--- a/app/views/steps/cost/penalty_amount/edit.html.erb
+++ b/app/views/steps/cost/penalty_amount/edit.html.erb
@@ -7,7 +7,7 @@
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :penalty_amount,
+      <%= f.radio_button_fieldset :penalty_level,
         choices: Steps::Cost::PenaltyAmountForm.choices %>
       <%= f.submit class: 'button' %>
     <% end %>

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -125,7 +125,7 @@ en:
             challenged_decision: Did you challenge the decision with HMRC first?
             case_type: What is your appeal about?
             dispute_type: What is your dispute about?
-            penalty_amount: What is the penalty or surcharge amount?
+            penalty_level: What is the penalty or surcharge amount?
             disputed_tax_paid: Have you paid the amount of tax involved in the dispute?
             hardship_review_requested: Did you apply for financial hardship?
             hardship_review_status: What is the status of your hardship application?
@@ -169,7 +169,7 @@ en:
               amount_and_penalty: Amount of tax and a penalty or surcharge
               information_notice: Appeal against an information notice
               other: Other
-            penalty_amount:
+            penalty_level:
               penalty_level_1: £100 or less
               penalty_level_2: £101 – £20,000
               penalty_level_3: £20,001 or more
@@ -213,7 +213,7 @@ en:
               inclusion: Select what your dispute is about
         steps/cost/penalty_amount_form:
           attributes:
-            penalty_amount:
+            penalty_level:
               inclusion: Select what the penalty or surcharge amount is
   helpers:
     fieldset:
@@ -226,7 +226,7 @@ en:
       steps_cost_dispute_type_form:
         dispute_type: What is your dispute about?
       steps_cost_penalty_amount_form:
-        penalty_amount: What is the penalty or surcharge amount?
+        penalty_level: What is the penalty or surcharge amount?
     label:
       steps_cost_challenged_decision_form:
         challenged_decision:
@@ -276,7 +276,7 @@ en:
           information_notice_html: <strong>Appeal against an information notice</strong>
           other_html: <strong>None of the above</strong>
       steps_cost_penalty_amount_form:
-        penalty_amount:
+        penalty_level:
           penalty_level_1: £100 or less
           penalty_level_2: £101 – £20,000
           penalty_level_3: £20,001 or more

--- a/config/locales/details.pdf.yml
+++ b/config/locales/details.pdf.yml
@@ -12,7 +12,7 @@ en:
           show:
             questions:
               challenged_decision: Decision challenged with HMRC?
-              penalty_amount: Penalty or surcharge amount
+              penalty_level: Penalty or surcharge amount
               lateness_reason: Reason for lateness?
             answers:
               # Insert here custom translations for answers

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -94,7 +94,7 @@ en:
             challenged_decision: Did you challenge the decision with HMRC first?
             case_type: What is your appeal about?
             dispute_type: What is your dispute about?
-            penalty_amount: What is the penalty or surcharge amount?
+            penalty_level: What is the penalty or surcharge amount?
             fee_amount: Fee
             in_time: Is this application late?
             lateness_reason: Reason(s) for late application
@@ -125,7 +125,7 @@ en:
               amount_of_tax: Amount of tax
               amount_and_penalty: Amount of tax and a penalty or surcharge
               other: Other
-            penalty_amount:
+            penalty_level:
               penalty_level_1: £100 or less
               penalty_level_2: £101 – £20,000
               penalty_level_3: £20,001 or more

--- a/db/migrate/20170118103849_rename_penalty_amount_to_penalty_level.rb
+++ b/db/migrate/20170118103849_rename_penalty_amount_to_penalty_level.rb
@@ -1,0 +1,5 @@
+class RenamePenaltyAmountToPenaltyLevel < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :tribunal_cases, :penalty_amount, :penalty_level
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170111094739) do
+ActiveRecord::Schema.define(version: 20170118103849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20170111094739) do
     t.datetime "updated_at",                                                                 null: false
     t.string   "case_type"
     t.string   "dispute_type"
-    t.string   "penalty_amount"
+    t.string   "penalty_level"
     t.string   "in_time"
     t.text     "lateness_reason"
     t.string   "taxpayer_type"

--- a/spec/forms/steps/cost/case_type_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Steps::Cost::CaseTypeForm do
         expect(tribunal_case).to receive(:update).with(
           case_type: case_type_object,
           dispute_type: nil,
-          penalty_amount: nil
+          penalty_level: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_show_more_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Steps::Cost::CaseTypeShowMoreForm do
         expect(tribunal_case).to receive(:update).with(
           case_type: case_type_object,
           dispute_type: nil,
-          penalty_amount: nil
+          penalty_level: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/challenged_decision_form_spec.rb
+++ b/spec/forms/steps/cost/challenged_decision_form_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Steps::Cost::ChallengedDecisionForm do
           challenged_decision: ChallengedDecision::NO,
           case_type: nil,
           dispute_type: nil,
-          penalty_amount: nil
+          penalty_level: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/dispute_type_form_spec.rb
+++ b/spec/forms/steps/cost/dispute_type_form_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           dispute_type: DisputeType::PENALTY,
-          penalty_amount: nil
+          penalty_level: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/penalty_amount_form_spec.rb
+++ b/spec/forms/steps/cost/penalty_amount_form_spec.rb
@@ -2,37 +2,37 @@ require 'spec_helper'
 
 RSpec.describe Steps::Cost::PenaltyAmountForm do
   let(:arguments) { {
-    tribunal_case:  tribunal_case,
-    penalty_amount: penalty_amount
+    tribunal_case: tribunal_case,
+    penalty_level: penalty_level
   } }
-  let(:tribunal_case)         { instance_double(TribunalCase, penalty_amount: nil) }
-  let(:penalty_amount) { nil }
+  let(:tribunal_case) { instance_double(TribunalCase, penalty_level: nil) }
+  let(:penalty_level) { nil }
 
   subject { described_class.new(arguments) }
 
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)  { nil }
-      let(:penalty_amount) { 'penalty_level_1' }
+      let(:tribunal_case) { nil }
+      let(:penalty_level) { 'penalty_level_1' }
 
       it 'raises an error' do
         expect { subject.save }.to raise_error(RuntimeError)
       end
     end
 
-    context 'when penalty_amount is not given' do
+    context 'when penalty_level is not given' do
       it 'returns false' do
         expect(subject.save).to be(false)
       end
 
       it 'has a validation error on the field' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:penalty_amount]).to_not be_empty
+        expect(subject.errors[:penalty_level]).to_not be_empty
       end
     end
 
-    context 'when penalty_amount is not valid' do
-      let(:penalty_amount) { 'loads-of-$$$' }
+    context 'when penalty_level is not valid' do
+      let(:penalty_level) { 'loads-of-$$$' }
 
       it 'returns false' do
         expect(subject.save).to be(false)
@@ -40,16 +40,16 @@ RSpec.describe Steps::Cost::PenaltyAmountForm do
 
       it 'has a validation error on the field' do
         expect(subject).to_not be_valid
-        expect(subject.errors[:penalty_amount]).to_not be_empty
+        expect(subject.errors[:penalty_level]).to_not be_empty
       end
     end
 
-    context 'when penalty_amount is valid' do
-      let(:penalty_amount) { 'penalty_level_1' }
+    context 'when penalty_level is valid' do
+      let(:penalty_level) { 'penalty_level_1' }
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          penalty_amount: PenaltyAmount::PENALTY_LEVEL_1
+          penalty_level: PenaltyLevel::PENALTY_LEVEL_1
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CheckAnswersHelper do
   describe '#pdf_t' do
     # These are just 2 keys to perform a quick sanity check of the method.
     # If ever changed or removed, any other keys can be used instead.
-    let(:found_key) { '.questions.penalty_amount' }
+    let(:found_key) { '.questions.penalty_level' }
     let(:cascaded_key) { '.questions.fee_amount' }
 
     before do

--- a/spec/presenters/change_cost_answers_presenter_spec.rb
+++ b/spec/presenters/change_cost_answers_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ChangeCostAnswersPresenter do
       challenged_decision: challenged_decision,
       case_type: case_type,
       dispute_type: dispute_type,
-      penalty_amount: penalty_amount,
+      penalty_level: penalty_level,
       disputed_tax_paid: disputed_tax_paid,
       hardship_review_requested: hardship_review_requested,
       hardship_review_status: hardship_review_status
@@ -19,7 +19,7 @@ RSpec.describe ChangeCostAnswersPresenter do
   let(:challenged_decision)       { true }
   let(:case_type)                 { 'foo' }
   let(:dispute_type)              { nil }
-  let(:penalty_amount)            { nil }
+  let(:penalty_level)             { nil }
   let(:disputed_tax_paid)         { nil }
   let(:hardship_review_requested) { nil }
   let(:hardship_review_status)    { nil }
@@ -94,27 +94,27 @@ RSpec.describe ChangeCostAnswersPresenter do
       end
     end
 
-    describe '`penalty_amount` row' do
+    describe '`penalty_level` row' do
       let(:row) { subject.rows[3] }
 
       # Needed so that the row is in the correct position
       let(:dispute_type) { 'foo' }
       let(:case_type) { 'bar' }
 
-      context 'when `penalty_amount` is nil' do
-        let(:penalty_amount) { nil }
+      context 'when `penalty_level` is nil' do
+        let(:penalty_level) { nil }
 
         it 'is not included' do
           expect(row).to be_nil
         end
       end
 
-      context 'when `penalty_amount` is given' do
-        let(:penalty_amount)  { 'foo' }
+      context 'when `penalty_level` is given' do
+        let(:penalty_level)  { 'foo' }
 
         it 'has the correct attributes' do
-          expect(row.question).to    eq('.questions.penalty_amount')
-          expect(row.answer).to      eq('.answers.penalty_amount.foo')
+          expect(row.question).to    eq('.questions.penalty_level')
+          expect(row.answer).to      eq('.answers.penalty_level.foo')
           expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
         end
       end

--- a/spec/presenters/fee_details_answers_presenter_spec.rb
+++ b/spec/presenters/fee_details_answers_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
       challenged_decision: challenged_decision,
       case_type: case_type,
       dispute_type: dispute_type,
-      penalty_amount: penalty_amount,
+      penalty_level: penalty_level,
       lodgement_fee: lodgement_fee
     )
   }
@@ -17,7 +17,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
   let(:challenged_decision) { true }
   let(:case_type)           { 'foo' }
   let(:dispute_type)        { nil }
-  let(:penalty_amount)      { nil }
+  let(:penalty_level)       { nil }
   let(:lodgement_fee)       { nil }
 
   describe '#rows' do
@@ -94,27 +94,27 @@ RSpec.describe FeeDetailsAnswersPresenter do
       end
     end
 
-    describe '`penalty_amount` row' do
+    describe '`penalty_level` row' do
       let(:row) { subject.rows[3] }
 
       # Needed so that the row is in the correct position
       let(:dispute_type) { 'foo' }
       let(:case_type) { 'bar' }
 
-      context 'when `penalty_amount` is nil' do
-        let(:penalty_amount) { nil }
+      context 'when `penalty_level` is nil' do
+        let(:penalty_level) { nil }
 
         it 'is not included' do
           expect(row).to be_nil
         end
       end
 
-      context 'when `penalty_amount` is given' do
-        let(:penalty_amount) { 'foo' }
+      context 'when `penalty_level` is given' do
+        let(:penalty_level) { 'foo' }
 
         it 'has the correct attributes' do
-          expect(row.question).to    eq('.questions.penalty_amount')
-          expect(row.answer).to      eq('.answers.penalty_amount.foo')
+          expect(row.question).to    eq('.questions.penalty_level')
+          expect(row.answer).to      eq('.answers.penalty_level.foo')
           expect(row.change_path).to be_nil
         end
       end
@@ -126,7 +126,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
       # Needed so that the row is in the correct position
       let(:dispute_type) { 'foo' }
       let(:case_type) { 'bar' }
-      let(:penalty_amount) { 'foo' }
+      let(:penalty_level) { 'foo' }
 
       context 'when `lodgement_fee` is nil' do
         let(:lodgement_fee) { nil }

--- a/spec/services/hardship_decision_tree_spec.rb
+++ b/spec/services/hardship_decision_tree_spec.rb
@@ -59,16 +59,16 @@ RSpec.describe HardshipDecisionTree do
   describe '#previous' do
     context 'when the step is `disputed_tax_paid`' do
       let(:step_params) { { disputed_tax_paid: 'anything' } }
-      let(:tribunal_case) { instance_double(TribunalCase, penalty_amount?: has_penalty_amount) }
+      let(:tribunal_case) { instance_double(TribunalCase, penalty_level?: has_penalty_level) }
 
       context 'when the tribunal_case has a penalty' do
-        let(:has_penalty_amount) { true }
+        let(:has_penalty_level) { true }
 
         it { is_expected.to have_previous('/steps/cost/penalty_amount', :edit) }
       end
 
       context 'when the tribunal_case does not have a penalty' do
-        let(:has_penalty_amount) { false }
+        let(:has_penalty_level) { false }
 
         it { is_expected.to have_previous('/steps/cost/dispute_type', :edit) }
       end

--- a/spec/services/mapping_code_determiner_spec.rb
+++ b/spec/services/mapping_code_determiner_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe MappingCodeDeterminer do
       challenged_decision: challenged_decision,
       case_type:           case_type,
       dispute_type:        dispute_type,
-      penalty_amount:      penalty_amount
+      penalty_level:       penalty_level
     )
   }
 
   let(:challenged_decision) { nil }
   let(:case_type)           { nil }
   let(:dispute_type)        { nil }
-  let(:penalty_amount)      { nil }
+  let(:penalty_level)       { nil }
 
   subject { described_class.new(tribunal_case) }
 
@@ -23,25 +23,25 @@ RSpec.describe MappingCodeDeterminer do
   end
 
   context 'when there is a penalty and it is level 1' do
-    let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_1 }
+    let(:penalty_level) { PenaltyLevel::PENALTY_LEVEL_1 }
 
     it { is_expected.to have_mapping_code(:taxpenaltylow) }
   end
 
   context 'when there is a penalty and it is level 2' do
-    let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_2 }
+    let(:penalty_level) { PenaltyLevel::PENALTY_LEVEL_2 }
 
     it { is_expected.to have_mapping_code(:taxpenaltymed) }
   end
 
   context 'when there is a penalty and it is level 3' do
-    let(:penalty_amount) { PenaltyAmount::PENALTY_LEVEL_3 }
+    let(:penalty_level) { PenaltyLevel::PENALTY_LEVEL_3 }
 
     it { is_expected.to have_mapping_code(:taxpenaltyhigh) }
   end
 
   context 'when there is a penalty but it is an unhandled value' do
-    let(:penalty_amount) { PenaltyAmount.new('$^&%*') }
+    let(:penalty_level) { PenaltyLevel.new('$^&%*') }
 
     it { is_expected.to fail_to_determine_mapping_code }
   end


### PR DESCRIPTION
This is a first PR needed for a further introduction of a new `penalty_amount` attribute,
which is going to be free text and will be filled by the user, in addition to choosing
the penalty level as it is now. This the renaming of the current `penalty_amount` attribute
to something more meaninful.