### PR TITLE
Closure flow - Part IV. Support documents upload step.

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,11 +5,11 @@ class DocumentsController < ApplicationController
     uploader = DocumentUpload.new(document_param, collection_ref: collection_ref)
     uploader.upload! if uploader.valid?
 
-    respond_with(uploader, location: edit_steps_details_documents_checklist_path) do |format|
+    respond_with(uploader, location: current_step_path) do |format|
       if uploader.errors?
         format.html {
           flash[:alert] = uploader.errors
-          redirect_to edit_steps_details_documents_checklist_path
+          redirect_to current_step_path
         }
         format.json {
           render json: {error: uploader.errors}, status: :unprocessable_entity
@@ -24,15 +24,10 @@ class DocumentsController < ApplicationController
       filename: filename
     ).call
 
-    if grounds_for_appeal_filename?
-      current_tribunal_case.update(grounds_for_appeal_file_name: nil)
-      back_step = edit_steps_details_grounds_for_appeal_path
-    else
-      back_step = edit_steps_details_documents_checklist_path
-    end
+    current_tribunal_case.update(grounds_for_appeal_file_name: nil) if grounds_for_appeal_filename?
 
     respond_to do |format|
-      format.html { redirect_to back_step }
+      format.html { redirect_to current_step_path }
       format.json { head :no_content }
       format.js   { head :no_content }
     end
@@ -46,6 +41,10 @@ class DocumentsController < ApplicationController
 
   def grounds_for_appeal_filename?
     decoded_filename == current_tribunal_case.grounds_for_appeal_file_name
+  end
+
+  def current_step_path
+    document_params[:current_step_path]
   end
 
   def filename
@@ -65,6 +64,6 @@ class DocumentsController < ApplicationController
   end
 
   def document_params
-    params.permit(:_method, :id, :step, :document, :authenticity_token)
+    params.permit(:_method, :id, :current_step_path, :document, :authenticity_token)
   end
 end

--- a/app/controllers/steps/closure/support_documents_controller.rb
+++ b/app/controllers/steps/closure/support_documents_controller.rb
@@ -1,0 +1,24 @@
+module Steps::Closure
+  class SupportDocumentsController < Steps::ClosureStepController
+    before_action :set_documents_list, only: [:edit, :update]
+
+    def edit
+      super
+      @form_object = SupportDocumentsForm.new(
+        tribunal_case: current_tribunal_case,
+        closure_problems_uploading_documents: current_tribunal_case.closure_problems_uploading_documents,
+        closure_problems_uploading_details: current_tribunal_case.closure_problems_uploading_details
+      )
+    end
+
+    def update
+      update_and_advance(SupportDocumentsForm, as: :support_documents)
+    end
+
+    private
+
+    def set_documents_list
+      @document_list = current_tribunal_case&.documents || []
+    end
+  end
+end

--- a/app/forms/steps/closure/support_documents_form.rb
+++ b/app/forms/steps/closure/support_documents_form.rb
@@ -1,0 +1,20 @@
+module Steps::Closure
+  class SupportDocumentsForm < BaseForm
+    attribute :closure_problems_uploading_documents, Boolean
+    attribute :closure_problems_uploading_details, String
+
+    validates_length_of :closure_problems_uploading_details, minimum: 2,
+                        if: :closure_problems_uploading_documents
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.update(
+        closure_problems_uploading_documents: closure_problems_uploading_documents,
+        closure_problems_uploading_details: closure_problems_uploading_details
+      )
+    end
+  end
+end

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -7,6 +7,10 @@ class ClosureDecisionTree < DecisionTree
       edit('/steps/details/taxpayer_type')
     when :enquiry_details
       edit(:additional_info)
+    when :additional_info
+      edit(:support_documents)
+    when :support_documents
+      show(:start) # TODO: check your answers step
     else
       raise "Invalid step '#{step_params}'"
     end
@@ -20,6 +24,8 @@ class ClosureDecisionTree < DecisionTree
       edit('/steps/details/taxpayer_type')
     when :additional_info
       edit(:enquiry_details)
