### PR TITLE
Store the current step path in session for a later user.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
     @current_tribunal_case ||= TribunalCase.find_by_id(session[:tribunal_case_id])
   end
 
+  def current_step_path
+    session[:current_step_path]
+  end
+
   private
 
   def initialize_tribunal_case(intent:)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -43,10 +43,6 @@ class DocumentsController < ApplicationController
     decoded_filename == current_tribunal_case.grounds_for_appeal_file_name
   end
 
-  def current_step_path
-    document_params[:current_step_path]
-  end
-
   def filename
     URI.encode(decoded_filename)
   end
@@ -64,6 +60,6 @@ class DocumentsController < ApplicationController
   end
 
   def document_params
-    params.permit(:_method, :id, :current_step_path, :document, :authenticity_token)
+    params.permit(:_method, :id, :document, :authenticity_token)
   end
 end

--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -1,4 +1,6 @@
 class StepController < ApplicationController
+  before_action :store_step_path_in_session, only: [:edit, :update]
+
   def edit
     raise 'No tribunal case in session' unless current_tribunal_case
   end
@@ -42,5 +44,9 @@ class StepController < ApplicationController
     params
       .fetch(form_class.model_name.singular, {})
       .permit(form_class.new.attributes.keys)
+  end
+
+  def store_step_path_in_session
+    session[:current_step_path] = request.fullpath
   end
 end

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -7,7 +7,6 @@
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= form_tag documents_url, multipart: true, class: 'hide-when-js-is-loaded' do %>
-      <%= hidden_field_tag :current_step_path, edit_steps_closure_support_documents_path %>
       <%= file_field_tag :document %>
       <%= submit_tag 'Upload', class: 'button' %>
     <% end %>
@@ -33,8 +32,7 @@
           <% @document_list.each do |doc| %>
             <li class="file hide-when-js-is-loaded">
               <%= doc.name %>
-              <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' },
-                            class: 'button', params: { current_step_path: edit_steps_closure_support_documents_path } %>
+              <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
             </li>
 
             <li class="file js-hidden show-when-js-is-loaded">

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -7,7 +7,6 @@
     <p class="lede"><%=t '.lead_text' %></p>
 
     <%= form_tag documents_url, multipart: true, class: 'hide-when-js-is-loaded' do %>
-        <%= hidden_field_tag :current_step_path, edit_steps_details_documents_checklist_path %>
         <%= file_field_tag :document %>
         <%= submit_tag 'Upload', class: 'button' %>
     <% end %>
@@ -35,8 +34,7 @@
             <% @document_list.each do |doc| %>
                 <li class="file hide-when-js-is-loaded">
                   <%= doc.name %>
-                  <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' },
-                                class: 'button', params: { current_step_path: edit_steps_details_documents_checklist_path } %>
+                  <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
                 </li>
 
                 <li class="file js-hidden show-when-js-is-loaded">

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -25,8 +25,7 @@
       <% if uploaded_document %>
           <div class="gfa_uploaded_doc_container">
             <p><%= t('.previous_document', file_name: uploaded_document.name) %></p>
-            <%= button_to 'Remove', document_path(uploaded_document), method: :delete, data: {confirm: 'Are you sure?'},
-                          class: 'button', params: { current_step_path: edit_steps_details_grounds_for_appeal_path } %>
+            <%= button_to 'Remove', document_path(uploaded_document), method: :delete, data: {confirm: 'Are you sure?'}, class: 'button' %>
           </div>
       <% end %>
     </div>

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
     let(:expected_params) { { form_class_params_name => { foo: 'bar' } } }
 
     before do
+      expect(controller).to receive(:store_step_path_in_session)
       allow(form_class).to receive(:new).and_return(form_object)
     end
 
@@ -107,6 +108,10 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
 end
 
 RSpec.shared_examples 'an intermediate step controller without update' do
+  before do
+    expect(controller).to receive(:store_step_path_in_session)
+  end
+
   context '#update' do
     it 'raises an exception' do
       expect { put :update }.to raise_error(AbstractController::ActionNotFound)


### PR DESCRIPTION
This improves over the previous problem of knowing where to redirect back the user
when uploading or removing files with JS disabled, not needing to submit a hidden
input with the path.

At the moment only steps doing document uploads are using this session value but
it seemed sensible to have this set in all StepController children, mainly for
consistency, and because we might need it for other situations.