### PR TITLE
Remove taxpayer details when taxpayer type changes

### DIFF
--- a/app/forms/steps/details/taxpayer_type_form.rb
+++ b/app/forms/steps/details/taxpayer_type_form.rb
@@ -22,8 +22,16 @@ module Steps::Details
       return true unless changed?
 
       tribunal_case.update(
-        taxpayer_type: taxpayer_type_value
+        taxpayer_type: taxpayer_type_value,
         # The following are dependent attributes that need to be reset
+        taxpayer_individual_name: nil,
+        taxpayer_organisation_name: nil,
+        taxpayer_organisation_registration_number: nil,
+        taxpayer_organisation_fao: nil,
+        taxpayer_contact_address: nil,
+        taxpayer_contact_postcode: nil,
+        taxpayer_contact_email: nil,
+        taxpayer_contact_phone: nil
       )
     end
   end

--- a/spec/forms/steps/details/taxpayer_type_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_type_form_spec.rb
@@ -49,7 +49,15 @@ RSpec.describe Steps::Details::TaxpayerTypeForm do
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          taxpayer_type: ContactableEntityType::INDIVIDUAL
+          taxpayer_type: ContactableEntityType::INDIVIDUAL,
+          taxpayer_individual_name: nil,
+          taxpayer_organisation_name: nil,
+          taxpayer_organisation_registration_number: nil,
+          taxpayer_organisation_fao: nil,
+          taxpayer_contact_address: nil,
+          taxpayer_contact_postcode: nil,
+          taxpayer_contact_email: nil,
+          taxpayer_contact_phone: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end


### PR DESCRIPTION
This avoids irrelevant fields staying around and being submitted if a
user jumps around the flow.