### PR TITLE
Closure flow - Part II. Repellant and enquiry details steps.

### DIFF
--- a/app/controllers/steps/closure/case_type_controller.rb
+++ b/app/controllers/steps/closure/case_type_controller.rb
@@ -9,7 +9,7 @@ module Steps::Closure
     end
 
     def update
-      update_and_advance(CaseTypeForm)
+      update_and_advance(CaseTypeForm, as: :case_type)
     end
 
     private

--- a/app/controllers/steps/closure/enquiry_details_controller.rb
+++ b/app/controllers/steps/closure/enquiry_details_controller.rb
@@ -1,0 +1,17 @@
+module Steps::Closure
+  class EnquiryDetailsController < Steps::ClosureStepController
+    def edit
+      super
+      @form_object = EnquiryDetailsForm.new(
+        tribunal_case: current_tribunal_case,
+        closure_hmrc_reference: current_tribunal_case.closure_hmrc_reference,
+        closure_hmrc_officer: current_tribunal_case.closure_hmrc_officer,
+        closure_years_under_enquiry: current_tribunal_case.closure_years_under_enquiry
+      )
+    end
+
+    def update
+      update_and_advance(EnquiryDetailsForm, as: :enquiry_details)
+    end
+  end
+end

--- a/app/forms/steps/closure/enquiry_details_form.rb
+++ b/app/forms/steps/closure/enquiry_details_form.rb
@@ -1,0 +1,22 @@
+module Steps::Closure
+  class EnquiryDetailsForm < BaseForm
+    attribute :closure_hmrc_reference, String
+    attribute :closure_hmrc_officer, String
+    attribute :closure_years_under_enquiry, String
+
+    validates_presence_of :closure_hmrc_reference,
+                          :closure_years_under_enquiry
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.update(
+        closure_hmrc_reference: closure_hmrc_reference,
+        closure_hmrc_officer: closure_hmrc_officer,
+        closure_years_under_enquiry: closure_years_under_enquiry
+      )
+    end
+  end
+end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -16,6 +16,10 @@ class TribunalCase < ApplicationRecord
   # Details task
   has_value_object :taxpayer_type, class_name: 'ContactableEntityType'
 
+  # Closure task
+  has_value_object :intent
+  has_value_object :closure_case_type
+
   def mapping_code
     MappingCodeDeterminer.new(self).mapping_code
   end

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -4,7 +4,7 @@ class ClosureDecisionTree < DecisionTree
 
     case step_name.to_sym
     when :case_type
-      # TODO: do something
+      edit('/steps/details/taxpayer_type')
     else
       raise "Invalid step '#{step_params}'"
     end
@@ -14,6 +14,8 @@ class ClosureDecisionTree < DecisionTree
     case step_name.to_sym
     when :case_type
       show(:start)
+    when :enquiry_details
+      edit('/steps/details/taxpayer_type')
     else
       raise "Invalid step '#{step_params}'"
     end

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -6,7 +6,7 @@ class DetailsDecisionTree < DecisionTree
     when :taxpayer_type
       after_taxpayer_type_step
     when :individual_details, :organisation_details
-      edit(:grounds_for_appeal)
+      after_details_step
     when :grounds_for_appeal
       edit(:outcome)
     when :outcome
@@ -23,7 +23,7 @@ class DetailsDecisionTree < DecisionTree
   def previous
     case step_name.to_sym
     when :taxpayer_type
-      show(:start)
+      before_taxpayer_type_step
     when :individual_details, :organisation_details
       edit(:taxpayer_type)
     when :grounds_for_appeal
@@ -56,6 +56,24 @@ class DetailsDecisionTree < DecisionTree
       edit(:individual_details)
     when :organisation, :other_organisation
       edit(:organisation_details)
