### PR TITLE
Implement reverse repellant flow

### DIFF
--- a/app/controllers/steps/details/user_type_controller.rb
+++ b/app/controllers/steps/details/user_type_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Details
+  class UserTypeController < Steps::DetailsStepController
+    def edit
+      super
+      @form_object = UserTypeForm.new(
+        tribunal_case: current_tribunal_case,
+        user_type: current_tribunal_case.user_type
+      )
+    end
+
+    def update
+      update_and_advance(UserTypeForm)
+    end
+  end
+end

--- a/app/forms/steps/details/user_type_form.rb
+++ b/app/forms/steps/details/user_type_form.rb
@@ -1,0 +1,29 @@
+module Steps::Details
+  class UserTypeForm < BaseForm
+    attribute :user_type, String
+
+    def self.choices
+      UserType.values.map(&:to_s)
+    end
+    validates_inclusion_of :user_type, in: choices
+
+    private
+
+    def user_type_value
+      UserType.new(user_type)
+    end
+
+    def changed?
+      tribunal_case.user_type != user_type_value
+    end
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+      return true unless changed?
+
+      tribunal_case.update(
+        user_type: user_type_value
+      )
+    end
+  end
+end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -14,6 +14,7 @@ class TribunalCase < ApplicationRecord
   has_value_object :in_time
 
   # Details task
+  has_value_object :user_type
   has_value_object :has_representative
   has_value_object :taxpayer_type, class_name: 'ContactableEntityType'
   has_value_object :representative_type, class_name: 'ContactableEntityType'

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -21,13 +21,28 @@ class ClosureDecisionTree < DecisionTree
     when :case_type
       show(:start)
     when :enquiry_details
-      edit('/steps/details/taxpayer_type')
+      before_enquiry_details_step
     when :additional_info
       edit(:enquiry_details)
     when :support_documents
       edit(:additional_info)
     else
       raise "Invalid step '#{step_params}'"
+    end
+  end
+
+  private
+
+  def before_enquiry_details_step
+    case tribunal_case.user_type
+    when UserType::REPRESENTATIVE
+      edit('/steps/details/taxpayer_details')
+    when UserType::TAXPAYER
+      if tribunal_case.has_representative == HasRepresentative::YES
+        edit('/steps/details/representative_details')
+      else
+        edit('/steps/details/has_representative')
+      end
     end
   end
 end

--- a/app/value_objects/user_type.rb
+++ b/app/value_objects/user_type.rb
@@ -1,0 +1,10 @@
+class UserType < ValueObject
+  VALUES = [
+    TAXPAYER       = new(:taxpayer),
+    REPRESENTATIVE = new(:representative)
+  ].freeze
+
+  def self.values
+    VALUES
+  end
+end

--- a/app/views/steps/details/start/show.html.erb
+++ b/app/views/steps/details/start/show.html.erb
@@ -10,7 +10,7 @@
 
 <% if @can_start %>
   <p>
-    <%= link_to t('.continue'), edit_steps_details_taxpayer_type_path, class: 'button button-start', role: 'button' %>
+    <%= link_to t('.continue'), edit_steps_details_user_type_path, class: 'button button-start', role: 'button' %>
   </p>
 <% else %>
   <p>

--- a/app/views/steps/details/user_type/edit.html.erb
+++ b/app/views/steps/details/user_type/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header(:details, 0) %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <%= step_form @form_object do |f| %>
+      <%= f.radio_button_fieldset :user_type,
+        choices: Steps::Details::UserTypeForm.choices %>
+      <%= f.submit class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -50,6 +50,9 @@ en:
             </p>
           previous_step_not_completed: You must complete Step 1 and Step 2 before you can enter your appeal details.
           continue: Continue
+      user_type:
+        edit:
+          heading: Are you the taxpayer involved in the appeal?
       taxpayer_type:
         edit:
           heading: Who is your appeal for?
@@ -163,6 +166,10 @@ en:
   activemodel:
     errors:
       models:
+        steps/details/user_type_form:
+          attributes:
+            user_type:
+              inclusion: Select whether you are the taxpayer involved in the appeal
         steps/details/taxpayer_type_form:
           attributes:
             taxpayer_type:
