### PR TITLE
Final tweaks for taxpayer forms

### DIFF
--- a/app/forms/steps/details/taxpayer_company_details_form.rb
+++ b/app/forms/steps/details/taxpayer_company_details_form.rb
@@ -5,7 +5,6 @@ module Steps::Details
     attribute :taxpayer_organisation_fao, String
 
     validates_presence_of :taxpayer_organisation_name,
-                          :taxpayer_organisation_registration_number,
                           :taxpayer_organisation_fao
 
     def name_fields

--- a/app/forms/steps/details/taxpayer_details_form.rb
+++ b/app/forms/steps/details/taxpayer_details_form.rb
@@ -7,8 +7,7 @@ module Steps::Details
 
     validates_presence_of :taxpayer_contact_address,
                           :taxpayer_contact_postcode,
-                          :taxpayer_contact_email,
-                          :taxpayer_contact_phone
+                          :taxpayer_contact_email
 
     private
 

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -170,21 +170,24 @@ en:
           individual_html: <strong>Individual</strong>
           company_html: <strong>Company</strong>
           other_organisation_html: <strong>Other type of organisation</strong><br>for example partnership (LLP), trust, club or association
+      generic_taxpayer_contact_labels: &generic_taxpayer_contact_labels
+        taxpayer_contact_address: Address
+        taxpayer_contact_postcode: Postcode
+        taxpayer_contact_email: Email address (to receive confirmation by email)
+        taxpayer_contact_phone: Contact phone number (optional)
       steps_details_taxpayer_individual_details_form:
+        <<: *generic_taxpayer_contact_labels
         taxpayer_individual_first_name: First name
         taxpayer_individual_last_name: Last name
-        taxpayer_contact_address: Address
-        taxpayer_contact_postcode: Postcode
-        taxpayer_contact_email: Email address
-        taxpayer_contact_phone: Phone number
-      steps_details_taxpayer_organisation_details_form:
+      steps_details_taxpayer_company_details_form:
+        <<: *generic_taxpayer_contact_labels
         taxpayer_organisation_name: Company name
-        taxpayer_organisation_registration_number: Company registration number
-        taxpayer_organisation_fao: Company contact person (first name and last name)
-        taxpayer_contact_address: Address
-        taxpayer_contact_postcode: Postcode
-        taxpayer_contact_email: Email address
-        taxpayer_contact_phone: Phone number
+        taxpayer_organisation_registration_number: Company registration number (optional)
+        taxpayer_organisation_fao: Contact name
+      steps_details_taxpayer_organisation_details_form:
+        <<: *generic_taxpayer_contact_labels
+        taxpayer_organisation_name: Organisation name
+        taxpayer_organisation_fao: Contact name
       steps_details_grounds_for_appeal_form:
         grounds_for_appeal: Enter reasons below or attach as a document
         grounds_for_appeal_document: Attach reasons as a document

--- a/spec/forms/steps/details/taxpayer_company_details_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_company_details_form_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Steps::Details::TaxpayerCompanyDetailsForm do
       :taxpayer_organisation_name,
       :taxpayer_organisation_registration_number,
       :taxpayer_organisation_fao
+    ],
+    optional_fields: [
+      :taxpayer_organisation_registration_number
     ]
 
   describe '#name_fields' do

--- a/spec/support/contactable_entity_shared_examples.rb
+++ b/spec/support/contactable_entity_shared_examples.rb
@@ -1,6 +1,7 @@
 RSpec.shared_examples 'a contactable entity form' do |params|
   entity_type = params.fetch(:entity_type)
   additional_fields = params.fetch(:additional_fields, [])
+  optional_fields = params.fetch(:optional_fields, [])
 
   default_fields = [
     "#{entity_type}_contact_address",
@@ -9,7 +10,12 @@ RSpec.shared_examples 'a contactable entity form' do |params|
     "#{entity_type}_contact_phone"
   ].map(&:to_sym)
 
+  optional_fields += [
+    "#{entity_type}_contact_phone"
+  ].map(&:to_sym)
+
   fields = default_fields + additional_fields
+  required_fields = fields - optional_fields
 
   let(:fields_with_dummy_values) { fields.map {|k| [k, 'dummy_value'] }.to_h }
   let(:arguments) { fields_with_dummy_values.merge({ tribunal_case: tribunal_case }) }
@@ -26,7 +32,7 @@ RSpec.shared_examples 'a contactable entity form' do |params|
       end
     end
 
-    fields.each do |field|
+    required_fields.each do |field|
       context "when #{field} is not present" do
         let(:fields_with_dummy_values) { super().merge(field => nil) }
 


### PR DESCRIPTION
- Update and DRY up copy to match prototype and remove duplication
- Make phone number and company registration number fields optional