### PR TITLE
Allow easy REPL access on Docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'wicked_pdf', '~> 1.1.0'
 gem 'wkhtmltopdf-binary'
 
 group :development do
+  gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'faker'
   gem 'i18n-debug'
   gem 'listen', '~> 3.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,12 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     brakeman (3.4.0)
     builder (3.2.2)
     byebug (9.0.6)
@@ -343,6 +349,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   brakeman
   byebug
   capybara

--- a/config/initializers/development/better_errors.rb
+++ b/config/initializers/development/better_errors.rb
@@ -1,0 +1,7 @@
+#:nocov:
+if defined? BetterErrors
+  BetterErrors::Middleware.allow_ip! '10.0.0.0/8'
+  BetterErrors::Middleware.allow_ip! '172.16.0.0/12'
+  BetterErrors::Middleware.allow_ip! '192.168.0.0/16'
+end
+#:nocov:


### PR DESCRIPTION
Plus get better-looking error dumps.

I was having difficulty getting to a REPL using the docker-containers.
This makes it straightforward to do in the error page.