### PR TITLE
Add representative to details flow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -228,7 +228,7 @@
                    A complexity metric that is strongly correlated to the number
                    of test cases needed to validate a method.
     Enabled: true
-    Max: 10
+    Max: 15
 
   Metrics/LineLength:
     Description: 'Limit lines to 80 characters.'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,12 +31,24 @@ class SessionsController < ApplicationController
       case_type: CaseType::OTHER,
       challenged_decision: ChallengedDecision::YES,
       in_time: InTime::YES,
+      taxpayer_type: ContactableEntityType::INDIVIDUAL,
       taxpayer_contact_phone: Faker::PhoneNumber.phone_number,
       taxpayer_contact_email: Faker::Internet.email,
       taxpayer_contact_postcode: Faker::Address.postcode,
       taxpayer_individual_first_name: Faker::Name.first_name,
       taxpayer_individual_last_name: Faker::Name.last_name,
       taxpayer_contact_address: [
+        Faker::Address.street_address,
+        Faker::Address.city,
+        Faker::Address.county
+      ].join("\n"),
+      representative_type: ContactableEntityType::INDIVIDUAL,
+      representative_contact_phone: Faker::PhoneNumber.phone_number,
+      representative_contact_email: Faker::Internet.email,
+      representative_contact_postcode: Faker::Address.postcode,
+      representative_individual_first_name: Faker::Name.first_name,
+      representative_individual_last_name: Faker::Name.last_name,
+      representative_contact_address: [
         Faker::Address.street_address,
         Faker::Address.city,
         Faker::Address.county

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,11 @@ class SessionsController < ApplicationController
   def create_and_fill_appeal
     raise 'For development use only' unless Rails.env.development?
     # :nocov:
-    tribunal_case.update(case_type: CaseType::OTHER, challenged_decision: ChallengedDecision::YES)
+    tribunal_case.update(
+      intent: Intent::TAX_APPEAL,
+      case_type: CaseType::OTHER,
+      challenged_decision: ChallengedDecision::YES
+    )
     redirect_to task_list_path
     # :nocov:
   end
@@ -23,6 +27,7 @@ class SessionsController < ApplicationController
     raise 'For development use only' unless Rails.env.development?
     # :nocov:
     tribunal_case.update(
+      intent: Intent::TAX_APPEAL,
       case_type: CaseType::OTHER,
       challenged_decision: ChallengedDecision::YES,
       in_time: InTime::YES,

--- a/app/controllers/steps/details/has_representative_controller.rb
+++ b/app/controllers/steps/details/has_representative_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Details
+  class HasRepresentativeController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = HasRepresentativeForm.new(
+        tribunal_case: current_tribunal_case,
+        has_representative: current_tribunal_case.has_representative
+      )
+    end
+
+    def update
+      update_and_advance(HasRepresentativeForm)
+    end
+  end
+end

--- a/app/controllers/steps/details/representative_details_controller.rb
+++ b/app/controllers/steps/details/representative_details_controller.rb
@@ -1,0 +1,38 @@
+module Steps::Details
+  class RepresentativeDetailsController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = form_klass.new(
+        tribunal_case: current_tribunal_case,
+        # Values for all possible form objects are here, as irrelevant ones will simply be
+        # discarded by the concrete implementation
+        representative_individual_first_name: current_tribunal_case.representative_individual_first_name,
+        representative_individual_last_name: current_tribunal_case.representative_individual_last_name,
+        representative_organisation_name: current_tribunal_case.representative_organisation_name,
+        representative_organisation_registration_number: current_tribunal_case.representative_organisation_registration_number,
+        representative_organisation_fao: current_tribunal_case.representative_organisation_fao,
+        representative_contact_address: current_tribunal_case.representative_contact_address,
+        representative_contact_postcode: current_tribunal_case.representative_contact_postcode,
+        representative_contact_email: current_tribunal_case.representative_contact_email,
+        representative_contact_phone: current_tribunal_case.representative_contact_phone
+      )
+    end
+
+    def update
+      update_and_advance(form_klass, as: :representative_details)
+    end
+
+    private
+
+    def form_klass
+      case current_tribunal_case.representative_type
+      when ContactableEntityType::INDIVIDUAL
+        RepresentativeIndividualDetailsForm
+      when ContactableEntityType::COMPANY
+        RepresentativeCompanyDetailsForm
+      when ContactableEntityType::OTHER_ORGANISATION
+        RepresentativeOrganisationDetailsForm
+      end
+    end
+  end
+end

--- a/app/controllers/steps/details/representative_type_controller.rb
+++ b/app/controllers/steps/details/representative_type_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Details
+  class RepresentativeTypeController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = RepresentativeTypeForm.new(
+        tribunal_case: current_tribunal_case,
+        representative_type: current_tribunal_case.representative_type
+      )
+    end
+
+    def update
+      update_and_advance(RepresentativeTypeForm)
+    end
+  end
+end

--- a/app/forms/steps/details/has_representative_form.rb
+++ b/app/forms/steps/details/has_representative_form.rb
@@ -1,0 +1,39 @@
+module Steps::Details
+  class HasRepresentativeForm < BaseForm
+    attribute :has_representative, String
+
+    def self.choices
+      HasRepresentative.values.map(&:to_s)
+    end
+    validates_inclusion_of :has_representative, in: choices
+
+    private
+
+    def has_representative_value
+      HasRepresentative.new(has_representative)
+    end
+
+    def changed?
+      tribunal_case.has_representative != has_representative_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return true unless changed?
+
+      tribunal_case.update(
+        has_representative: has_representative_value,
+        # The following are dependent attributes that need to be reset
+        representative_individual_first_name: nil,
+        representative_individual_last_name: nil,
+        representative_organisation_name: nil,
+        representative_organisation_registration_number: nil,
+        representative_organisation_fao: nil,
+        representative_contact_address: nil,
+        representative_contact_postcode: nil,
+        representative_contact_email: nil,
+        representative_contact_phone: nil
+      )
+    end
+  end
+end

--- a/app/forms/steps/details/representative_company_details_form.rb
+++ b/app/forms/steps/details/representative_company_details_form.rb
@@ -1,0 +1,32 @@
+module Steps::Details
+  class RepresentativeCompanyDetailsForm < RepresentativeDetailsForm
+    attribute :representative_organisation_name, String
+    attribute :representative_organisation_registration_number, String
+    attribute :representative_organisation_fao, String
+
+    validates_presence_of :representative_organisation_name,
+                          :representative_organisation_fao
+
+    def name_fields
+      [:representative_organisation_name]
+    end
+
+    def show_fao?
+      true
+    end
+
+    def show_registration_number?
+      true
+    end
+
+    private
+
+    def persist!
+      super(
+        representative_organisation_name:                representative_organisation_name,
+        representative_organisation_registration_number: representative_organisation_registration_number,
+        representative_organisation_fao:                 representative_organisation_fao
+      )
+    end
+  end
+end

--- a/app/forms/steps/details/representative_details_form.rb
+++ b/app/forms/steps/details/representative_details_form.rb
@@ -1,0 +1,25 @@
+module Steps::Details
+  class RepresentativeDetailsForm < BaseForm
+    attribute :representative_contact_address, String
+    attribute :representative_contact_postcode, String
+    attribute :representative_contact_email, String
+    attribute :representative_contact_phone, String
+
+    validates_presence_of :representative_contact_address,
+                          :representative_contact_postcode,
+                          :representative_contact_email
+
+    private
+
+    def persist!(additional_attributes)
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.update({
+        representative_contact_address:  representative_contact_address,
+        representative_contact_postcode: representative_contact_postcode,
+        representative_contact_email:    representative_contact_email,
+        representative_contact_phone:    representative_contact_phone
+      }.merge(additional_attributes))
+    end
+  end
+end

--- a/app/forms/steps/details/representative_individual_details_form.rb
+++ b/app/forms/steps/details/representative_individual_details_form.rb
@@ -1,0 +1,30 @@
+module Steps::Details
+  class RepresentativeIndividualDetailsForm < RepresentativeDetailsForm
+    attribute :representative_individual_first_name, String
+    attribute :representative_individual_last_name, String
+
+    validates_presence_of :representative_individual_first_name,
+                          :representative_individual_last_name
+
+    def name_fields
+      [:representative_individual_first_name, :representative_individual_last_name]
+    end
+
+    def show_fao?
+      false
+    end
+
+    def show_registration_number?
+      false
+    end
+
+    private
+
+    def persist!
+      super(
+        representative_individual_first_name: representative_individual_first_name,
+        representative_individual_last_name: representative_individual_last_name
+      )
+    end
+  end
+end

--- a/app/forms/steps/details/representative_organisation_details_form.rb
+++ b/app/forms/steps/details/representative_organisation_details_form.rb
@@ -1,0 +1,30 @@
+module Steps::Details
+  class RepresentativeOrganisationDetailsForm < RepresentativeDetailsForm
+    attribute :representative_organisation_name, String
+    attribute :representative_organisation_fao, String
+
+    validates_presence_of :representative_organisation_name,
+                          :representative_organisation_fao
+
+    def name_fields
+      [:representative_organisation_name]
+    end
+
+    def show_fao?
+      true
+    end
+
+    def show_registration_number?
+      false
+    end
+
+    private
+
+    def persist!
+      super(
+        representative_organisation_name: representative_organisation_name,
+        representative_organisation_fao: representative_organisation_fao
+      )
+    end
+  end
+end

--- a/app/forms/steps/details/representative_type_form.rb
+++ b/app/forms/steps/details/representative_type_form.rb
@@ -1,0 +1,39 @@
+module Steps::Details
+  class RepresentativeTypeForm < BaseForm
+    attribute :representative_type, String
+
+    def self.choices
+      ContactableEntityType.values.map(&:to_s)
+    end
+    validates_inclusion_of :representative_type, in: choices
+
+    private
+
+    def representative_type_value
+      ContactableEntityType.new(representative_type)
+    end
+
+    def changed?
+      tribunal_case.representative_type != representative_type_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return true unless changed?
+
+      tribunal_case.update(
+        representative_type: representative_type_value,
+        # The following are dependent attributes that need to be reset
+        representative_individual_first_name: nil,
+        representative_individual_last_name: nil,
+        representative_organisation_name: nil,
+        representative_organisation_registration_number: nil,
+        representative_organisation_fao: nil,
+        representative_contact_address: nil,
+        representative_contact_postcode: nil,
+        representative_contact_email: nil,
+        representative_contact_phone: nil
+      )
+    end
+  end
+end

--- a/app/forms/steps/details/taxpayer_type_form.rb
+++ b/app/forms/steps/details/taxpayer_type_form.rb
@@ -3,7 +3,7 @@ module Steps::Details
     attribute :taxpayer_type, String
 
     def self.choices
-     ContactableEntityType.values.map(&:to_s)
+      ContactableEntityType.values.map(&:to_s)
     end
     validates_inclusion_of :taxpayer_type, in: choices
 

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -14,7 +14,9 @@ class TribunalCase < ApplicationRecord
   has_value_object :in_time
 
   # Details task
+  has_value_object :has_representative
   has_value_object :taxpayer_type, class_name: 'ContactableEntityType'
+  has_value_object :representative_type, class_name: 'ContactableEntityType'
 
   # Closure task
   has_value_object :intent

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -6,6 +6,12 @@ class DetailsDecisionTree < DecisionTree
     when :taxpayer_type
       edit(:taxpayer_details)
     when :taxpayer_details
+      edit(:has_representative)
+    when :has_representative
+      after_has_representative_step
+    when :representative_type
+      edit(:representative_details)
+    when :representative_details
       after_details_step
     when :grounds_for_appeal
       edit(:outcome)
@@ -26,8 +32,14 @@ class DetailsDecisionTree < DecisionTree
       before_taxpayer_type_step
     when :taxpayer_details
       edit(:taxpayer_type)
-    when :grounds_for_appeal
+    when :has_representative
       edit(:taxpayer_details)
+    when :representative_type
+      edit(:has_representative)
+    when :representative_details
+      edit(:representative_type)
+    when :grounds_for_appeal
+      before_grounds_for_appeal_step
     when :outcome
       edit(:grounds_for_appeal)
     when :documents_checklist
@@ -50,12 +62,30 @@ class DetailsDecisionTree < DecisionTree
     end
   end
 
+  def after_has_representative_step
+    case tribunal_case.has_representative
+    when HasRepresentative::YES
+      edit(:representative_type)
+    when HasRepresentative::NO
+      after_details_step
+    end
+  end
+
   def after_details_step
     case tribunal_case.intent
     when Intent::TAX_APPEAL
       edit(:grounds_for_appeal)
     when Intent::CLOSE_ENQUIRY
       edit('/steps/closure/enquiry_details')
+    end
+  end
+
+  def before_grounds_for_appeal_step
+    case tribunal_case.has_representative
+    when HasRepresentative::YES
+      edit(:representative_details)
+    when HasRepresentative::NO
+      edit(:has_representative)
     end
   end
 end

--- a/app/value_objects/has_representative.rb
+++ b/app/value_objects/has_representative.rb
@@ -1,0 +1,10 @@
+class HasRepresentative < ValueObject
+  VALUES = [
+    YES = new(:yes),
+    NO  = new(:no),
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/details/has_representative/edit.html.erb
+++ b/app/views/steps/details/has_representative/edit.html.erb
@@ -1,0 +1,24 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:details, 3) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :has_representative,
+        choices: Steps::Details::HasRepresentativeForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+    
+    <details role="group">
+      <summary role="button" aria-controls="details-content-0" aria-expanded="true">
+        <%=t '.details_heading' %>
+      </summary>
+			<div class="panel" id="details-content-0" aria-hidden="false">
+        <%=t '.details_content_html' %>
+			</div>
+		</details>  
+  </div>
+</div>

--- a/app/views/steps/details/has_representative/edit.html.erb
+++ b/app/views/steps/details/has_representative/edit.html.erb
@@ -11,14 +11,14 @@
         choices: Steps::Details::HasRepresentativeForm.choices %>
       <%= f.submit class: 'button' %>
     <% end %>
-    
+
     <details role="group">
       <summary role="button" aria-controls="details-content-0" aria-expanded="true">
         <%=t '.details_heading' %>
       </summary>
-			<div class="panel" id="details-content-0" aria-hidden="false">
+      <div class="panel" id="details-content-0" aria-hidden="false">
         <%=t '.details_content_html' %>
-			</div>
-		</details>  
+      </div>
+    </details>
   </div>
 </div>

--- a/app/views/steps/details/representative_details/edit.html.erb
+++ b/app/views/steps/details/representative_details/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:details, 0) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= step_form @form_object do |f| %>
+      <% @form_object.name_fields.each do |name_field| %>
+        <%= f.text_field name_field %>
+      <% end %>
+      <%= f.text_area :representative_contact_address, size: '40x4', class: 'form-control-3-4' %>
+      <%= f.text_field :representative_contact_postcode %>
+      <% if @form_object.show_fao? %>
+        <%= f.text_field :representative_organisation_fao %>
+      <% end %>
+      <%= f.text_field :representative_contact_email %>
+      <%= f.text_field :representative_contact_phone %>
+      <% if @form_object.show_registration_number? %>
+        <%= f.text_field :representative_organisation_registration_number %>
+      <% end %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/steps/details/representative_type/edit.html.erb
+++ b/app/views/steps/details/representative_type/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:details, 0) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :representative_type,
+        choices: Steps::Details::RepresentativeTypeForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -41,6 +41,24 @@ en:
       taxpayer_details:
         edit:
           heading: Enter taxpayer's details
