### PR TITLE
Ask the amount of disputed tax.

### DIFF
--- a/app/controllers/steps/cost/tax_amount_controller.rb
+++ b/app/controllers/steps/cost/tax_amount_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Cost
+  class TaxAmountController < Steps::CostStepController
+    def edit
+      super
+      @form_object = TaxAmountForm.new(
+        tribunal_case: current_tribunal_case,
+        tax_amount: current_tribunal_case.tax_amount
+      )
+    end
+
+    def update
+      update_and_advance(TaxAmountForm)
+    end
+  end
+end

--- a/app/forms/steps/cost/case_type_form.rb
+++ b/app/forms/steps/cost/case_type_form.rb
@@ -40,7 +40,9 @@ module Steps::Cost
         case_type: case_type_value,
         # The following are dependent attributes that need to be reset
         dispute_type: nil,
-        penalty_level: nil
+        penalty_level: nil,
+        penalty_amount: nil,
+        tax_amount: nil
       )
     end
   end

--- a/app/forms/steps/cost/case_type_show_more_form.rb
+++ b/app/forms/steps/cost/case_type_show_more_form.rb
@@ -27,7 +27,9 @@ module Steps::Cost
         case_type: case_type_value,
         # The following are dependent attributes that need to be reset
         dispute_type: nil,
-        penalty_level: nil
+        penalty_level: nil,
+        penalty_amount: nil,
+        tax_amount: nil
       )
     end
   end

--- a/app/forms/steps/cost/challenged_decision_form.rb
+++ b/app/forms/steps/cost/challenged_decision_form.rb
@@ -27,7 +27,9 @@ module Steps::Cost
         # The following are dependent attributes that need to be reset
         case_type: nil,
         dispute_type: nil,
-        penalty_level: nil
+        penalty_level: nil,
+        penalty_amount: nil,
+        tax_amount: nil
       )
     end
   end

--- a/app/forms/steps/cost/dispute_type_form.rb
+++ b/app/forms/steps/cost/dispute_type_form.rb
@@ -35,7 +35,9 @@ module Steps::Cost
       tribunal_case.update(
         dispute_type: dispute_type_value,
         # The following are dependent attributes that need to be reset
-        penalty_level: nil
+        penalty_level: nil,
+        penalty_amount: nil,
+        tax_amount: nil
       )
     end
   end

--- a/app/forms/steps/cost/tax_amount_form.rb
+++ b/app/forms/steps/cost/tax_amount_form.rb
@@ -1,0 +1,12 @@
+module Steps::Cost
+  class TaxAmountForm < BaseForm
+    attribute :tax_amount, String
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      tribunal_case.update(tax_amount: tax_amount)
+    end
+  end
+end

--- a/app/presenters/change_cost_answers_presenter.rb
+++ b/app/presenters/change_cost_answers_presenter.rb
@@ -6,6 +6,7 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       dispute_type_question,
       penalty_level_question,
       penalty_amount_question,
+      tax_amount_question,
       disputed_tax_paid_question,
       hardship_review_requested_question,
       hardship_review_status_question
@@ -52,6 +53,15 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       as: :penalty_amount,
       i18n_value: false,
       change_path: edit_steps_cost_penalty_amount_path
+    )
+  end
+
+  def tax_amount_question
+    row(
+      tribunal_case.tax_amount,
+      as: :tax_amount,
+      i18n_value: false,
+      change_path: edit_steps_cost_tax_amount_path
     )
   end
 

--- a/app/presenters/fee_details_answers_presenter.rb
+++ b/app/presenters/fee_details_answers_presenter.rb
@@ -8,6 +8,7 @@ class FeeDetailsAnswersPresenter < BaseAnswersPresenter
       dispute_type_question,
       penalty_level_question,
       penalty_amount_question,
+      tax_amount_question,
       fee_amount_question
     ].compact
   end
