### PR TITLE
Copy change in lateness reason step according to prototype.

### DIFF
--- a/app/forms/steps/lateness/lateness_reason_form.rb
+++ b/app/forms/steps/lateness/lateness_reason_form.rb
@@ -4,6 +4,10 @@ module Steps::Lateness
 
     validates_length_of :lateness_reason, minimum: 5
 
+    def lateness_unknown?
+      tribunal_case.in_time == InTime::UNSURE
+    end
+
     private
 
     def persist!

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -2,9 +2,13 @@
   <div class="column-two-thirds">
     <%= step_header(:lateness, 2) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="heading-large">
+      <%= @form_object.lateness_unknown? ? t('.heading_unsure') : t('.heading') %>
+    </h1>
 
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="lede">
+      <%= @form_object.lateness_unknown? ? t('.lead_text_unsure') : t('.lead_text') %>
+    </p>
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :lateness_reason, size: '40x4', class: 'form-control-3-4' %>

--- a/config/locales/lateness.yml
+++ b/config/locales/lateness.yml
@@ -5,14 +5,14 @@ en:
       start:
         show:
           heading: 2. Check you meet tribunal deadlines
-          lead_text: You must appeal within the time stated on your last letter from HMRC. This is usually 30 days.
+          lead_text: You have 30 calendar days to submit an appeal. You can still appeal late if you have good reasons.
           description_html: |
-            <p>If you have asked HMRC for a review with a tax officer not originally involved in your case, you should wait until the review finishes.</p>
-            <p>Once the review is completed and you have received a letter from HMRC with the review conclusions you can then appeal to the tax tribunal.</p>
+            <p>The deadline to appeal begins from the date shown on either the original notice letter or review conclusion letter.</p>
+            <p>If you accepted or asked for a review, you can only appeal once you have received a review conclusion letter or 45 days passes without receiving one.</p>
             <h4 class="heading-small">What you will need</h4>
             <ul class="list list-bullet">
-              <li>date you received your last letter from HMRC</li>
-              <li>reasons why you're outside the time limit if you want to submit an appeal late</li>
+              <li><strong>date of the decision letter</strong> - this will be shown on either the original notice letter or review conclusion letter</li>
+              <li><strong>reasons if you want to appeal late</strong> - the judge will consider your reasons and decide whether to accept or reject your appeal</li>
             </ul>
           previous_step_not_completed: You must complete Step 1 before you can check whether or not you meet the tribunal deadlines.
           back_to_start: Return to start page
@@ -23,7 +23,9 @@ en:
       lateness_reason:
         edit:
           heading: Why are you late with your appeal?
+          heading_unsure: Are there reasons why your appeal might be late?
           lead_text: You must provide reasonable grounds for appealing late. If the judge rejects your reasons, your appeal will not proceed and any fees will not be refunded.
+          lead_text_unsure: To help us process your case quickly, you should give reasons why your appeal might be late. The judge will look at your reasons and decide whether to accept your appeal if it is late.
           details_title: Help with late appeals
           details_content: You must provide reasonable grounds for submitting your appeal late. These are usually unforeseen circumstances or events beyond your control which meant you weren't able to meet the tax tribunal deadlines.
   activemodel:

--- a/spec/forms/steps/lateness/lateness_reason_form_spec.rb
+++ b/spec/forms/steps/lateness/lateness_reason_form_spec.rb
@@ -5,10 +5,37 @@ RSpec.describe Steps::Lateness::LatenessReasonForm do
     tribunal_case:   tribunal_case,
     lateness_reason: lateness_reason
   } }
-  let(:tribunal_case)   { instance_double(TribunalCase, lateness_reason: nil) }
+  let(:tribunal_case)   { instance_double(TribunalCase, lateness_reason: nil, in_time: in_time) }
   let(:lateness_reason) { nil }
+  let(:in_time)         { nil }
 
   subject { described_class.new(arguments) }
+
+  describe '#lateness_unknown?' do
+    context 'when appeal is late' do
+      let(:in_time) { InTime::YES }
+
+      it 'should return false' do
+        expect(subject.lateness_unknown?).to be(false)
+      end
+    end
+
+    context 'when appeal is not late' do
+      let(:in_time) { InTime::NO }
+
+      it 'should return false' do
+        expect(subject.lateness_unknown?).to be(false)
+      end
+    end
+
+    context 'when appeal is unsure to be late' do
+      let(:in_time) { InTime::UNSURE }
+
+      it 'should return false' do
+        expect(subject.lateness_unknown?).to be(true)
+      end
+    end
+  end
 
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do

--- a/spec/forms/steps/lateness/lateness_reason_form_spec.rb
+++ b/spec/forms/steps/lateness/lateness_reason_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Steps::Lateness::LatenessReasonForm do
   subject { described_class.new(arguments) }
 
   describe '#lateness_unknown?' do
-    context 'when appeal is late' do
+    context 'when appeal is not late' do
       let(:in_time) { InTime::YES }
 
       it 'should return false' do
@@ -20,7 +20,7 @@ RSpec.describe Steps::Lateness::LatenessReasonForm do
       end
     end
 
-    context 'when appeal is not late' do
+    context 'when appeal is late' do
       let(:in_time) { InTime::NO }
 
       it 'should return false' do
@@ -28,7 +28,7 @@ RSpec.describe Steps::Lateness::LatenessReasonForm do
       end
     end
 
-    context 'when appeal is unsure to be late' do
+    context 'when appellant is not sure' do
       let(:in_time) { InTime::UNSURE }
 
       it 'should return false' do


### PR DESCRIPTION
Depending on the answer to the lateness question (late or unsure) the copy
in the lateness reason view will change slighly, according to the prototype.