+      has_representative:
+        edit:
+          heading: Do you have someone to represent you?
+          lead_text: A representative can receive correspondence on your behalf or represent you if you need a hearing.
+          details_heading: What is a representative and what can they do?
+          details_content_html: |
+            <p>A representative is someone who can act on your behalf when dealing with the tax tribunal.</p>
+            <p>You may want to use one if you need help or advice, or need assistance submitting an appeal or application.</p>
+            <p>A representative could be a lawyer, tax adviser or accountant. It could also be a friend or family relative who you approve to act on your behalf.</p>
+            <p>If a representative is not a certified legal professional they will need to be authorised by the taxpayer to act on their behalf to handle any matters related to an appeal or application.</p>
+            <p>An authorised representative will be able to receive any correspondence from the tax tribunal and can represent the taxpayer at a hearing with the judge.</p>
+      representative_type:
+        edit:
+          heading: Is your representative an individual, company or other type of organisation?
+      representative_details:
+        edit:
+          heading: Representative's details
+          lead_text: If you have approved your representative to act on your behalf, all correspondence will be sent to the address, or email address, you enter below.
       grounds_for_appeal:
         edit:
           heading: Grounds for appeal
@@ -134,7 +152,15 @@ en:
         steps/details/taxpayer_type_form:
           attributes:
             taxpayer_type:
-              inclusion: Select whether the appeal is for an individual or organisation
+              inclusion: Select whether the appeal is for an individual, company or organisation
+        steps/details/has_representative_form:
+          attributes:
+            has_representative:
+              inclusion: Select whether you have someone to represent you
+        steps/details/representative_type_form:
+          attributes:
+            representative_type:
+              inclusion: Select whether your representative is an individual, company or organisation
         steps/details/grounds_for_appeal_form:
           attributes:
             grounds_for_appeal:
@@ -150,6 +176,8 @@ en:
               too_short: You must outline the result you want. Use at least %{count} characters.
         steps/details/taxpayer_individual_details_form:
           blank: You must enter the taxpayer's %{attribute}
+        steps/details/taxpayer_company_details_form:
+          blank: You must enter the taxpayer's %{attribute}
         steps/details/taxpayer_organisation_details_form:
           blank: You must enter the taxpayer's %{attribute}
         steps/details/documents_checklist_form:
@@ -164,12 +192,25 @@ en:
     fieldset:
       steps_details_taxpayer_type_form:
         taxpayer_type: Who is your appeal for?
+      steps_details_has_representative_form:
+        has_representative: Do you have someone to represent you?
+      steps_details_representative_type_form:
+        representative_type: Is your representative an individual, company or other type of organisation?
     label:
       steps_details_taxpayer_type_form:
         taxpayer_type:
           individual_html: <strong>Individual</strong>
           company_html: <strong>Company</strong>
           other_organisation_html: <strong>Other type of organisation</strong><br>for example partnership (LLP), trust, club or association
