### PR TITLE
Optionally ask for a penalty amount (free text) depending on radio buttons.

### DIFF
--- a/app/assets/javascripts/modules/custom-radio-toggles.js
+++ b/app/assets/javascripts/modules/custom-radio-toggles.js
@@ -1,0 +1,39 @@
+'use strict';
+
+moj.Modules.customRadioToggles = {
+  config: {
+    $targetElement: null, // the element to be shown or to hide
+    $showElements: [],    // collection of elements that triggers the showing of the target element
+    $hideElements: []     // collection of elements that triggers the hiding of the target element
+  },
+
+  init: function () {
+    if (!this.config.$targetElement) { return }
+
+    this.hideElementUnlessRelevant();
+    this.bindEvents();
+  },
+
+  bindEvents: function () {
+    var self = this;
+
+    self.config.$showElements.each(function () {
+      $(this).on('click', function () { self.showElement() });
+    });
+
+    self.config.$hideElements.each(function () {
+      $(this).on('click', function () { self.hideElementUnlessRelevant() });
+    });
+  },
+
+  showElement: function () {
+    this.config.$targetElement.show();
+  },
+
+  hideElementUnlessRelevant: function () {
+    if (this.config.$showElements.filter($(':checked')).length) { return }
+
+    this.config.$targetElement.find('input').val('');
+    this.config.$targetElement.hide();
+  }
+};

--- a/app/controllers/steps/cost/penalty_amount_controller.rb
+++ b/app/controllers/steps/cost/penalty_amount_controller.rb
@@ -3,8 +3,9 @@ module Steps::Cost
     def edit
       super
       @form_object = PenaltyAmountForm.new(
-        tribunal_case: current_tribunal_case,
-        penalty_level: current_tribunal_case.penalty_level
+        tribunal_case:  current_tribunal_case,
+        penalty_level:  current_tribunal_case.penalty_level,
+        penalty_amount: current_tribunal_case.penalty_amount,
       )
     end
 

--- a/app/forms/steps/cost/penalty_amount_form.rb
+++ b/app/forms/steps/cost/penalty_amount_form.rb
@@ -1,6 +1,7 @@
 module Steps::Cost
   class PenaltyAmountForm < BaseForm
     attribute :penalty_level, String
+    attribute :penalty_amount, String
 
     def self.choices
       PenaltyLevel.values.map(&:to_s)
@@ -15,7 +16,10 @@ module Steps::Cost
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      tribunal_case.update(penalty_level: penalty_level_value)
+      tribunal_case.update(
+        penalty_level: penalty_level_value,
+        penalty_amount: penalty_amount
+      )
     end
   end
 end

--- a/app/presenters/change_cost_answers_presenter.rb
+++ b/app/presenters/change_cost_answers_presenter.rb
@@ -5,6 +5,7 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       case_type_question,
       dispute_type_question,
       penalty_level_question,
+      penalty_amount_question,
       disputed_tax_paid_question,
       hardship_review_requested_question,
       hardship_review_status_question
@@ -41,6 +42,15 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
     row(
       tribunal_case.penalty_level,
       as: :penalty_level,
+      change_path: edit_steps_cost_penalty_amount_path
+    )
+  end
+
+  def penalty_amount_question
+    row(
+      tribunal_case.penalty_amount,
+      as: :penalty_amount,
+      i18n_value: false,
       change_path: edit_steps_cost_penalty_amount_path
     )
   end

--- a/app/presenters/fee_details_answers_presenter.rb
+++ b/app/presenters/fee_details_answers_presenter.rb
@@ -7,6 +7,7 @@ class FeeDetailsAnswersPresenter < BaseAnswersPresenter
       case_type_question,
       dispute_type_question,
       penalty_level_question,
+      penalty_amount_question,
       fee_amount_question
     ].compact
   end
@@ -39,6 +40,14 @@ class FeeDetailsAnswersPresenter < BaseAnswersPresenter
     row(
       tribunal_case.penalty_level,
       as: :penalty_level
+    )
+  end
+
+  def penalty_amount_question
+    row(
+      tribunal_case.penalty_amount,
+      as: :penalty_amount,
+      i18n_value: false
     )
   end
 

--- a/app/views/steps/cost/penalty_amount/edit.html.erb
+++ b/app/views/steps/cost/penalty_amount/edit.html.erb
@@ -9,7 +9,22 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :penalty_level,
         choices: Steps::Cost::PenaltyAmountForm.choices %>