+    end
+  end
+
+  def before_taxpayer_type_step
+    case tribunal_case.intent
+    when Intent::TAX_APPEAL
+      show(:start)
+    when Intent::CLOSE_ENQUIRY
+      edit('/steps/closure/case_type')
+    end
+  end
+
+  def after_details_step
+    case tribunal_case.intent
+    when Intent::TAX_APPEAL
+      edit(:grounds_for_appeal)
+    when Intent::CLOSE_ENQUIRY
+      edit('/steps/closure/enquiry_details')
     end
   end
 end

--- a/app/views/steps/closure/enquiry_details/edit.html.erb
+++ b/app/views/steps/closure/enquiry_details/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:closure, 0) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.text_field :closure_hmrc_reference %>
+      <%= f.text_field :closure_years_under_enquiry %>
+      <%= f.text_field :closure_hmrc_officer %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -19,6 +19,10 @@ en:
         edit:
           heading: What type of tax return is under enquiry?
           lead_text: The tax tribunal can only receive applications to close the following types of enquiry.
+      enquiry_details:
+        edit:
+          heading: Enter details for the enquiry you want to close
+          lead_text: You will find this information on any letters you have received from HMRC about the enquiry.
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend
@@ -32,3 +36,16 @@ en:
           income_tax_closure_html: Income Tax
           partnership_tax_closure_html: Partnership Tax
           stamp_duty_land_tax_closure_html: Stamp Duty Land Tax
+      steps_closure_enquiry_details_form:
+        closure_hmrc_reference: HMRC reference number
+        closure_years_under_enquiry: Years under enquiry
+        closure_hmrc_officer: Name of HMRC officer conducting the enquiry (optional)
+  activemodel:
+    errors:
+      models:
+        steps/closure/enquiry_details_form:
+          attributes:
+            closure_hmrc_reference:
+              blank: Enter the reference number
+            closure_years_under_enquiry:
+              blank: Enter the years under enquiry

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     namespace :closure do
       show_step :start
       edit_step :case_type
+      edit_step :enquiry_details
     end
 
     namespace :details do

