### PR TITLE
Only requiring Raven (Sentry) in production envs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0'
 gem 'responders'
 gem 'sass-rails', '~> 5.0'
-gem 'sentry-raven'
+gem 'sentry-raven', require: false
 gem 'uglifier', '>= 1.3.0'
 gem 'uk_postcode'
 gem 'virtus'

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,2 +1,2 @@
 
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :confirmation_code]

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,10 @@
+# :nocov:
+if %w( production ).include?(Rails.env) && ENV['SENTRY_DSN'].present?
+  require 'raven'
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+    config.environments = %w( production )
+    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  end
+end
+# :nocov:


### PR DESCRIPTION
Also filtering confirmation_code from the details being sent to Sentry.