+      steps_details_has_representative_form:
+        has_representative:
+          'yes': 'Yes'
+          'no': 'No'
+      steps_details_representative_type_form:
+        representative_type:
+          individual_html: <strong>Individual</strong>
+          company_html: <strong>Company</strong>
+          other_organisation_html: <strong>Other type of organisation</strong><br>for example partnership (LLP)
       generic_taxpayer_contact_labels: &generic_taxpayer_contact_labels
         taxpayer_contact_address: Address
         taxpayer_contact_postcode: Postcode
@@ -188,6 +229,24 @@ en:
         <<: *generic_taxpayer_contact_labels
         taxpayer_organisation_name: Organisation name
         taxpayer_organisation_fao: Contact name
+      generic_representative_contact_labels: &generic_representative_contact_labels
+        representative_contact_address: Address
+        representative_contact_postcode: Postcode
+        representative_contact_email: Email address (to receive confirmation by email)
+        representative_contact_phone: Contact phone number (optional)
+      steps_details_representative_individual_details_form:
+        <<: *generic_representative_contact_labels
+        representative_individual_first_name: First name
+        representative_individual_last_name: Last name
+      steps_details_representative_company_details_form:
+        <<: *generic_representative_contact_labels
+        representative_organisation_name: Company name
+        representative_organisation_registration_number: Company registration number (optional)
+        representative_organisation_fao: Contact name
+      steps_details_representative_organisation_details_form:
+        <<: *generic_representative_contact_labels
+        representative_organisation_name: Organisation name
+        representative_organisation_fao: Contact name
       steps_details_grounds_for_appeal_form:
         grounds_for_appeal: Enter reasons below or attach as a document
         grounds_for_appeal_document: Attach reasons as a document

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,9 @@ Rails.application.routes.draw do
       show_step :start
       edit_step :taxpayer_type
       edit_step :taxpayer_details