+    when :support_documents
+      edit(:additional_info)
     else
       raise "Invalid step '#{step_params}'"
     end

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -1,0 +1,73 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:closure, 0) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <%= form_tag documents_url, multipart: true, class: 'hide-when-js-is-loaded' do %>
+      <%= hidden_field_tag :current_step_path, edit_steps_closure_support_documents_path %>
+      <%= file_field_tag :document %>
+      <%= submit_tag 'Upload', class: 'button' %>
+    <% end %>
+
+    <div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0">
+      <div class="dz-default dz-message grid-row">
+        <div class="column-one-third arrow-icon">
+          <p></p>
+        </div>
+        <div class="column-one-half">
+          <p class="dz-message-copy">
+            <%= t 'shared.file_upload.dropzone_message_html' %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="uploaded-files-wrapper">
+      <h2 class="heading-medium"><%= t 'shared.file_upload.uploaded_files_header' %></h2>
+
+      <ol class="list uploaded-files">
+        <% if @document_list&.any? %>
+          <% @document_list.each do |doc| %>
+            <li class="file hide-when-js-is-loaded">
+              <%= doc.name %>
+              <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' },
+                            class: 'button', params: { current_step_path: edit_steps_closure_support_documents_path } %>
+            </li>
+
+            <li class="file js-hidden show-when-js-is-loaded">
+              <%= doc.name %>
+              <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name %>
+            </li>
+          <% end %>
+        <% else %>
+          <li class="no-files"><%= t 'shared.file_upload.no_uploaded_files' %></li>
+        <% end %>
+      </ol>
+    </div>
+
+    <%= step_form @form_object do |f| %>
+      <div class="form-group util_mt-large">
+        <%= f.label :closure_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
+          <%= f.check_box :closure_problems_uploading_documents, 'aria-controls': 'unable_to_upload_panel' %>
+          <%= t('shared.file_upload.having_problems') %>
+        <% end %>
+
+        <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
+          <p><%= t('shared.file_upload.having_problems_explanation') %></p>
+          <%= f.text_area :closure_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
+        </div>
+      </div>
+
+      <div class="form-group util_mt-large">
+        <%= f.submit class: 'button' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="column-one-third">
+    <%= render partial: 'steps/shared/file_upload_sidebar' %>
+  </div>
+</div>

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -7,6 +7,7 @@
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= form_tag documents_url, multipart: true, class: 'hide-when-js-is-loaded' do %>
+        <%= hidden_field_tag :current_step_path, edit_steps_details_documents_checklist_path %>
         <%= file_field_tag :document %>
         <%= submit_tag 'Upload', class: 'button' %>
     <% end %>
@@ -27,14 +28,15 @@
     </div>
 
     <div class="uploaded-files-wrapper">
-      <h2 class="heading-medium"><%= t '.uploaded_files_header' %></h2>
+      <h2 class="heading-medium"><%= t 'shared.file_upload.uploaded_files_header' %></h2>
 
       <ol class="list uploaded-files">
         <% if @document_list&.any? %>
             <% @document_list.each do |doc| %>
                 <li class="file hide-when-js-is-loaded">
                   <%= doc.name %>
-                  <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
+                  <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' },
+                                class: 'button', params: { current_step_path: edit_steps_details_documents_checklist_path } %>
                 </li>
 
                 <li class="file js-hidden show-when-js-is-loaded">
@@ -43,7 +45,7 @@
                 </li>
             <% end %>
         <% else %>
-            <li class="no-files"><%= t '.no_uploaded_files' %></li>
+            <li class="no-files"><%= t 'shared.file_upload.no_uploaded_files' %></li>
         <% end %>
       </ol>
     </div>
@@ -64,7 +66,7 @@
         <div class="form-group util_mt-large">
           <%= f.label :having_problems_uploading_documents, class: 'block-label selection-button-checkbox' do %>
               <%= f.check_box :having_problems_uploading_documents %>
-              <%= t '.having_problems_uploading_documents_html' %>
+              <%= t 'shared.file_upload.having_problems' %>
           <% end %>
         </div>
 
@@ -75,11 +77,6 @@
   </div>
 
   <div class="column-one-third">
-    <p class="lede">&nbsp;</p>
-    <p class="lede">&nbsp;</p>
-    <h2 class="heading-small"><%= t('.need_help') %></h2>
-    <nav role="navigation" class="font-xsmall">
-      <p><a href="#"><%= t('.contact_us') %></a></p>
-    </nav>
+    <%= render partial: 'steps/shared/file_upload_sidebar' %>
   </div>
 </div>

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -25,7 +25,8 @@
       <% if uploaded_document %>
           <div class="gfa_uploaded_doc_container">
             <p><%= t('.previous_document', file_name: uploaded_document.name) %></p>