@@ -203,6 +210,8 @@ en:
               too_short: You must give a reason why you can't upload your documents
   helpers:
     fieldset:
+      steps_details_user_type_form:
+        user_type: Are you the taxpayer involved in the appeal?
       steps_details_taxpayer_type_form:
         taxpayer_type: Who is your appeal for?
       steps_details_has_representative_form:
@@ -210,6 +219,10 @@ en:
       steps_details_representative_type_form:
         representative_type: Is your representative an individual, company or other type of organisation?
     label:
+      steps_details_user_type_form:
+        user_type:
+          taxpayer: 'Yes'
+          representative: No, I am acting on behalf of the taxpayer
       steps_details_taxpayer_type_form:
         taxpayer_type:
           individual_html: <strong>Individual</strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
       edit_step :outcome
       edit_step :documents_checklist
       show_step :check_answers
+      edit_step :user_type
     end
   end
 

--- a/db/migrate/20170203154438_add_user_type_to_tribunal_case.rb
+++ b/db/migrate/20170203154438_add_user_type_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddUserTypeToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :user_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202144329) do
+ActiveRecord::Schema.define(version: 20170203154438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20170202144329) do
     t.string   "representative_organisation_fao"
     t.string   "representative_organisation_registration_number"
     t.text     "having_problems_uploading_details"
+    t.string   "user_type"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/steps/details/user_type_controller_spec.rb
+++ b/spec/controllers/steps/details/user_type_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::UserTypeController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::UserTypeForm, DetailsDecisionTree
+end

--- a/spec/forms/steps/details/user_type_form_spec.rb
+++ b/spec/forms/steps/details/user_type_form_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Steps::Details::UserTypeForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    user_type: user_type
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, user_type: nil) }
+  let(:user_type) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:user_type) { 'taxpayer' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when user_type is not given' do
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:user_type]).to_not be_empty
+      end
+    end
+
+    context 'when user_type is not valid' do
+      let(:user_type) { 'concerned_citizen' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:user_type]).to_not be_empty
+      end
+    end
+
+    context 'when user_type is valid' do
+      let(:user_type) { 'representative' }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+          user_type: UserType::REPRESENTATIVE
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when user_type is already the same on the model' do
+      let(:tribunal_case) {
+        instance_double(
+          TribunalCase,
+          user_type: UserType::TAXPAYER
+        )
+      }
+      let(:user_type) { 'taxpayer' }
+
+      it 'does not save the record but returns true' do
+        expect(tribunal_case).to_not receive(:update)
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end
+

--- a/spec/services/closure_decision_tree_spec.rb
+++ b/spec/services/closure_decision_tree_spec.rb
@@ -52,7 +52,25 @@ RSpec.describe ClosureDecisionTree do
     context 'when the step is `enquiry_details`' do
       let(:step_params) { { enquiry_details: 'anything' } }
 
-      it { is_expected.to have_previous('/steps/details/taxpayer_type', :edit) }
+      context 'and there is a representative' do
+        context 'and the user is the taxpayer' do
+          let(:tribunal_case) { instance_double(TribunalCase, has_representative: HasRepresentative::YES, user_type: UserType::TAXPAYER) }
+
+          it { is_expected.to have_previous('/steps/details/representative_details', :edit) }
+        end
+
+        context 'and the user is the representative' do
+          let(:tribunal_case) { instance_double(TribunalCase, has_representative: HasRepresentative::YES, user_type: UserType::REPRESENTATIVE) }
+
+          it { is_expected.to have_previous('/steps/details/taxpayer_details', :edit) }
+        end
+      end
+
+      context 'and there is no representative' do
+        let(:tribunal_case) { instance_double(TribunalCase, has_representative: HasRepresentative::NO, user_type: UserType::TAXPAYER) }
+
+        it { is_expected.to have_previous('/steps/details/has_representative', :edit) }
+      end
     end
 
     context 'when the step is `additional_info`' do


### PR DESCRIPTION
Ask the user whether they are the taxpayer or a representative, if the
latter, reverse the usual flow (i.e. ask for the representative's
details first before asking for the taxpayer's details).

- Add a step for "Are you the representative or the taxpayer?"
- Update details and closure decision trees to reflect the updated flow