+      edit_step :has_representative
+      edit_step :representative_type
+      edit_step :representative_details
       edit_step :grounds_for_appeal
       edit_step :outcome
       edit_step :documents_checklist

--- a/db/migrate/20170131174559_add_has_representative_to_tribunal_cases.rb
+++ b/db/migrate/20170131174559_add_has_representative_to_tribunal_cases.rb
@@ -1,0 +1,5 @@
+class AddHasRepresentativeToTribunalCases < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :has_representative, :string
+  end
+end

--- a/db/migrate/20170131191054_add_representative_fields_to_tribunal_case.rb
+++ b/db/migrate/20170131191054_add_representative_fields_to_tribunal_case.rb
@@ -1,0 +1,14 @@
+class AddRepresentativeFieldsToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :representative_type, :string
+    add_column :tribunal_cases, :representative_individual_first_name, :string
+    add_column :tribunal_cases, :representative_individual_last_name, :string
+    add_column :tribunal_cases, :representative_contact_address, :text
+    add_column :tribunal_cases, :representative_contact_postcode, :text
+    add_column :tribunal_cases, :representative_contact_email, :string
+    add_column :tribunal_cases, :representative_contact_phone, :string
+    add_column :tribunal_cases, :representative_organisation_name, :string
+    add_column :tribunal_cases, :representative_organisation_fao, :string
+    add_column :tribunal_cases, :representative_organisation_registration_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131114018) do
+ActiveRecord::Schema.define(version: 20170131191054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.datetime "created_at",                                                                      null: false
-    t.datetime "updated_at",                                                                      null: false
+    t.datetime "created_at",                                                                            null: false
+    t.datetime "updated_at",                                                                            null: false
     t.string   "case_type"
     t.string   "dispute_type"
     t.string   "penalty_level"
@@ -34,10 +34,10 @@ ActiveRecord::Schema.define(version: 20170131114018) do
     t.string   "taxpayer_organisation_registration_number"
     t.text     "grounds_for_appeal"
     t.string   "grounds_for_appeal_file_name"
-    t.uuid     "files_collection_ref",                      default: -> { "uuid_generate_v4()" }
-    t.boolean  "original_notice_provided",                  default: false
-    t.boolean  "review_conclusion_provided",                default: false
-    t.boolean  "having_problems_uploading_documents",       default: false
+    t.uuid     "files_collection_ref",                            default: -> { "uuid_generate_v4()" }
+    t.boolean  "original_notice_provided",                        default: false
+    t.boolean  "review_conclusion_provided",                      default: false
+    t.boolean  "having_problems_uploading_documents",             default: false
     t.string   "challenged_decision"
     t.string   "disputed_tax_paid"
     t.string   "hardship_review_requested"
@@ -56,6 +56,17 @@ ActiveRecord::Schema.define(version: 20170131114018) do
     t.text     "closure_additional_info"
     t.string   "taxpayer_individual_first_name"
     t.string   "taxpayer_individual_last_name"
+    t.string   "has_representative"
+    t.string   "representative_type"
+    t.string   "representative_individual_first_name"
+    t.string   "representative_individual_last_name"
+    t.text     "representative_contact_address"
+    t.text     "representative_contact_postcode"
+    t.string   "representative_contact_email"
+    t.string   "representative_contact_phone"
+    t.string   "representative_organisation_name"
+    t.string   "representative_organisation_fao"
+    t.string   "representative_organisation_registration_number"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/steps/details/has_representative_controller_spec.rb
+++ b/spec/controllers/steps/details/has_representative_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::HasRepresentativeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::HasRepresentativeForm, DetailsDecisionTree
+end

--- a/spec/controllers/steps/details/representative_details_controller_spec.rb
+++ b/spec/controllers/steps/details/representative_details_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::RepresentativeDetailsController, type: :controller do
+  before do
+    allow(controller).to receive(:current_tribunal_case).and_return(tribunal_case)
+  end
+
+  context 'given an individual representative' do
+    let(:tribunal_case) { TribunalCase.new(representative_type: ContactableEntityType::INDIVIDUAL) }
+
+    it_behaves_like 'an intermediate step controller', Steps::Details::RepresentativeIndividualDetailsForm, DetailsDecisionTree
+  end
+
+  context 'given a company representative' do
+    let(:tribunal_case) { TribunalCase.new(representative_type: ContactableEntityType::COMPANY) }
+
+    it_behaves_like 'an intermediate step controller', Steps::Details::RepresentativeCompanyDetailsForm, DetailsDecisionTree
+  end
+
+  context 'given an organisation representative' do
+    let(:tribunal_case) { TribunalCase.new(representative_type: ContactableEntityType::OTHER_ORGANISATION) }
+
+    it_behaves_like 'an intermediate step controller', Steps::Details::RepresentativeOrganisationDetailsForm, DetailsDecisionTree
+  end
+end

--- a/spec/controllers/steps/details/representative_type_controller_spec.rb
+++ b/spec/controllers/steps/details/representative_type_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::RepresentativeTypeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::RepresentativeTypeForm, DetailsDecisionTree
+end

--- a/spec/forms/steps/details/has_representative_form_spec.rb
+++ b/spec/forms/steps/details/has_representative_form_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::HasRepresentativeForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    has_representative: has_representative
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, has_representative: nil) }
+  let(:has_representative) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:has_representative) { 'yes' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when has_representative is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:has_representative]).to_not be_empty
+      end
+    end
+
+    context 'when has_representative is not valid' do
+      let(:has_representative) { 'Alan Shore' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:has_representative]).to_not be_empty
+      end
+    end
+
+    context 'when has_representative is valid' do
+      let(:has_representative) { 'yes' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          has_representative: HasRepresentative::YES,
+          representative_individual_first_name: nil,
+          representative_individual_last_name: nil,
+          representative_organisation_name: nil,
+          representative_organisation_registration_number: nil,
+          representative_organisation_fao: nil,
+          representative_contact_address: nil,
+          representative_contact_postcode: nil,
+          representative_contact_email: nil,
+          representative_contact_phone: nil
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when has_representative is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          has_representative: HasRepresentative::NO
+        )
+      }
+      let(:has_representative) { 'no' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/forms/steps/details/representative_company_details_form_spec.rb
+++ b/spec/forms/steps/details/representative_company_details_form_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::RepresentativeCompanyDetailsForm do
+  it_behaves_like 'a contactable entity form',
+    entity_type: :representative,
+    additional_fields: [
+      :representative_organisation_name,
+      :representative_organisation_registration_number,
+      :representative_organisation_fao
+    ],
+    optional_fields: [
+      :representative_organisation_registration_number
+    ]
+
+  describe '#name_fields' do
+    specify { expect(subject.name_fields).to eq([:representative_organisation_name]) }
+  end
+
+  describe '#show_fao?' do
+    specify { expect(subject.show_fao?).to eq(true) }
+  end
+
+  describe '#show_registration_number?' do
+    specify { expect(subject.show_registration_number?).to eq(true) }
+  end
+end

--- a/spec/forms/steps/details/representative_individual_details_form_spec.rb
+++ b/spec/forms/steps/details/representative_individual_details_form_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::RepresentativeIndividualDetailsForm do
+  it_behaves_like 'a contactable entity form',
+    entity_type: :representative,
+    additional_fields: [
+      :representative_individual_first_name,
+      :representative_individual_last_name
+    ]
+
+  describe '#name_fields' do
+    specify { expect(subject.name_fields).to eq([:representative_individual_first_name, :representative_individual_last_name]) }
+  end
+
+  describe '#show_fao?' do
+    specify { expect(subject.show_fao?).to eq(false) }
+  end
+
+  describe '#show_registration_number?' do
+    specify { expect(subject.show_registration_number?).to eq(false) }
+  end
+end

--- a/spec/forms/steps/details/representative_organisation_details_form_spec.rb
+++ b/spec/forms/steps/details/representative_organisation_details_form_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::RepresentativeOrganisationDetailsForm do
+  it_behaves_like 'a contactable entity form',
+    entity_type: :representative,
+    additional_fields: [
+      :representative_organisation_name,
+      :representative_organisation_fao
+    ]
+
+  describe '#name_fields' do
+    specify { expect(subject.name_fields).to eq([:representative_organisation_name]) }
+  end
+
+  describe '#show_fao?' do
+    specify { expect(subject.show_fao?).to eq(true) }
+  end
+
+  describe '#show_registration_number?' do
+    specify { expect(subject.show_registration_number?).to eq(false) }
+  end
+end

--- a/spec/forms/steps/details/representative_type_form_spec.rb
+++ b/spec/forms/steps/details/representative_type_form_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::RepresentativeTypeForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    representative_type: representative_type
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, representative_type: nil) }
+  let(:representative_type) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:representative_type) { 'company' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when representative_type is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:representative_type]).to_not be_empty
+      end
+    end
+
+    context 'when representative_type is not valid' do
+      let(:representative_type) { 'denny_crane' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:representative_type]).to_not be_empty
+      end
+    end
+
+    context 'when representative_type is valid' do
+      let(:representative_type) { 'individual' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          representative_type: ContactableEntityType::INDIVIDUAL,
+          representative_individual_first_name: nil,
+          representative_individual_last_name: nil,
+          representative_organisation_name: nil,
+          representative_organisation_registration_number: nil,
+          representative_organisation_fao: nil,
+          representative_contact_address: nil,
+          representative_contact_postcode: nil,
+          representative_contact_email: nil,
+          representative_contact_phone: nil
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when representative_type is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          representative_type: ContactableEntityType.new(:individual)
+        )
+      }
+      let(:representative_type) { 'individual' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -16,6 +16,42 @@ RSpec.describe DetailsDecisionTree do
     context 'when the step is `taxpayer_details`' do
       let(:step_params) { { taxpayer_details: 'anything'  } }
 
+      it { is_expected.to have_destination(:has_representative, :edit) }
+    end
+
+    context 'when the step is `has_representative`' do
+      let(:step_params) { { has_representative: 'anything'  } }
+
+      context 'and the answer is yes' do
+        let(:tribunal_case) { instance_double(TribunalCase, has_representative: HasRepresentative::YES) }
+
+        it { is_expected.to have_destination(:representative_type, :edit) }
+      end
+
+      context 'and the answer is no' do
+        context 'for a tax appeal' do
+          let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::TAX_APPEAL, has_representative: HasRepresentative::NO) }
+
+          it { is_expected.to have_destination(:grounds_for_appeal, :edit) }
+        end
+
+        context 'for a closure enquiry' do
+          let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::CLOSE_ENQUIRY, has_representative: HasRepresentative::NO) }
+
+          it { is_expected.to have_destination('/steps/closure/enquiry_details', :edit) }
+        end
+      end
+    end
+
+    context 'when the step is `representative_type`' do
+      let(:step_params) { { representative_type: 'anything'  } }
+
+      it { is_expected.to have_destination(:representative_details, :edit) }
+    end
+
+    context 'when the step is `representative_details`' do
+      let(:step_params) { { representative_details: 'anything'  } }
+
       context 'for a tax appeal' do
         let(:tribunal_case) { instance_double(TribunalCase, intent: Intent::TAX_APPEAL) }
 