@@ -50,6 +51,15 @@ class FeeDetailsAnswersPresenter < BaseAnswersPresenter
       as: :penalty_amount,
       i18n_value: false,
       change_path: edit_steps_cost_penalty_amount_path
+    )
+  end
+
+  def tax_amount_question
+    row(
+      tribunal_case.tax_amount,
+      as: :tax_amount,
+      i18n_value: false,
+      change_path: edit_steps_cost_tax_amount_path
     )
   end
 

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -9,7 +9,7 @@ class CostDecisionTree < DecisionTree
       after_case_type_step
     when :dispute_type
       after_dispute_type_step
-    when :penalty_amount
+    when :penalty_amount, :tax_amount
       hardship_or_determine_cost_step
     else
       raise "Invalid step '#{step_params}'"
@@ -26,8 +26,8 @@ class CostDecisionTree < DecisionTree
       edit(:case_type)
     when :dispute_type
       before_dispute_type_step
-    when :penalty_amount
-      before_penalty_amount_step
+    when :penalty_amount, :tax_amount
+      before_penalty_or_tax_amount_step
     else
       raise "Invalid step '#{step_params}'"
     end
@@ -57,6 +57,8 @@ class CostDecisionTree < DecisionTree
   def after_dispute_type_step
     if tribunal_case.dispute_type.ask_penalty?
       edit(:penalty_amount)
+    elsif tribunal_case.dispute_type.ask_tax?
+      edit(:tax_amount)
     else
       hardship_or_determine_cost_step
     end
@@ -78,7 +80,7 @@ class CostDecisionTree < DecisionTree
     end
   end
 
-  def before_penalty_amount_step
+  def before_penalty_or_tax_amount_step
     if tribunal_case.dispute_type?
       edit(:dispute_type)
     else

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -16,6 +16,10 @@ class DisputeType < ValueObject
     self == PENALTY
   end
 
+  def ask_tax?
+    self == AMOUNT_OF_TAX
+  end
+
   def ask_hardship?
     [AMOUNT_OF_TAX, AMOUNT_AND_PENALTY].include?(self)
   end

--- a/app/views/steps/cost/case_type/edit.html.erb
+++ b/app/views/steps/cost/case_type/edit.html.erb
@@ -6,8 +6,6 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <p><%=t '.description_text' %></p>
-
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :case_type,
         choices: Steps::Cost::CaseTypeForm.choices %>

--- a/app/views/steps/cost/determine_cost/show.html.erb
+++ b/app/views/steps/cost/determine_cost/show.html.erb
@@ -19,7 +19,7 @@
     <% @change_answers.rows.each do |row| %>
       <tr>
         <th><%=t row.question %></th>
-        <td><%=t row.answer %></td>
+        <td><%= row.i18n_value ? t(row.answer) : row.answer %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/steps/cost/tax_amount/edit.html.erb
+++ b/app/views/steps/cost/tax_amount/edit.html.erb
@@ -1,14 +1,13 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= step_header(:cost, 4) %>
+    <%= step_header(:cost, 5) %>
 
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
-      <%= f.radio_button_fieldset :dispute_type,
-        choices: @form_object.choices %>
+      <%= f.text_field :tax_amount, class: 'form-control' %>
       <%= f.submit class: 'button' %>
     <% end %>
   </div>

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -101,8 +101,7 @@ en:
       case_type:
         edit:
           heading: What is your appeal about?
-          lead_text: The type of tax, decision or application is usually shown on the original notice letter from HMRC, or review conclusion letter (if you had a review with HMRC).
-          description_text: If the tax or issue is not listed below or you’re making a different type of appeal or application, please select ‘other’.
+          lead_text: You will find this information on either the original notice letter or review conclusion letter from HMRC.
       case_type_show_more:
         edit:
           heading: What is your appeal about?
@@ -110,8 +109,7 @@ en:
       dispute_type:
         edit:
           heading: What is your dispute about?