+
+      <div class="panel toggleable" id="penalty_amount_detail" aria-hidden="true">
+        <%= f.text_field :penalty_amount, class: 'form-control' %>
+      </div>
+
       <%= f.submit class: 'button' %>
+    <% end %>
+
+    <%= javascript_tag do %>
+      //
+      // This is a hack because we want two out of three radio buttons to show the amount field,
+      // and that is not possible to do with the current gov.uk elements form builder version.
+      //
+      moj.Modules.customRadioToggles.config.$targetElement = $('#penalty_amount_detail');
+      moj.Modules.customRadioToggles.config.$showElements  = $('form input:radio:not(:first)');
+      moj.Modules.customRadioToggles.config.$hideElements  = $('form input:radio:first');
     <% end %>
   </div>
 </div>

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -116,6 +116,9 @@ en:
         edit:
           heading: What is the penalty or surcharge amount?
           lead_text: Select an option below based on the amount shown on the original notice letter or review conclusion letter you received from HMRC.
+          penalty_level_1: £100 or less
+          penalty_level_2: over £100 – £20,000
+          penalty_level_3: over £20,000
       determine_cost:
         show:
           fee_label: To submit your appeal you will have to pay
@@ -126,6 +129,7 @@ en:
             case_type: What is your appeal about?
             dispute_type: What is your dispute about?
             penalty_level: What is the penalty or surcharge amount?
+            penalty_amount: What is the penalty or surcharge amount?
             disputed_tax_paid: Have you paid the amount of tax involved in the dispute?
             hardship_review_requested: Did you apply for financial hardship?
             hardship_review_status: What is the status of your hardship application?
@@ -171,8 +175,8 @@ en:
               other: Other
             penalty_level:
               penalty_level_1: £100 or less
-              penalty_level_2: £101 – £20,000
-              penalty_level_3: £20,001 or more
+              penalty_level_2: over £100 – £20,000
+              penalty_level_3: over £20,000
             disputed_tax_paid:
               'no': 'No'
               'yes': 'Yes'
@@ -226,7 +230,8 @@ en:
       steps_cost_dispute_type_form:
         dispute_type: What is your dispute about?
       steps_cost_penalty_amount_form:
-        penalty_level: What is the penalty or surcharge amount?
+        # Use empty string in _html keys to not show the fieldset legend
+        penalty_level_html: ""
     label:
       steps_cost_challenged_decision_form:
         challenged_decision:
@@ -276,7 +281,8 @@ en:
           information_notice_html: <strong>Appeal against an information notice</strong>
           other_html: <strong>None of the above</strong>
       steps_cost_penalty_amount_form:
+        penalty_amount: What is the penalty or surcharge amount? (Optional)
         penalty_level:
           penalty_level_1: £100 or less
-          penalty_level_2: £101 – £20,000
-          penalty_level_3: £20,001 or more
+          penalty_level_2: over £100 – £20,000
+          penalty_level_3: over £20,000

--- a/config/locales/details.pdf.yml
+++ b/config/locales/details.pdf.yml
@@ -13,6 +13,7 @@ en:
             questions:
               challenged_decision: Decision challenged with HMRC?
               penalty_level: Penalty or surcharge amount
+              penalty_amount: Penalty or surcharge amount
               lateness_reason: Reason for lateness?
             answers:
               # Insert here custom translations for answers

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -127,8 +127,8 @@ en:
               other: Other
             penalty_level:
               penalty_level_1: £100 or less
-              penalty_level_2: £101 – £20,000
-              penalty_level_3: £20,001 or more
+              penalty_level_2: over £100 – £20,000
+              penalty_level_3: over £20,000
             in_time: # The question we are answering is if we are late, thus if YES, we are NOT on time, and vice versa
               yes: No
               no: Yes

--- a/db/migrate/20170118150453_add_penalty_amount_to_tribunal_case.rb
+++ b/db/migrate/20170118150453_add_penalty_amount_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddPenaltyAmountToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :penalty_amount, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118103849) do
+ActiveRecord::Schema.define(version: 20170118150453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20170118103849) do
     t.string   "hardship_review_requested"
     t.string   "hardship_review_status"
     t.string   "case_reference"
+    t.string   "penalty_amount"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/forms/steps/cost/penalty_amount_form_spec.rb
+++ b/spec/forms/steps/cost/penalty_amount_form_spec.rb
@@ -3,10 +3,12 @@ require 'spec_helper'
 RSpec.describe Steps::Cost::PenaltyAmountForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