@@ -85,10 +121,38 @@ RSpec.describe DetailsDecisionTree do
       it { is_expected.to have_previous(:taxpayer_type, :edit) }
     end
 
+    context 'when the step is `has_representative`' do
+      let(:step_params) { { has_representative: 'anything'  } }
+
+      it { is_expected.to have_previous(:taxpayer_details, :edit) }
+    end
+
+    context 'when the step is `representative_type`' do
+      let(:step_params) { { representative_type: 'anything'  } }
+
+      it { is_expected.to have_previous(:has_representative, :edit) }
+    end
+
+    context 'when the step is `representative_details`' do
+      let(:step_params) { { representative_details: 'anything'  } }
+
+      it { is_expected.to have_previous(:representative_type, :edit) }
+    end
+
     context 'when the step is `grounds_for_appeal`' do
       let(:step_params) { { grounds_for_appeal: 'anything'  } }
 
-      it { is_expected.to have_previous(:taxpayer_details, :edit) }
+      context 'when there is a representative' do
+        let(:tribunal_case) { instance_double(TribunalCase, has_representative: HasRepresentative::YES) }
+
+        it { is_expected.to have_previous(:representative_details, :edit) }
+      end
+
+      context 'when there is not a representative' do
+        let(:tribunal_case) { instance_double(TribunalCase, has_representative: HasRepresentative::NO) }
+
+        it { is_expected.to have_previous(:has_representative, :edit) }
+      end
     end
 
     context 'when the step is `outcome`' do


### PR DESCRIPTION
Taxpayers can be represented by someone else in their tribunal case.
This adds the ability to specify the taxpayer's representative as part
of the details flow.

- Add a question about whether or not the taxpayer has a representative,
  along with the necessary controller, form, view, and a value object
  for the answer
- Mirror the controller/form/view structure for taxpayer details for
  representative details
- Wire up the details decision tree accordingly