--- a/db/migrate/20170130152514_add_closure_enquiry_details_to_tribunal_case.rb
+++ b/db/migrate/20170130152514_add_closure_enquiry_details_to_tribunal_case.rb
@@ -1,0 +1,7 @@
+class AddClosureEnquiryDetailsToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :closure_hmrc_reference, :string
+    add_column :tribunal_cases, :closure_hmrc_officer, :string
+    add_column :tribunal_cases, :closure_years_under_enquiry, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170130120812) do
+ActiveRecord::Schema.define(version: 20170130152514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,9 @@ ActiveRecord::Schema.define(version: 20170130120812) do
     t.string   "case_type_other_value"
     t.string   "intent"
     t.string   "closure_case_type"
+    t.string   "closure_hmrc_reference"
+    t.string   "closure_hmrc_officer"
+    t.string   "closure_years_under_enquiry"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/steps/closure/enquiry_details_controller_spec.rb
+++ b/spec/controllers/steps/closure/enquiry_details_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Closure::EnquiryDetailsController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Closure::EnquiryDetailsForm, ClosureDecisionTree
+end

--- a/spec/forms/steps/closure/enquiry_details_form_spec.rb
+++ b/spec/forms/steps/closure/enquiry_details_form_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Closure::EnquiryDetailsForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    closure_hmrc_reference: closure_hmrc_reference,
+    closure_hmrc_officer: closure_hmrc_officer,
+    closure_years_under_enquiry: closure_years_under_enquiry
+  } }
+
+  let(:tribunal_case) { instance_double(TribunalCase,
+                                        closure_hmrc_reference: closure_hmrc_reference,
+                                        closure_hmrc_officer: closure_hmrc_officer,
+                                        closure_years_under_enquiry: closure_years_under_enquiry) }
+  let(:closure_hmrc_reference) { nil }
+  let(:closure_hmrc_officer) { nil }
+  let(:closure_years_under_enquiry) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case) { nil }
+      let(:closure_hmrc_reference) { 'hmrc reference' }
+      let(:closure_years_under_enquiry) { '3 years and 5 months' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when enquiry details are not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the closure_hmrc_reference field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:closure_hmrc_reference]).to_not be_empty
+      end
+
+      it 'has a validation error on the closure_years_under_enquiry field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:closure_years_under_enquiry]).to_not be_empty
+      end
+
+      it 'does not have a validation error on the closure_hmrc_officer field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:closure_hmrc_officer]).to be_empty
+      end
+    end
+
+    context 'when enquiry details are valid' do
+      let(:closure_hmrc_reference) { 'hmrc reference' }
+      let(:closure_hmrc_officer) { 'hmrc officer' }
+      let(:closure_years_under_enquiry) { '3 years and 5 months' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          closure_hmrc_reference: 'hmrc reference',
+          closure_hmrc_officer: 'hmrc officer',
+          closure_years_under_enquiry: '3 years and 5 months'
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/closure_decision_tree_spec.rb
+++ b/spec/services/closure_decision_tree_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe ClosureDecisionTree do
   subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
   describe '#destination' do
+    context 'when the step is `case_type`' do
+      let(:step_params) { { case_type: 'anything' } }
+
+      it { is_expected.to have_destination('/steps/details/taxpayer_type', :edit) }
+    end
+
     context 'when the step is invalid' do
       let(:step_params) { {ungueltig: {waschmaschine: 'nein'}} }
 
@@ -18,10 +24,16 @@ RSpec.describe ClosureDecisionTree do
   end
 
   describe '#previous' do
-    context 'when the step is `change_me`' do
+    context 'when the step is `case_type`' do
       let(:step_params) { { case_type: 'anything' } }
 
       it { is_expected.to have_previous(:start, :show) }
+    end
+
+    context 'when the step is `enquiry_details`' do
+      let(:step_params) { { enquiry_details: 'anything' } }
+
+      it { is_expected.to have_previous('/steps/details/taxpayer_type', :edit) }
     end
 
     context 'when the step is invalid' do

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -28,15 +28,35 @@ RSpec.describe DetailsDecisionTree do
     end
 
     context 'when the step is `individual_details`' do
-      let(:step_params) { { individual_details: 'anything'  } }
+      let(:step_params) { {individual_details: 'anything'} }
 
-      it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
+      context 'for a tax appeal' do
+        let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::TAX_APPEAL) }
+
+        it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
+      end
+
+      context 'for a closure enquiry' do
+        let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::CLOSE_ENQUIRY) }
+
+        it { is_expected.to have_destination('/steps/closure/enquiry_details', :edit) }
+      end
     end
 
     context 'when the step is `organisation_details`' do
       let(:step_params) { { organisation_details: 'anything'  } }
 
-      it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
+      context 'for a tax appeal' do
+        let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::TAX_APPEAL) }
+
+        it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
+      end
+
+      context 'for a closure enquiry' do
+        let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::CLOSE_ENQUIRY) }
+
+        it { is_expected.to have_destination('/steps/closure/enquiry_details', :edit) }
+      end
     end
 
     context 'when the step is `grounds_for_appeal`' do
@@ -76,7 +96,17 @@ RSpec.describe DetailsDecisionTree do
     context 'when the step is `taxpayer_type`' do
       let(:step_params) { { taxpayer_type: 'anything'  } }
 
-      it { is_expected.to have_previous(:start, :show) }
+      context 'for a tax appeal' do
+        let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::TAX_APPEAL) }
+
+        it { is_expected.to have_previous(:start, :show) }
+      end
+
+      context 'for a closure enquiry' do
+        let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::CLOSE_ENQUIRY) }
+
+        it { is_expected.to have_previous('/steps/closure/case_type', :edit) }
+      end
     end
 
     context 'when the step is `individual_details`' do


### PR DESCRIPTION
After selecting a closure case type, the decision tree will enter the repellant flow
(which is WIP as part of another PR, so we might need to change things here) and after
the repellant details it will re-enter the closure decision tree, asking for the enquiry details.

3 new attributes added to the database to store the enquiry details.