### PR TITLE
Split taxpayer name into first/last name fields

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,7 +29,8 @@ class SessionsController < ApplicationController
       taxpayer_contact_phone: Faker::PhoneNumber.phone_number,
       taxpayer_contact_email: Faker::Internet.email,
       taxpayer_contact_postcode: Faker::Address.postcode,
-      taxpayer_individual_name: Faker::Name.name,
+      taxpayer_individual_first_name: Faker::Name.first_name,
+      taxpayer_individual_last_name: Faker::Name.last_name,
       taxpayer_contact_address: [
         Faker::Address.street_address,
         Faker::Address.city,

--- a/app/controllers/steps/details/taxpayer_details_controller.rb
+++ b/app/controllers/steps/details/taxpayer_details_controller.rb
@@ -6,7 +6,8 @@ module Steps::Details
         tribunal_case: current_tribunal_case,
         # Values for all possible form objects are here, as irrelevant ones will simply be
         # discarded by the concrete implementation
-        taxpayer_individual_name: current_tribunal_case.taxpayer_individual_name,
+        taxpayer_individual_first_name: current_tribunal_case.taxpayer_individual_first_name,
+        taxpayer_individual_last_name: current_tribunal_case.taxpayer_individual_last_name,
         taxpayer_organisation_name: current_tribunal_case.taxpayer_organisation_name,
         taxpayer_organisation_registration_number: current_tribunal_case.taxpayer_organisation_registration_number,
         taxpayer_organisation_fao: current_tribunal_case.taxpayer_organisation_fao,

--- a/app/forms/steps/details/taxpayer_individual_details_form.rb
+++ b/app/forms/steps/details/taxpayer_individual_details_form.rb
@@ -1,11 +1,13 @@
 module Steps::Details
   class TaxpayerIndividualDetailsForm < TaxpayerDetailsForm
-    attribute :taxpayer_individual_name, String
+    attribute :taxpayer_individual_first_name, String
+    attribute :taxpayer_individual_last_name, String
 
-    validates_presence_of :taxpayer_individual_name
+    validates_presence_of :taxpayer_individual_first_name,
+                          :taxpayer_individual_last_name
 
     def name_fields
-      [:taxpayer_individual_name]
+      [:taxpayer_individual_first_name, :taxpayer_individual_last_name]
     end
 
     def show_fao?
@@ -20,7 +22,8 @@ module Steps::Details
 
     def persist!
       super(
-        taxpayer_individual_name: taxpayer_individual_name
+        taxpayer_individual_first_name: taxpayer_individual_first_name,
+        taxpayer_individual_last_name: taxpayer_individual_last_name
       )
     end
   end

--- a/app/forms/steps/details/taxpayer_type_form.rb
+++ b/app/forms/steps/details/taxpayer_type_form.rb
@@ -24,7 +24,8 @@ module Steps::Details
       tribunal_case.update(
         taxpayer_type: taxpayer_type_value,
         # The following are dependent attributes that need to be reset
-        taxpayer_individual_name: nil,
+        taxpayer_individual_first_name: nil,
+        taxpayer_individual_last_name: nil,
         taxpayer_organisation_name: nil,
         taxpayer_organisation_registration_number: nil,
         taxpayer_organisation_fao: nil,

--- a/app/presenters/taxpayer_details_presenter.rb
+++ b/app/presenters/taxpayer_details_presenter.rb
@@ -2,7 +2,7 @@ class TaxpayerDetailsPresenter < BaseAnswersPresenter
 
   def name
     return tribunal_case.taxpayer_organisation_fao if tribunal_case.taxpayer_is_organisation?
-    tribunal_case.taxpayer_individual_name
+    [tribunal_case.taxpayer_individual_first_name, tribunal_case.taxpayer_individual_last_name].join(' ')
   end
 
   def phone

--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -34,8 +34,8 @@ class GlimrNewCase
       )
     else
       params.merge!(
-        contactFirstName: taxpayer_first_name,
-        contactLastName: taxpayer_last_name
+        contactFirstName: tc.taxpayer_individual_first_name,
+        contactLastName: tc.taxpayer_individual_last_name
       )
     end
   end
@@ -48,14 +48,6 @@ class GlimrNewCase
 
   def documents_url
     [ENV.fetch('TAX_TRIBUNALS_DOWNLOADER_URL'), tc.files_collection_ref].join('/')
-  end
-
-  def taxpayer_first_name
-    tc.taxpayer_individual_name.split(' ', 2)[0]
-  end
-
-  def taxpayer_last_name
-    tc.taxpayer_individual_name.split(' ', 2)[1]
   end
 
   # contactStreetX are indexed 1 to 4, so if there are more lines than available

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -171,7 +171,8 @@ en:
           company_html: <strong>Company</strong>
           other_organisation_html: <strong>Other type of organisation</strong><br>for example partnership (LLP), trust, club or association
       steps_details_taxpayer_individual_details_form:
-        taxpayer_individual_name: Name (first name and last name)
+        taxpayer_individual_first_name: First name
+        taxpayer_individual_last_name: Last name
         taxpayer_contact_address: Address
         taxpayer_contact_postcode: Postcode
         taxpayer_contact_email: Email address

--- a/db/migrate/20170131114018_split_tribunal_case_taxpayer_name.rb
+++ b/db/migrate/20170131114018_split_tribunal_case_taxpayer_name.rb
@@ -1,0 +1,7 @@
+class SplitTribunalCaseTaxpayerName < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :tribunal_cases, :taxpayer_individual_name
+    add_column :tribunal_cases, :taxpayer_individual_first_name, :string
+    add_column :tribunal_cases, :taxpayer_individual_last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131094256) do
+ActiveRecord::Schema.define(version: 20170131114018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,6 @@ ActiveRecord::Schema.define(version: 20170131094256) do
     t.string   "in_time"
     t.text     "lateness_reason"
     t.string   "taxpayer_type"
-    t.string   "taxpayer_individual_name"
     t.text     "taxpayer_contact_address"
     t.text     "taxpayer_contact_postcode"
     t.string   "taxpayer_contact_email"
@@ -55,6 +54,8 @@ ActiveRecord::Schema.define(version: 20170131094256) do
     t.string   "closure_hmrc_officer"
     t.string   "closure_years_under_enquiry"
     t.text     "closure_additional_info"
+    t.string   "taxpayer_individual_first_name"
+    t.string   "taxpayer_individual_last_name"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/forms/steps/details/taxpayer_individual_details_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_individual_details_form_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe Steps::Details::TaxpayerIndividualDetailsForm do
   it_behaves_like 'a contactable entity form',
     entity_type: :taxpayer,
     additional_fields: [
-      :taxpayer_individual_name
+      :taxpayer_individual_first_name,
+      :taxpayer_individual_last_name
     ]
 
   describe '#name_fields' do
-    specify { expect(subject.name_fields).to eq([:taxpayer_individual_name]) }
+    specify { expect(subject.name_fields).to eq([:taxpayer_individual_first_name, :taxpayer_individual_last_name]) }
   end
 
   describe '#show_fao?' do

--- a/spec/forms/steps/details/taxpayer_type_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_type_form_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Steps::Details::TaxpayerTypeForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           taxpayer_type: ContactableEntityType::INDIVIDUAL,
-          taxpayer_individual_name: nil,
+          taxpayer_individual_first_name: nil,
+          taxpayer_individual_last_name: nil,
           taxpayer_organisation_name: nil,
           taxpayer_organisation_registration_number: nil,
           taxpayer_organisation_fao: nil,

--- a/spec/presenters/taxpayer_details_presenter_spec.rb
+++ b/spec/presenters/taxpayer_details_presenter_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe TaxpayerDetailsPresenter do
   let(:tribunal_case) {
     TribunalCase.new(
       taxpayer_type: taxpayer_type,
-      taxpayer_individual_name: taxpayer_individual_name,
+      taxpayer_individual_first_name: taxpayer_individual_first_name,
+      taxpayer_individual_last_name: taxpayer_individual_last_name,
       taxpayer_contact_address: taxpayer_contact_address,
       taxpayer_contact_postcode: taxpayer_contact_postcode,
       taxpayer_contact_email: taxpayer_contact_email,
@@ -18,7 +19,8 @@ RSpec.describe TaxpayerDetailsPresenter do
   let(:paths) { Rails.application.routes.url_helpers }
 
   let(:taxpayer_type) { nil }
-  let(:taxpayer_individual_name) { 'Name' }
+  let(:taxpayer_individual_first_name) { 'Firstname' }
+  let(:taxpayer_individual_last_name) { 'Lastname' }
   let(:taxpayer_contact_address) { 'Address' }
   let(:taxpayer_contact_postcode) { 'Postcode' }
   let(:taxpayer_contact_email) { 'Email' }
@@ -31,8 +33,8 @@ RSpec.describe TaxpayerDetailsPresenter do
     context 'when taxpayer is not an organisation' do
       let(:taxpayer_type) { OpenStruct.new(value: :anything, organisation?: false) }
 
-      it 'should returns the taxpayer_individual_name field' do
-        expect(subject.name).to eq('Name')
+      it 'should returns the concatenated individual name fields' do
+        expect(subject.name).to eq('Firstname Lastname')
       end
     end
 

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe CaseDetailsPdf do
     {
       case_type: CaseType::OTHER,
       taxpayer_type: taxpayer_type,
-      taxpayer_individual_name: 'Individual Name',
+      taxpayer_individual_first_name: 'Firstname',
+      taxpayer_individual_last_name: 'Lastname',
       taxpayer_organisation_fao: 'Company Contact Name',
       files_collection_ref: 'd29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
       case_reference: 'TC/2016/12345',
@@ -52,7 +53,7 @@ RSpec.describe CaseDetailsPdf do
       expect(controller_ctx).to receive(:render_to_string).and_return('rendered pdf')
       expect(DocumentUpload).to receive(:new).with(
         an_instance_of(File),
-        filename: 'TC_2016_12345_HMRC_IndividualName.pdf',
+        filename: 'TC_2016_12345_HMRC_FirstnameLastname.pdf',
         content_type: 'application/pdf',
         collection_ref: 'd29210a8-f2fe-4d6f-ac96-ea4f9fd66687'
       ).and_return(uploader_double)

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe GlimrNewCase do
-  let!(:tribunal_case)   { TribunalCase.create(case_attributes) }
-  let(:taxpayer_type)    { ContactableEntityType::INDIVIDUAL }
-  let(:taxpayer_name)    { 'Filomena Keebler' }
-  let(:taxpayer_address) { "769 Eleanore Landing\nSuite 225" }
+  let!(:tribunal_case)      { TribunalCase.create(case_attributes) }
+  let(:taxpayer_type)       { ContactableEntityType::INDIVIDUAL }
+  let(:taxpayer_first_name) { 'Filomena' }
+  let(:taxpayer_last_name)  { 'Keebler' }
+  let(:taxpayer_address)    { "769 Eleanore Landing\nSuite 225" }
 
   let(:case_attributes) do
     {
       taxpayer_type: taxpayer_type,
-      taxpayer_individual_name: taxpayer_name,
+      taxpayer_individual_first_name: taxpayer_first_name,
+      taxpayer_individual_last_name: taxpayer_last_name,
       taxpayer_contact_address: taxpayer_address,
       taxpayer_contact_postcode: 'SW1H 9AJ',
       taxpayer_contact_phone: '0700 12345678',
@@ -70,22 +72,6 @@ RSpec.describe GlimrNewCase do
           subject.call!
           expect(subject.case_reference).to eq('TC/12345')
           expect(subject.confirmation_code).to eq('ABCDEF')
-        end
-
-        describe 'different variations of the taxpayer name' do
-          context 'only a first name' do
-            let(:taxpayer_name) { 'Filomena' }
-            let(:glimr_params) { {contactFirstName: 'Filomena', contactLastName: nil} }
-
-            it { subject.call! }
-          end
-
-          context 'a first name and two last names' do
-            let(:taxpayer_name) { 'Filomena Keebler Mayer' }
-            let(:glimr_params) { {contactFirstName: 'Filomena', contactLastName: 'Keebler Mayer'} }
-
-            it { subject.call! }
-          end
         end
 
         context 'lengthy addresses' do


### PR DESCRIPTION
The prototype now has these fields split, which means we can split them
in here as well, simplifying things a bit when it comes to sending data
to GLiMR.