-          lead_text: Your dispute will be stated on either the original notice letter from HMRC, or the review conclusion letter if your case was reviewed.
-          description_text: You can't combine separate disputes on separate letters into one appeal.
+          lead_text: You will find this information on either the original notice letter or review conclusion letter from HMRC.
       penalty_amount:
         edit:
           heading: What is the penalty or surcharge amount?
@@ -119,6 +117,10 @@ en:
           penalty_level_1: £100 or less
           penalty_level_2: over £100 – £20,000
           penalty_level_3: over £20,000
+      tax_amount:
+        edit:
+          heading: What amount of tax is under dispute?
+          lead_text: Enter the amount shown on the original notice letter or review conclusion letter you received from HMRC.
       determine_cost:
         show:
           fee_label: To submit an appeal costs
@@ -133,6 +135,7 @@ en:
             dispute_type: What is your dispute about?
             penalty_level: What is the penalty or surcharge amount?
             penalty_amount: What is the penalty or surcharge amount?
+            tax_amount: What is the amount of tax?
             disputed_tax_paid: Have you paid the amount of tax involved in the dispute?
             hardship_review_requested: Did you apply for financial hardship?
             hardship_review_status: What is the status of your hardship application?
@@ -224,16 +227,16 @@ en:
               inclusion: Select what the penalty or surcharge amount is
   helpers:
     fieldset:
+      # Use an empty string in _html keys to not show the fieldset legend
       steps_cost_challenged_decision_form:
         challenged_decision: Did you challenge the decision with HMRC first?
       steps_cost_case_type_form:
-        case_type: What is your appeal about?
+        case_type_html: ""
       steps_cost_case_type_show_more_form:
         case_type: What is your appeal about?
       steps_cost_dispute_type_form:
-        dispute_type: What is your dispute about?
+        dispute_type_html: ""
       steps_cost_penalty_amount_form:
-        # Use empty string in _html keys to not show the fieldset legend
         penalty_level_html: ""
     label:
       steps_cost_challenged_decision_form:
@@ -247,7 +250,7 @@ en:
           capital_gains_tax_html: <strong>Capital Gains Tax</strong>
           corporation_tax_html: <strong>Corporation Tax</strong>
           inaccurate_return_penalty_html: <strong>Inaccurate return penalty</strong>
-          information_notice_html: <strong>Information notices</strong><br>including penalties for non-compliance with information notices
+          information_notice_html: <strong>Information notices</strong>
           _show_more_html: <strong>Other type of tax, appeal or application</strong>
       steps_cost_case_type_show_more_form:
         case_type:
@@ -278,9 +281,9 @@ en:
       steps_cost_dispute_type_form:
         dispute_type:
           paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
-          penalty_html: <strong>Penalty or surcharge</strong><br>for late filing of returns and documents, late payment of duties, inaccuracies, or non-compliance with information notices or Schedule 41
-          amount_of_tax_html: <strong>Amount of tax</strong><br>either tax you owe or money that HMRC should pay to you
-          amount_and_penalty_html: <strong>Amount of tax and a penalty or surcharge</strong><br>both of these disputes will be stated on either the original notice letter from HMRC or the review conclusion letter
+          penalty_html: <strong>Penalty or surcharge</strong>
+          amount_of_tax_html: <strong>Amount of tax</strong>
+          amount_and_penalty_html: <strong>Amount of tax and a penalty or surcharge</strong><br>both must be stated on the same letter
           information_notice_html: <strong>Appeal against an information notice</strong>
           other_html: <strong>None of the above</strong>
       steps_cost_penalty_amount_form:
@@ -289,3 +292,5 @@ en:
           penalty_level_1: £100 or less
           penalty_level_2: over £100 – £20,000
           penalty_level_3: over £20,000
+      steps_cost_tax_amount_form:
+        tax_amount: The amount of tax under dispute (optional)

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -96,6 +96,7 @@ en:
             dispute_type: What is your dispute about?
             penalty_level: What is the penalty or surcharge amount?
             penalty_amount: What is the penalty or surcharge amount?