-            <%= button_to 'Remove', document_path(uploaded_document), method: :delete, data: {confirm: 'Are you sure?'}, class: 'button' %>
+            <%= button_to 'Remove', document_path(uploaded_document), method: :delete, data: {confirm: 'Are you sure?'},
+                          class: 'button', params: { current_step_path: edit_steps_details_grounds_for_appeal_path } %>
           </div>
       <% end %>
     </div>

--- a/app/views/steps/shared/_file_upload_sidebar.html.erb
+++ b/app/views/steps/shared/_file_upload_sidebar.html.erb
@@ -1,0 +1,6 @@
+<p class="lede">&nbsp;</p>
+<p class="lede">&nbsp;</p>
+<h2 class="heading-small"><%= t('shared.service_help.need_help') %></h2>
+<nav role="navigation" class="font-xsmall">
+  <p><a href="#"><%= t('shared.service_help.contact_us') %></a></p>
+</nav>

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -26,6 +26,11 @@ en:
       additional_info:
         edit:
           heading: Say why you think the enquiry should close (optional)
+      support_documents:
+        edit:
+          heading: Add documents to support your application (optional)
+          lead_text: We accept scanned images or good quality pictures, for example via a smartphone. You can upload PDF, JPG, GIF or PNG formats. Maximum file size of 20MB.
+          having_problems_uploading_documents_html: I am having trouble uploading my documents
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend
@@ -45,6 +50,8 @@ en:
         closure_hmrc_officer: Name of HMRC officer conducting the enquiry (optional)
       steps_closure_additional_info_form:
         closure_additional_info: Additional information
+      steps_closure_support_documents_form:
+        closure_problems_uploading_details: Describe the trouble you are having uploading your documents
   activemodel:
     errors:
       models:
@@ -54,3 +61,7 @@ en:
               blank: Enter the reference number
             closure_years_under_enquiry:
               blank: Enter the years under enquiry
+        steps/closure/support_documents_form:
+          attributes:
+            closure_problems_uploading_details:
+              too_short: You must give a reason why you can't upload your documents

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -9,7 +9,14 @@ en:
           <li>Files cannot be password protected</li>
         </ul>
       footer: You can’t upload executable (.exe) and other zip, archive or compressed files due to virus risks.
-      dropzone_message_html: Drag and drop files here<br> <strong>or</strong><br><span class="faux-link">click to choose a file</span>
+      dropzone_message_html: Drag and drop files here<br> <strong>or</strong><br><span class="faux-link" tabindex="-1">click to choose a file</span>
+      uploaded_files_header: Uploaded files
+      no_uploaded_files: No files uploaded
+      having_problems: I am having trouble uploading my documents
+      having_problems_explanation: You will need to continue completing your appeal and print off details, send copies of letters with a cheque or money order.
+    service_help:
+      need_help: Need help using the online service?
+      contact_us: Contact us
   steps:
     details:
       step_header: Question %{step} of ?
@@ -56,11 +63,6 @@ en:
           documents_check_heading: 'You must upload the following (select the items you have uploaded):'
           original_notice_provided_html: <strong>Original notice letter</strong><br>including the explanation for any decision(s)
           review_conclusion_provided_html: <strong>Review conclusion letter</strong><br>you will only have this if your case was reviewed
-          having_problems_uploading_documents_html: I am having trouble uploading my documents
-          uploaded_files_header: Uploaded files
-          no_uploaded_files: No files uploaded
-          need_help: Need help using the online service?
-          contact_us: Contact us
       check_answers:
         show:
           submit_and_continue: Submit and continue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
       edit_step :case_type
       edit_step :enquiry_details
       edit_step :additional_info
+      edit_step :support_documents
     end
 
     namespace :details do

