### PR TITLE
Ask for both, penalty and tax amounts.

### DIFF
--- a/app/controllers/steps/cost/penalty_and_tax_amounts_controller.rb
+++ b/app/controllers/steps/cost/penalty_and_tax_amounts_controller.rb
@@ -1,0 +1,16 @@
+module Steps::Cost
+  class PenaltyAndTaxAmountsController < Steps::CostStepController
+    def edit
+      super
+      @form_object = PenaltyAndTaxAmountsForm.new(
+        tribunal_case:  current_tribunal_case,
+        penalty_amount: current_tribunal_case.penalty_amount,
+        tax_amount:     current_tribunal_case.tax_amount
+      )
+    end
+
+    def update
+      update_and_advance(PenaltyAndTaxAmountsForm, as: :penalty_and_tax_amounts)
+    end
+  end
+end

--- a/app/forms/steps/cost/penalty_and_tax_amounts_form.rb
+++ b/app/forms/steps/cost/penalty_and_tax_amounts_form.rb
@@ -1,0 +1,16 @@
+module Steps::Cost
+  class PenaltyAndTaxAmountsForm < BaseForm
+    attribute :penalty_amount, String
+    attribute :tax_amount, String
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      tribunal_case.update(
+        penalty_amount: penalty_amount,
+        tax_amount: tax_amount
+      )
+    end
+  end
+end

--- a/app/presenters/change_cost_answers_presenter.rb
+++ b/app/presenters/change_cost_answers_presenter.rb
@@ -4,9 +4,9 @@ class ChangeCostAnswersPresenter < BaseAnswersPresenter
       challenged_decision_question,
       case_type_question,
       dispute_type_question,
+      tax_amount_question,
       penalty_level_question,
       penalty_amount_question,
-      tax_amount_question,
       disputed_tax_paid_question,
       hardship_review_requested_question,
       hardship_review_status_question

--- a/app/services/cost_decision_tree.rb
+++ b/app/services/cost_decision_tree.rb
@@ -9,7 +9,7 @@ class CostDecisionTree < DecisionTree
       after_case_type_step
     when :dispute_type
       after_dispute_type_step
-    when :penalty_amount, :tax_amount
+    when :penalty_amount, :tax_amount, :penalty_and_tax_amounts
       hardship_or_determine_cost_step
     else
       raise "Invalid step '#{step_params}'"
@@ -26,7 +26,7 @@ class CostDecisionTree < DecisionTree
       edit(:case_type)
     when :dispute_type
       before_dispute_type_step
-    when :penalty_amount, :tax_amount
+    when :penalty_amount, :tax_amount, :penalty_and_tax_amounts
       before_penalty_or_tax_amount_step
     else
       raise "Invalid step '#{step_params}'"
@@ -59,6 +59,8 @@ class CostDecisionTree < DecisionTree
       edit(:penalty_amount)
     elsif tribunal_case.dispute_type.ask_tax?
       edit(:tax_amount)
+    elsif tribunal_case.dispute_type.ask_penalty_and_tax?
+      edit(:penalty_and_tax_amounts)
     else
       hardship_or_determine_cost_step
     end

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -20,6 +20,10 @@ class DisputeType < ValueObject
     self == AMOUNT_OF_TAX
   end
 
+  def ask_penalty_and_tax?
+    self == AMOUNT_AND_PENALTY
+  end
+
   def ask_hardship?
     [AMOUNT_OF_TAX, AMOUNT_AND_PENALTY].include?(self)
   end

--- a/app/views/steps/cost/penalty_and_tax_amounts/edit.html.erb
+++ b/app/views/steps/cost/penalty_and_tax_amounts/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:cost, 5) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_field :tax_amount, class: 'form-control' %>
+      <%= f.text_field :penalty_amount, class: 'form-control' %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/cost.yml
+++ b/config/locales/cost.yml
@@ -121,6 +121,10 @@ en:
         edit:
           heading: What amount of tax is under dispute?
           lead_text: Enter the amount shown on the original notice letter or review conclusion letter you received from HMRC.
+      penalty_and_tax_amounts:
+        edit:
+          heading: What is the tax amount and penalty or surcharge amount?
+          lead_text: Enter the amount shown on the original notice letter or review conclusion letter you received from HMRC.
       determine_cost:
         show:
           fee_label: To submit an appeal costs
@@ -135,7 +139,7 @@ en:
             dispute_type: What is your dispute about?
             penalty_level: What is the penalty or surcharge amount?
             penalty_amount: What is the penalty or surcharge amount?
-            tax_amount: What is the amount of tax?
+            tax_amount: What is the amount of tax in dispute?
             disputed_tax_paid: Have you paid the amount of tax involved in the dispute?
             hardship_review_requested: Did you apply for financial hardship?
             hardship_review_status: What is the status of your hardship application?
@@ -294,3 +298,6 @@ en:
           penalty_level_3: over £20,000
       steps_cost_tax_amount_form:
         tax_amount: The amount of tax under dispute (optional)