+            tax_amount: What is the amount of tax?
             fee_amount: Initial appeal fee
             in_time: Is the appeal late?
             lateness_reason: Reason(s) for late appeal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       edit_step :penalty_amount
       show_step :determine_cost
       show_step :must_challenge_hmrc
+      edit_step :tax_amount
     end
 
     namespace :hardship do

--- a/db/migrate/20170119171456_add_tax_amount_to_tribunal_case.rb
+++ b/db/migrate/20170119171456_add_tax_amount_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddTaxAmountToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :tax_amount, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118150453) do
+ActiveRecord::Schema.define(version: 20170119171456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20170118150453) do
     t.string   "hardship_review_status"
     t.string   "case_reference"
     t.string   "penalty_amount"
+    t.string   "tax_amount"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/steps/cost/tax_amount_controller_spec.rb
+++ b/spec/controllers/steps/cost/tax_amount_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Cost::TaxAmountController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Cost::TaxAmountForm, CostDecisionTree
+end

--- a/spec/forms/steps/cost/case_type_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_form_spec.rb
@@ -53,7 +53,9 @@ RSpec.describe Steps::Cost::CaseTypeForm do
         expect(tribunal_case).to receive(:update).with(
           case_type: case_type_object,
           dispute_type: nil,
-          penalty_level: nil
+          penalty_level: nil,
+          penalty_amount: nil,
+          tax_amount: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/cost/case_type_show_more_form_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe Steps::Cost::CaseTypeShowMoreForm do
         expect(tribunal_case).to receive(:update).with(
           case_type: case_type_object,
           dispute_type: nil,
-          penalty_level: nil
+          penalty_level: nil,
+          penalty_amount: nil,
+          tax_amount: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/challenged_decision_form_spec.rb
+++ b/spec/forms/steps/cost/challenged_decision_form_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe Steps::Cost::ChallengedDecisionForm do
           challenged_decision: ChallengedDecision::NO,
           case_type: nil,
           dispute_type: nil,
-          penalty_level: nil
+          penalty_level: nil,
+          penalty_amount: nil,
+          tax_amount: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/dispute_type_form_spec.rb
+++ b/spec/forms/steps/cost/dispute_type_form_spec.rb
@@ -99,7 +99,9 @@ RSpec.describe Steps::Cost::DisputeTypeForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           dispute_type: DisputeType::PENALTY,
-          penalty_level: nil
+          penalty_level: nil,
+          penalty_amount: nil,
+          tax_amount: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/cost/tax_amount_form_spec.rb
+++ b/spec/forms/steps/cost/tax_amount_form_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Cost::TaxAmountForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    tax_amount: tax_amount
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, tax_amount: nil) }
+  let(:tax_amount) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when tax_amount is not given' do
+      it 'returns true' do
+        expect(tribunal_case).to receive(:update).with(
+          tax_amount: nil
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when tax_amount is given' do
+      let(:tax_amount) { 'about 12345' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          tax_amount: 'about 12345'
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/change_cost_answers_presenter_spec.rb
+++ b/spec/presenters/change_cost_answers_presenter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ChangeCostAnswersPresenter do
       dispute_type: dispute_type,
       penalty_level: penalty_level,
       penalty_amount: penalty_amount,
+      tax_amount: tax_amount,
       disputed_tax_paid: disputed_tax_paid,
       hardship_review_requested: hardship_review_requested,
       hardship_review_status: hardship_review_status
@@ -22,6 +23,7 @@ RSpec.describe ChangeCostAnswersPresenter do
   let(:dispute_type)              { nil }
   let(:penalty_level)             { nil }
   let(:penalty_amount)            { nil }
+  let(:tax_amount)                { nil }
   let(:disputed_tax_paid)         { nil }
   let(:hardship_review_requested) { nil }
   let(:hardship_review_status)    { nil }
@@ -145,6 +147,32 @@ RSpec.describe ChangeCostAnswersPresenter do
           expect(row.question).to    eq('.questions.penalty_amount')
           expect(row.answer).to      eq('about 12345')
           expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
+        end
+      end
+    end
+
+    describe '`tax_amount` row' do
+      let(:row) { subject.rows[3] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+
+      context 'when `tax_amount` is nil' do
+        let(:tax_amount) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `tax_amount` is given' do
+        let(:tax_amount) { 'about 12345' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.tax_amount')
+          expect(row.answer).to      eq('about 12345')
+          expect(row.change_path).to eq(paths.edit_steps_cost_tax_amount_path)
         end
       end
     end

--- a/spec/presenters/fee_details_answers_presenter_spec.rb
+++ b/spec/presenters/fee_details_answers_presenter_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
       dispute_type: dispute_type,
       penalty_level: penalty_level,
       penalty_amount: penalty_amount,
+      tax_amount: tax_amount,
       lodgement_fee: lodgement_fee
     )
   }
@@ -20,6 +21,7 @@ RSpec.describe FeeDetailsAnswersPresenter do
   let(:dispute_type)        { nil }
   let(:penalty_level)       { nil }
   let(:penalty_amount)      { nil }
+  let(:tax_amount)          { nil }
   let(:lodgement_fee)       { nil }
 
   describe '#rows' do
@@ -145,6 +147,32 @@ RSpec.describe FeeDetailsAnswersPresenter do
           expect(row.question).to    eq('.questions.penalty_amount')
           expect(row.answer).to      eq('about 12345')
           expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
+        end
+      end
+    end
+
+    describe '`tax_amount` row' do
+      let(:row) { subject.rows[3] }
+
+      # Needed so that the row is in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+
+      context 'when `tax_amount` is nil' do
+        let(:tax_amount) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `tax_amount` is given' do
+        let(:tax_amount)  { 'about 12345' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.tax_amount')
+          expect(row.answer).to      eq('about 12345')
+          expect(row.change_path).to eq(paths.edit_steps_cost_tax_amount_path)
         end
       end
     end

--- a/spec/services/cost_decision_tree_spec.rb
+++ b/spec/services/cost_decision_tree_spec.rb
@@ -66,27 +66,33 @@ RSpec.describe CostDecisionTree do
       let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type, dispute_type: dispute_type) }
 
       context 'and the dispute type should ask for a penalty amount' do
-        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: true) }
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: true, ask_tax?: false) }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
 
