### PR TITLE
Fix sending wrong parameters to GLiMR

### DIFF
--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -29,8 +29,8 @@ class GlimrNewCase
 
     if tc.taxpayer_is_organisation?
       params.merge!(
-        repOrganisationName: tc.taxpayer_organisation_name,
-        repFAO: tc.taxpayer_organisation_fao
+        contactOrganisationName: tc.taxpayer_organisation_name,
+        contactFAO: tc.taxpayer_organisation_fao
       )
     else
       params.merge!(

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe GlimrNewCase do
         let(:taxpayer_type) { ContactableEntityType::COMPANY }
         let(:organisation_params) {
           glimr_params.except(:contactFirstName, :contactLastName).merge(
-            repOrganisationName: 'Company Name', repFAO: 'Destany Fritsch')
+            contactOrganisationName: 'Company Name', contactFAO: 'Destany Fritsch')
         }
 
         it 'sends required organisation params but not individual params' do


### PR DESCRIPTION
When an organisation is specified as the taxpayer, the `GlimrNewCase`
object sends the wrong FAO and organisation name parameters.