--- a/db/migrate/20170131115831_add_closure_problems_uploading_documents_to_tribunal_case.rb
+++ b/db/migrate/20170131115831_add_closure_problems_uploading_documents_to_tribunal_case.rb
@@ -1,0 +1,6 @@
+class AddClosureProblemsUploadingDocumentsToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :closure_problems_uploading_documents, :boolean, default: false
+    add_column :tribunal_cases, :closure_problems_uploading_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131094256) do
+ActiveRecord::Schema.define(version: 20170131115831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,8 @@ ActiveRecord::Schema.define(version: 20170131094256) do
     t.string   "closure_hmrc_officer"
     t.string   "closure_years_under_enquiry"
     t.text     "closure_additional_info"
+    t.boolean  "closure_problems_uploading_documents",      default: false
+    t.text     "closure_problems_uploading_details"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/steps/closure/support_documents_controller_spec.rb
+++ b/spec/controllers/steps/closure/support_documents_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Closure::SupportDocumentsController, type: :controller do
+  let(:uploaded_files) { {collection: '12345', files: [
+    {key: '12345/test.doc', title: 'test.doc', last_modified: '2016-12-05T12:20:02.000Z'},
+  ]} }
+  let(:response_double) { instance_double(MojFileUploaderApiClient::Response, code: 200, body: uploaded_files) }
+
+  before do
+    allow(MojFileUploaderApiClient::ListFiles).to receive(:new).and_return(double(call: response_double))
+  end
+
+  it_behaves_like 'an intermediate step controller', Steps::Closure::SupportDocumentsForm, ClosureDecisionTree
+
+  describe '#edit' do
+    let!(:existing_case) { TribunalCase.create }
+
+    it 'assigns previously uploaded files' do
+      get :edit, session: { tribunal_case_id: existing_case.id }
+
+      documents = assigns[:document_list]
+      expect(documents.size).to eq(1)
+      expect(documents.first.name).to eq('test.doc')
+    end
+  end
+end

--- a/spec/forms/steps/closure/support_documents_form_spec.rb
+++ b/spec/forms/steps/closure/support_documents_form_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Closure::SupportDocumentsForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    closure_problems_uploading_documents: closure_problems_uploading_documents,
+    closure_problems_uploading_details: closure_problems_uploading_details
+  } }
+
+  let(:tribunal_case) { instance_double(TribunalCase, documents: documents) }
+
+  let(:closure_problems_uploading_documents) { false }
+  let(:closure_problems_uploading_details) { nil }
+  let(:documents) { ['test.doc'] }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case) { nil }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when no documents uploaded' do
+      let(:documents) { [] }
+
+      it 'returns validations true, as documents are optional' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when closure_problems_uploading_documents is selected' do
+      let(:closure_problems_uploading_documents) { true }
+
+      context 'no explanation provided' do
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:closure_problems_uploading_details]).to_not be_empty
+        end
+      end
+
+      context 'explanation provided is too short' do
+        let(:closure_problems_uploading_details) { 'x' }
+
+        it 'has a validation error' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:closure_problems_uploading_details]).to_not be_empty
+        end
+      end
+
+      context 'explanation provided is long enough' do
+        let(:closure_problems_uploading_details) { 'xx' }
+
+        it 'has no validation errors' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context 'when valid' do
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          closure_problems_uploading_documents: closure_problems_uploading_documents,
+          closure_problems_uploading_details: closure_problems_uploading_details
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/closure_decision_tree_spec.rb
+++ b/spec/services/closure_decision_tree_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe ClosureDecisionTree do
       it { is_expected.to have_destination(:additional_info, :edit) }
     end
 
+    context 'when the step is `additional_info`' do
+      let(:step_params) { { additional_info: 'anything' } }
+
+      it { is_expected.to have_destination(:support_documents, :edit) }
+    end
+
+    # TODO: change once we have the `check your answers` step
+    context 'when the step is `support_documents`' do
+      let(:step_params) { { support_documents: 'anything' } }
+
+      it { is_expected.to have_destination(:start, :show) }
+    end
+
     context 'when the step is invalid' do
       let(:step_params) { {ungueltig: {waschmaschine: 'nein'}} }
 
@@ -46,6 +59,12 @@ RSpec.describe ClosureDecisionTree do
       let(:step_params) { { additional_info: 'anything' } }
 
       it { is_expected.to have_previous(:enquiry_details, :edit) }
+    end
+
+    context 'when the step is `support_documents`' do
+      let(:step_params) { { support_documents: 'anything' } }
+
+      it { is_expected.to have_previous(:additional_info, :edit) }
     end
 
     context 'when the step is invalid' do


### PR DESCRIPTION
Some refactor involving the documents controller as we have now 3 different
places where uploading of documents can happen and we need to know where to redirect
the user back in case of errors or when removing documents, in the non-JS version.