-      context 'and the dispute type should not ask for a penalty amount but the dispute_type asks hardship and the case_type asks hardship' do
-        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_hardship?: true) }
+      context 'and the dispute type should ask for a tax amount' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_tax?: true) }
+
+        it { is_expected.to have_destination(:tax_amount, :edit) }
+      end
+
+      context 'and the dispute type should not ask for a penalty or tax amount but the dispute_type asks hardship and the case_type asks hardship' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_tax?: false, ask_hardship?: true) }
         let(:case_type)     { CaseType.new(:anything, ask_hardship: true) }
 
         it { is_expected.to have_destination('/steps/hardship/disputed_tax_paid', :edit) }
       end
 
-      context 'and the dispute type should not ask for a penalty amount but the dispute_type asks hardship but the case_type does not ask hardship' do
-        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_hardship?: true) }
+      context 'and the dispute type should not ask for a penalty or tax amount but the dispute_type asks hardship but the case_type does not ask hardship' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_tax?: false, ask_hardship?: true) }
         let(:case_type)     { CaseType.new(:anything, ask_hardship: false) }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
 
-      context 'and the dispute type should not ask for a penalty amount and not ask hardship' do
-        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_hardship?: false) }
+      context 'and the dispute type should not ask for a penalty amount, tax amount or hardship' do
+        let(:dispute_type) { instance_double(DisputeType, ask_penalty?: false, ask_tax?: false, ask_hardship?: false) }
 
         it { is_expected.to have_destination(:determine_cost, :show) }
       end