-    penalty_level: penalty_level
+    penalty_level: penalty_level,
+    penalty_amount: penalty_amount
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, penalty_level: nil) }
-  let(:penalty_level) { nil }
+  let(:tribunal_case) { instance_double(TribunalCase, penalty_level: nil, penalty_amount: nil) }
+  let(:penalty_level)  { nil }
+  let(:penalty_amount) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -49,9 +51,22 @@ RSpec.describe Steps::Cost::PenaltyAmountForm do
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          penalty_level: PenaltyLevel::PENALTY_LEVEL_1
+          penalty_level: PenaltyLevel::PENALTY_LEVEL_1,
+          penalty_amount: nil
         ).and_return(true)
         expect(subject.save).to be(true)
+      end
+
+      context 'when penalty amount supplied' do
+        let(:penalty_amount) { 'about 12345' }
+
+        it 'saves the record' do
+          expect(tribunal_case).to receive(:update).with(
+            penalty_level: PenaltyLevel::PENALTY_LEVEL_1,
+            penalty_amount: 'about 12345'
+          ).and_return(true)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end

--- a/spec/presenters/change_cost_answers_presenter_spec.rb
+++ b/spec/presenters/change_cost_answers_presenter_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ChangeCostAnswersPresenter do
       case_type: case_type,
       dispute_type: dispute_type,
       penalty_level: penalty_level,
+      penalty_amount: penalty_amount,
       disputed_tax_paid: disputed_tax_paid,
       hardship_review_requested: hardship_review_requested,
       hardship_review_status: hardship_review_status
@@ -20,6 +21,7 @@ RSpec.describe ChangeCostAnswersPresenter do
   let(:case_type)                 { 'foo' }
   let(:dispute_type)              { nil }
   let(:penalty_level)             { nil }
+  let(:penalty_amount)            { nil }
   let(:disputed_tax_paid)         { nil }
   let(:hardship_review_requested) { nil }
   let(:hardship_review_status)    { nil }
@@ -115,6 +117,33 @@ RSpec.describe ChangeCostAnswersPresenter do
         it 'has the correct attributes' do
           expect(row.question).to    eq('.questions.penalty_level')
           expect(row.answer).to      eq('.answers.penalty_level.foo')
+          expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
+        end
+      end
+    end
+
+    describe '`penalty_amount` row' do
+      let(:row) { subject.rows[4] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+      let(:penalty_level) { 'foo' }
+
+      context 'when `penalty_amount` is nil' do
+        let(:penalty_amount) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `penalty_amount` is given' do
+        let(:penalty_amount)  { 'about 12345' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.penalty_amount')
+          expect(row.answer).to      eq('about 12345')
           expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
         end
       end

--- a/spec/presenters/fee_details_answers_presenter_spec.rb
+++ b/spec/presenters/fee_details_answers_presenter_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
       case_type: case_type,
       dispute_type: dispute_type,
       penalty_level: penalty_level,
+      penalty_amount: penalty_amount,
       lodgement_fee: lodgement_fee
     )
   }
@@ -18,6 +19,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
   let(:case_type)           { 'foo' }
   let(:dispute_type)        { nil }
   let(:penalty_level)       { nil }
+  let(:penalty_amount)      { nil }
   let(:lodgement_fee)       { nil }
 
   describe '#rows' do
@@ -115,6 +117,33 @@ RSpec.describe FeeDetailsAnswersPresenter do
         it 'has the correct attributes' do
           expect(row.question).to    eq('.questions.penalty_level')
           expect(row.answer).to      eq('.answers.penalty_level.foo')
+          expect(row.change_path).to be_nil
+        end
+      end
+    end
+
+    describe '`penalty_amount` row' do
+      let(:row) { subject.rows[4] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+      let(:penalty_level) { 'foo' }
+
+      context 'when `penalty_amount` is nil' do
+        let(:penalty_amount) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `penalty_amount` is given' do
+        let(:penalty_amount)  { 'about 12345' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.penalty_amount')
+          expect(row.answer).to      eq('about 12345')
           expect(row.change_path).to be_nil
         end
       end


### PR DESCRIPTION
This PR is a continuation to #103 and introduces a new DB attribute, `penalty_amount`
which will allow us to store a free text given by a user.

The input field will show or hide according to the prototype when selecting specific
radio buttons, and because of this, some custom javascript was written to handle it,
as govuk elements form builder wouldn't allow us to have this specific behaviour.

The javascript should be generic enough to be used for any other step behaving in a
similar way.