+      steps_cost_penalty_and_tax_amounts_form:
+        tax_amount: The amount of tax you are disputing (optional)
+        penalty_amount: The penalty or surcharge amount you are disputing (optional)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       show_step :determine_cost
       show_step :must_challenge_hmrc
       edit_step :tax_amount
+      edit_step :penalty_and_tax_amounts
     end
 
     namespace :hardship do

--- a/spec/controllers/steps/cost/penalty_and_tax_amounts_controller_spec.rb
+++ b/spec/controllers/steps/cost/penalty_and_tax_amounts_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Cost::PenaltyAndTaxAmountsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Cost::PenaltyAndTaxAmountsForm, CostDecisionTree
+end

--- a/spec/forms/steps/cost/penalty_and_tax_amounts_form_spec.rb
+++ b/spec/forms/steps/cost/penalty_and_tax_amounts_form_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Cost::PenaltyAndTaxAmountsForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    penalty_amount: penalty_amount,
+    tax_amount: tax_amount
+  } }
+  let(:tribunal_case)  { instance_double(TribunalCase, penalty_amount: nil, tax_amount: nil) }
+  let(:penalty_amount) { nil }
+  let(:tax_amount)     { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when penalty and tax amounts are not given' do
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          penalty_amount: nil,
+          tax_amount: nil
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when penalty and tax amounts are given' do
+      let(:penalty_amount) { 'value 1' }
+      let(:tax_amount)     { 'value 2' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          penalty_amount: 'value 1',
+          tax_amount: 'value 2'
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/presenters/change_cost_answers_presenter_spec.rb
+++ b/spec/presenters/change_cost_answers_presenter_spec.rb
@@ -177,6 +177,65 @@ RSpec.describe ChangeCostAnswersPresenter do
       end
     end
 
+    describe '`penalty and tax amount` rows' do
+      let(:row) { subject.rows[3] }
+
+      # Needed so that the rows are in the correct position
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'bar' }
+
+      context 'when `tax amount` is nil and `penalty amount` is nil' do
+        let(:tax_amount) { nil }
+        let(:penalty_amount) { nil }
+
+        it 'row is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `tax amount` is given and `penalty amount` is nil' do
+        let(:tax_amount) { 'about 12345' }
+        let(:penalty_amount) { nil }
+
+        it 'tax amount row has the correct attributes' do
+          expect(row.question).to    eq('.questions.tax_amount')
+          expect(row.answer).to      eq('about 12345')
+          expect(row.change_path).to eq(paths.edit_steps_cost_tax_amount_path)
+        end
+      end
+
+      context 'when `tax amount` is nil and `penalty amount` is given' do
+        let(:tax_amount) { nil }
+        let(:penalty_amount) { 'about 12345' }
+
+        it 'penalty amount row has the correct attributes' do
+          expect(row.question).to    eq('.questions.penalty_amount')
+          expect(row.answer).to      eq('about 12345')
+          expect(row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
+        end
+      end
+
+      context 'when `tax amount` is given and `penalty amount` is given' do
+        let(:tax_amount) { 'about 12345' }
+        let(:penalty_amount) { 'about 54321' }
+
+        let(:tax_row) { subject.rows[3] }
+        let(:penalty_row) { subject.rows[4] }
+
+        it 'tax amount row has the correct attributes' do
+          expect(tax_row.question).to    eq('.questions.tax_amount')
+          expect(tax_row.answer).to      eq('about 12345')
+          expect(tax_row.change_path).to eq(paths.edit_steps_cost_tax_amount_path)
+        end
+
+        it 'penalty amount row has the correct attributes' do
+          expect(penalty_row.question).to    eq('.questions.penalty_amount')
+          expect(penalty_row.answer).to      eq('about 54321')
+          expect(penalty_row.change_path).to eq(paths.edit_steps_cost_penalty_amount_path)
+        end
+      end
+    end
+
     describe '`disputed_tax_paid` row' do
       let(:row) { subject.rows[3] }
 

--- a/spec/value_objects/dispute_type_spec.rb
+++ b/spec/value_objects/dispute_type_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe DisputeType do
     end
   end
 
+  describe '#ask_penalty_and_tax?' do
+    it 'returns false by default' do
+      expect(subject.ask_penalty_and_tax?).to be(false)
+    end
+
+    context 'when the dispute type is AMOUNT_AND_PENALTY' do
+      let(:type) { :amount_and_penalty }
+
+      it 'returns true' do
+        expect(subject.ask_penalty_and_tax?).to be(true)
+      end
+    end
+  end
+
   describe '#ask_hardship?' do
     it 'returns false by default' do
       expect(subject.ask_hardship?).to be(false)


### PR DESCRIPTION
When the user selects the dispute `Amount of tax and a penalty or surcharge`, a new
step form with 2 free text inputs to ask for the penalty and tax amounts will show.

Updated cost decision tree and implemented design according to prototype.