@@ -94,6 +100,39 @@ RSpec.describe CostDecisionTree do
 
     context 'when the step is `penalty_amount`' do
       let(:step_params) { { penalty_amount: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type, dispute_type: dispute_type) }
+
+      context 'and the case type should ask hardship and the dispute_type should ask hardship' do
+        let(:case_type)    { CaseType.new(:anything, ask_hardship: true) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: true) }
+
+        it { is_expected.to have_destination('/steps/hardship/disputed_tax_paid', :edit) }
+      end
+
+      context 'and the case type should ask the hardship questions but the dispute_type should not' do
+        let(:case_type) { CaseType.new(:anything, ask_hardship: true) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: false) }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the case type should not ask the hardship questions but the dispute_type is one that otherwise should' do
+        let(:case_type) { CaseType.new(:anything, ask_hardship: false) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: true) }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+
+      context 'and the case type should not ask the hardship questions and the dispute_type should not either' do
+        let(:case_type) { CaseType.new(:anything, ask_hardship: false) }
+        let(:dispute_type) { instance_double(DisputeType, ask_hardship?: false) }
+
+        it { is_expected.to have_destination(:determine_cost, :show) }
+      end
+    end
+
+    context 'when the step is `tax_amount`' do
+      let(:step_params) { { tax_amount: 'anything' } }
       let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type, dispute_type: dispute_type) }
 
       context 'and the case type should ask hardship and the dispute_type should ask hardship' do
@@ -176,6 +215,37 @@ RSpec.describe CostDecisionTree do
 
     context 'when the step is `penalty_amount`' do
       let(:step_params) { { penalty_amount: 'anything' } }
+      let(:tribunal_case) { instance_double(TribunalCase, case_type: CaseType.new(:foo), dispute_type?: has_dispute_type) }
+
+      context 'when the case does not have a dispute_type' do
+        let(:has_dispute_type) { false }
+
+        context 'when the case type was listed on the `case_type` step' do
+          before do
+            expect(Steps::Cost::CaseTypeForm).to receive(:choices).and_return(['foo'])
+          end
+
+          it { is_expected.to have_previous(:case_type, :edit) }
+        end
+
+        context 'when the case type was listed on the `case_type_show_more` step' do
+          before do
+            expect(Steps::Cost::CaseTypeForm).to receive(:choices).and_return(['not_foo'])
+          end
+
+          it { is_expected.to have_previous(:case_type_show_more, :edit) }
+        end
+      end
+
+      context 'when the case has a dispute type' do
+        let(:has_dispute_type) { true }
+
+        it { is_expected.to have_previous(:dispute_type, :edit) }
+      end
+    end
+
+    context 'when the step is `tax_amount`' do
+      let(:step_params) { { tax_amount: 'anything' } }
       let(:tribunal_case) { instance_double(TribunalCase, case_type: CaseType.new(:foo), dispute_type?: has_dispute_type) }
 
       context 'when the case does not have a dispute_type' do

--- a/spec/value_objects/dispute_type_spec.rb
+++ b/spec/value_objects/dispute_type_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe DisputeType do
     end
   end
 
+  describe '#ask_tax?' do
+    it 'returns false by default' do
+      expect(subject.ask_tax?).to be(false)
+    end
+
+    context 'when the dispute type is AMOUNT_OF_TAX' do
+      let(:type) { :amount_of_tax }
+
+      it 'returns true' do
+        expect(subject.ask_tax?).to be(true)
+      end
+    end
+  end
+
   describe '#ask_hardship?' do
     it 'returns false by default' do
       expect(subject.ask_hardship?).to be(false)


### PR DESCRIPTION
Introducing a new step after selecting dispute `amount of tax` to ask for the
amount of tax (free text), and updating cost decision tree, presenters and views.