### PR TITLE
Get appeal document uploader step in line with prototype.

### DIFF
--- a/app/assets/stylesheets/local/dropzone.scss
+++ b/app/assets/stylesheets/local/dropzone.scss
@@ -1,9 +1,9 @@
 
 .dropzone {
-  z-index: 100;
   border: 2px dashed $grey-1;
   padding: 30px;
   margin-bottom: 20px;
+  clear: both;
 
   .arrow-icon::before {
     content: image-url('drag-drop-upload-ico.svg');
@@ -69,8 +69,14 @@
       .faux-link {
         color: $link-colour;
         text-decoration: underline;
+        cursor: pointer;
+        display: inline-block;
       }
     }
+  }
+
+  &:focus {
+    outline: 3px solid $yellow;
   }
 }
 

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -8,22 +8,34 @@
 
     <p><%=t 'shared.file_upload.technical_info' %></p>
 
+    <%= fields_for @form_object do |f| %>
+      <div class="form-group">
+        <%= f.label :original_notice_provided, class: 'block-label selection-button-checkbox' do %>
+          <%= f.check_box :original_notice_provided, form: 'new_steps_details_documents_checklist_form' %>
+          <%= t '.original_notice_provided_html' %>
+        <% end %>
+
+        <%= f.label :review_conclusion_provided, class: 'block-label selection-button-checkbox' do %>
+          <%= f.check_box :review_conclusion_provided, form: 'new_steps_details_documents_checklist_form' %>
+          <%= t '.review_conclusion_provided_html' %>
+        <% end %>
+      </div>
+    <% end %>
+
     <%= form_tag documents_url, multipart: true, class: 'hide-when-js-is-loaded' do %>
         <%= file_field_tag :document %>
         <%= submit_tag 'Upload', class: 'button' %>
     <% end %>
 
-    <div id="doc_upload_zone-sticky-wrapper" class="sticky-wrapper" style="height: 240px;">
-      <div class="dropzone dz-clickable js-stick-at-top-when-scrolling js-hidden show-when-js-is-loaded" id="dz_doc_upload" style="width: 630px;">
-        <div class="dz-default dz-message grid-row">
-          <div class="column-one-third arrow-icon">
-            <p></p>
-          </div>
-          <div class="column-one-half">
-            <p class="dz-message-copy">
-              <%= t 'shared.file_upload.dropzone_message_html' %>
-            </p>
-          </div>
+    <div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0">
+      <div class="dz-default dz-message grid-row">
+        <div class="column-one-third arrow-icon">
+          <p></p>
+        </div>
+        <div class="column-one-half">
+          <p class="dz-message-copy">
+            <%= t 'shared.file_upload.dropzone_message_html' %>
+          </p>
         </div>
       </div>
     </div>
@@ -51,18 +63,6 @@
     </div>
 
     <%= step_form @form_object do |f| %>
-        <div class="form-group util_mt-large">
-          <%= f.label :original_notice_provided, class: 'block-label selection-button-checkbox' do %>
-              <%= f.check_box :original_notice_provided %>
-              <%= t '.original_notice_provided_html' %>
-          <% end %>
-
-          <%= f.label :review_conclusion_provided, class: 'block-label selection-button-checkbox' do %>
-              <%= f.check_box :review_conclusion_provided %>
-              <%= t '.review_conclusion_provided_html' %>
-          <% end %>
-        </div>
-
         <div class="form-group util_mt-large">
           <%= f.label :having_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
               <%= f.check_box :having_problems_uploading_documents %>


### PR DESCRIPTION
It was decided after user research to place the letter checkboxes above the dropzone area
and to have the other checkbox (problems uploading) below the dropzone area.

Markup changes and styling to support this without having nested forms.