### PR TITLE
Add representative details to CYA page and PDF

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,10 +38,9 @@ class SessionsController < ApplicationController
       taxpayer_individual_first_name: Faker::Name.first_name,
       taxpayer_individual_last_name: Faker::Name.last_name,
       taxpayer_contact_address: [
-        Faker::Address.street_address,
-        Faker::Address.city,
-        Faker::Address.county
+        Faker::Address.street_address, Faker::Address.city, Faker::Address.county
       ].join("\n"),
+      has_representative: HasRepresentative::YES,
       representative_type: ContactableEntityType::INDIVIDUAL,
       representative_contact_phone: Faker::PhoneNumber.phone_number,
       representative_contact_email: Faker::Internet.email,
@@ -49,9 +48,7 @@ class SessionsController < ApplicationController
       representative_individual_first_name: Faker::Name.first_name,
       representative_individual_last_name: Faker::Name.last_name,
       representative_contact_address: [
-        Faker::Address.street_address,
-        Faker::Address.city,
-        Faker::Address.county
+        Faker::Address.street_address, Faker::Address.city, Faker::Address.county
       ].join("\n")
     )
 

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -50,4 +50,8 @@ class TribunalCase < ApplicationRecord
   def taxpayer_is_organisation?
     taxpayer_type.organisation?
   end
+
+  def representative_is_organisation?
+    representative_type.organisation?
+  end
 end

--- a/app/presenters/case_details_presenter.rb
+++ b/app/presenters/case_details_presenter.rb
@@ -13,6 +13,10 @@ class CaseDetailsPresenter < SimpleDelegator
     @taxpayer ||= TaxpayerDetailsPresenter.new(tribunal_case)
   end
 
+  def representative
+    @representative ||= RepresentativeDetailsPresenter.new(tribunal_case)
+  end
+
   def documents
     @documents ||= DocumentsSubmittedPresenter.new(tribunal_case)
   end

--- a/app/presenters/representative_details_presenter.rb
+++ b/app/presenters/representative_details_presenter.rb
@@ -1,0 +1,26 @@
+class RepresentativeDetailsPresenter < BaseAnswersPresenter
+  def present?
+    tribunal_case.has_representative == HasRepresentative::YES
+  end
+
+  def name
+    return tribunal_case.representative_organisation_fao if tribunal_case.representative_is_organisation?
+    [tribunal_case.representative_individual_first_name, tribunal_case.representative_individual_last_name].join(' ')
+  end
+
+  def phone
+    tribunal_case.representative_contact_phone
+  end
+
+  def address
+    [
+      tribunal_case.representative_organisation_name,
+      tribunal_case.representative_contact_address,
+      tribunal_case.representative_contact_postcode
+    ].compact.join("\n")
+  end
+
+  def email
+    tribunal_case.representative_contact_email
+  end
+end

--- a/app/presenters/taxpayer_details_presenter.rb
+++ b/app/presenters/taxpayer_details_presenter.rb
@@ -1,5 +1,4 @@
 class TaxpayerDetailsPresenter < BaseAnswersPresenter
-
   def name
     return tribunal_case.taxpayer_organisation_fao if tribunal_case.taxpayer_is_organisation?
     [tribunal_case.taxpayer_individual_first_name, tribunal_case.taxpayer_individual_last_name].join(' ')

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -39,7 +39,24 @@
   <tr>
     <td class="section"><%= pdf_t '.questions.representative_details' %></td>
     <td class="content">
-      Not yet implemented in data capture.
+      <% if tribunal_case.representative.present? %>
+        <div><%= tribunal_case.representative.name %></div>
+        <div>
+          <%= simple_format(tribunal_case.representative.address) %>
+        </div>
+        <div>
+          <%= pdf_t '.questions.representative_phone' %>
+          <span><%= tribunal_case.representative.phone %></span>
+        </div>
+        <div>
+          <%= pdf_t '.questions.representative_email' %>
+          <span><%= tribunal_case.representative.email %></span>
+        </div>
+      <% else %>
+        <div>
+          <%= pdf_t '.answers.no_representative' %>
+        </div>
+      <% end %>
     </td>
   </tr>
   </tbody>

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -52,6 +52,28 @@
       <%= link_to t('.change'), edit_steps_details_taxpayer_type_path %>
     </td>
   </tr>
+    <tr>
+      <th><%= t '.questions.representative_details' %></th>
+      <td>
+        <% if @tribunal_case.representative.present? %>
+          <div><%= @tribunal_case.representative.name %></div>
+          <div class="js_breaklines">
+            <%= simple_format(@tribunal_case.representative.address) %>
+          </div>
+          <div>
+            <%= t '.questions.representative_phone' %> <span><%= @tribunal_case.representative.phone %></span>
+          </div>
+          <div>
+            <%= t '.questions.representative_email' %> <span><%= @tribunal_case.representative.email %></span>
+          </div>
+        <% else %>
+          <%= t '.answers.no_representative' %>
+        <% end %>
+      </td>
+      <td class="change-answer">
+        <%= link_to t('.change'), edit_steps_details_has_representative_path %>
+      </td>
+    </tr>
 
   <tr>
     <th><%= t '.questions.grounds_for_appeal' %></th>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -111,9 +111,11 @@ en:
             appellant_details: "Taxpayer's details"
             appellant_phone: "Tel:"
             appellant_email: "Email:"
+            representative_details: "Representative's details"
+            representative_phone: "Tel:"
+            representative_email: "Email:"
             grounds_for_appeal: Grounds for appeal
             documents_submitted: Documents submitted
-            representative_details: Representative details
             legal_representative: Legal representative
             desired_outcome: Desired outcome
           answers:
@@ -144,6 +146,7 @@ en:
               'no': 'Yes'
               unsure: Unknown
             no_grounds_for_appeal_text: No text entered
+            no_representative: I don't have a representative
       outcome:
         edit:
           heading: What outcome do you want from your appeal?

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -168,4 +168,13 @@ RSpec.describe TribunalCase, type: :model do
       expect(subject.taxpayer_is_organisation?).to eq(true)
     end
   end
+
+  describe '#representative_is_organisation?' do
+    let(:representative_type) { OpenStruct.new(organisation?: true, value: :anything) }
+    let(:attributes) { { representative_type: representative_type } }
+
+    it 'queries the representative_type' do
+      expect(subject.representative_is_organisation?).to eq(true)
+    end
+  end
 end

--- a/spec/presenters/case_details_presenter_spec.rb
+++ b/spec/presenters/case_details_presenter_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe CaseDetailsPresenter do
     end
   end
 
+  context '#representative' do
+    it 'returns a representative presenter instance' do
+      expect(subject.representative).to be_an_instance_of(RepresentativeDetailsPresenter)
+    end
+  end
+
   context '#documents' do
     it 'returns a documents presenter instance' do
       expect(subject.documents).to be_an_instance_of(DocumentsSubmittedPresenter)

--- a/spec/presenters/representative_details_presenter_spec.rb
+++ b/spec/presenters/representative_details_presenter_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+RSpec.describe RepresentativeDetailsPresenter do
+  subject { described_class.new(tribunal_case) }
+  let(:tribunal_case) {
+    TribunalCase.new(
+      has_representative: has_representative,
+      representative_type: representative_type,
+      representative_individual_first_name: representative_individual_first_name,
+      representative_individual_last_name: representative_individual_last_name,
+      representative_contact_address: representative_contact_address,
+      representative_contact_postcode: representative_contact_postcode,
+      representative_contact_email: representative_contact_email,
+      representative_contact_phone: representative_contact_phone,
+      representative_organisation_name: representative_organisation_name,
+      representative_organisation_fao: representative_organisation_fao,
+      representative_organisation_registration_number: representative_organisation_registration_number
+    )
+  }
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  let(:has_representative) { nil }
+  let(:representative_type) { nil }
+  let(:representative_individual_first_name) { 'Firstname' }
+  let(:representative_individual_last_name) { 'Lastname' }
+  let(:representative_contact_address) { 'Address' }
+  let(:representative_contact_postcode) { 'Postcode' }
+  let(:representative_contact_email) { 'Email' }
+  let(:representative_contact_phone) { 'Phone' }
+  let(:representative_organisation_name) { 'Company name' }
+  let(:representative_organisation_fao) { 'Company contact' }
+  let(:representative_organisation_registration_number) { '0123' }
+
+  describe '#present?' do
+    context 'when the case has a representative' do
+      let(:has_representative) { HasRepresentative::YES }
+
+      it { is_expected.to be_present }
+    end
+
+    context 'when the case does not have a representative' do
+      let(:has_representative) { HasRepresentative::NO }
+
+      it { is_expected.to_not be_present }
+    end
+  end
+
+  describe '#name' do
+    context 'when representative is not an organisation' do
+      let(:representative_type) { OpenStruct.new(value: :anything, organisation?: false) }
+
+      it 'should returns the concatenated individual name fields' do
+        expect(subject.name).to eq('Firstname Lastname')
+      end
+    end
+
+    context 'when representative is an organisation' do
+      let(:representative_type) { OpenStruct.new(value: :anything, organisation?: true) }
+
+      it 'should returns the representative_organisation_fao field' do
+        expect(subject.name).to eq('Company contact')
+      end
+    end
+  end
+
+  describe '#phone' do
+    it 'returns the phone number' do
+      expect(subject.phone).to eq('Phone')
+    end
+  end
+
+  describe '#email' do
+    it 'returns the email' do
+      expect(subject.email).to eq('Email')
+    end
+  end
+
+  describe '#address' do
+    context 'when representative is not an organisation' do
+      let(:representative_type) { OpenStruct.new(value: :anything, organisation?: false) }
+      let(:representative_organisation_name) { nil }
+
+      it 'returns the address, including postcode' do
+        expect(subject.address).to eq("Address\nPostcode")
+      end
+    end
+
+    context 'when representative is an organisation' do
+      let(:representative_type) { OpenStruct.new(value: :anything, organisation?: true) }
+      let(:representative_organisation_name) { 'Company name' }
+
+      it 'returns the address, including postcode' do
+        expect(subject.address).to eq("Company name\nAddress\nPostcode")
+      end
+    end
+  end
+end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe CaseDetailsPdf do
       taxpayer_individual_first_name: 'Firstname',
       taxpayer_individual_last_name: 'Lastname',
       taxpayer_organisation_fao: 'Company Contact Name',
+      has_representative: HasRepresentative::YES,
+      representative_type: ContactableEntityType::INDIVIDUAL,
+      representative_individual_first_name: 'Firstname',
+      representative_individual_last_name: 'Lastname',
+      representative_organisation_fao: 'Company Contact Name',
       files_collection_ref: 'd29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
       case_reference: 'TC/2016/12345',
       outcome: 'my desired outcome'
@@ -39,6 +44,7 @@ RSpec.describe CaseDetailsPdf do
       expect(controller_ctx).to receive(:render_to_string).at_least(:once).and_call_original
 
       expect(decorated_tribunal_case).to receive(:taxpayer).at_least(:once).and_call_original
+      expect(decorated_tribunal_case).to receive(:representative).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:documents).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:fee_answers).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:appeal_lateness_answers).at_least(:once).and_call_original


### PR DESCRIPTION
Add the representative details to the "Check your answers" page and the
case details PDF, and show an appropriate message in their place when
there is no representative for the case.