### PR TITLE
Several positioning, non-JS enhancements, error handling and copy.

### DIFF
--- a/app/assets/javascripts/modules/doc-upload-checkboxes.js
+++ b/app/assets/javascripts/modules/doc-upload-checkboxes.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * IE non-JS enabled browsers requires the letter checkboxes to be inside the form.
+ * This module will move (when JS is enabled) the checkboxes above the dropzone area,
+ * and a polyfill will make them work with IE browsers.
+ */
+
+moj.Modules.docUploadCheckboxes = {
+  element_class: '.supplied_letters_checkboxes',
+  containerId: '#supplied_letters_placeholder',
+
+  init: function () {
+    var cbElement = $(this.element_class),
+        container = $(this.containerId);
+
+    if (cbElement.length && container.length) {
+      container.replaceWith(cbElement);
+    }
+  }
+};

--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -3,11 +3,18 @@
 moj.Modules.docUpload = {
   form_id: 'dz_doc_upload',
   uploaded_files: '.uploaded-files',
+  preview_template: '.dz-file-preview',
   $form: null,
   $fileList: null,
 
+  config: {
+    maxFilesize: null,
+    acceptedFiles: null
+  },
+
   init: function() {
     var self = this,
+        previewTemplate,
         dzOptions;
 
     Dropzone.autoDiscover = false;
@@ -15,12 +22,20 @@ moj.Modules.docUpload = {
     self.$form = $('#' + self.form_id);
     self.$fileList = $(self.uploaded_files);
 
+    if (!self.$form.length) { return; }
+
+    previewTemplate = $(self.preview_template).remove()[0].outerHTML;
+
     dzOptions = {
       url: '/documents',
       paramName: 'document',
+      maxFilesize: parseInt(self.config.maxFilesize),
+      acceptedFiles: self.config.acceptedFiles,
       autoProcessQueue: true,
       addRemoveLinks: true,
       createImageThumbnails: false,
+      previewTemplate: previewTemplate,
+      dictRemoveFile: 'Remove',
       uploadMultiple: false,
       forceFallback: false,
       headers: {'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')},

--- a/app/assets/javascripts/modules/ie-form-attr.js
+++ b/app/assets/javascripts/modules/ie-form-attr.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * polyfill for html5 form attr
+ */
+
+moj.Modules.IEFormAttr = {
+  init: function () {
+    // detect if browser supports this
+    var SAMPLE_FORM_NAME = "html-5-polyfill-test";
+    var sampleForm = $("<form id='" + SAMPLE_FORM_NAME + "'/>");
+    var sampleFormAndHiddenInput = sampleForm.add($("<input type='hidden' form='" + SAMPLE_FORM_NAME + "'/>"));
+    sampleFormAndHiddenInput.prependTo('body');
+    var sampleElementFound = sampleForm[0].elements[0];
+    sampleFormAndHiddenInput.remove();
+    if (sampleElementFound) {
+      // browser supports it, no need to fix
+      return;
+    }
+
+    /**
+     * Append a field to a form
+     */
+    $.fn.appendField = function (data) {
+      // for form only
+      if (!this.is('form')) return;
+
+      // wrap data
+      if (!$.isArray(data) && data.name && data.value) {
+        data = [data];
+      }
+
+      var $form = this;
+
+      // attach new params
+      $.each(data, function (i, item) {
+        $('<input/>')
+          .attr('type', 'hidden')
+          .attr('name', item.name)
+          .val(item.value).appendTo($form);
+      });
+
+      return $form;
+    };
+
+    /**
+     * Find all input fields with form attribute point to jQuery object
+     */
+    $('form[id]').submit(function (e) {
+      // serialize data
+      var data = $('[form=' + this.id + ']').serializeArray();
+      // append data to form
+      $(this).appendField(data);
+    }).each(function () {
+      var form = this,
+        $fields = $('[form=' + this.id + ']');
+
+      $fields.filter('button, input').filter('[type=reset],[type=submit]').click(function () {
+        var type = this.type.toLowerCase();
+        if (type === 'reset') {
+          // reset form
+          form.reset();
+          // for elements outside form
+          $fields.each(function () {
+            this.value = this.defaultValue;
+            this.checked = this.defaultChecked;
+          }).filter('select').each(function () {
+            $(this).find('option').each(function () {
+              this.selected = this.defaultSelected;
+            });
+          });
+        } else if (type.match(/^submit|image$/i)) {
+          $(form).appendField({name: this.name, value: this.value}).submit();
+        }
+      });
+    });
+  }
+};

--- a/app/assets/javascripts/modules/ie-form-attr.js
+++ b/app/assets/javascripts/modules/ie-form-attr.js
@@ -2,8 +2,8 @@
 
 /**
  * polyfill for html5 form attr
+ * http://stackoverflow.com/a/40164509
  */
-
 moj.Modules.IEFormAttr = {
   init: function () {
     // detect if browser supports this

--- a/app/assets/stylesheets/local/dropzone.scss
+++ b/app/assets/stylesheets/local/dropzone.scss
@@ -37,11 +37,15 @@
   }
 
   .dz-preview {
-    padding-top: $gutter-half;
     width: 100%;
+    min-height: 50px;
+    margin: 0;
+    padding: 0;
+
     .dz-progress {
       width: 15em;
       display: inline-block;
+
       .dz-upload {
         background-color: $grass-green;
         display:inline-block;
@@ -54,10 +58,30 @@
         }
       }
     }
+    .dz-details {
+      position: revert;
+      text-align: left;
+      padding: 0;
+      margin: 0 0 0 20px;
+      font-size: 16px;
+
+      .file-container {
+        width: 80%;
+      }
+    }
+    .dz-remove {
+      text-align: right;
+      position: relative;
+      top: -42px;
+    }
+    .dz-error-mark {
+      position: relative;
+      top: -20px;
+      left: 20px;
+    }
   }
 
   .file-info {
-    font-size: 12px;
     color: $secondary-text-colour;
   }
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -12,7 +12,7 @@ class DocumentsController < ApplicationController
           redirect_to current_step_path
         }
         format.json {
-          render json: {error: uploader.errors}, status: :unprocessable_entity
+          render json: {error: uploader.errors.first}, status: :unprocessable_entity
         }
       end
     end

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -22,6 +22,7 @@ class DocumentUpload
     text/plain
     text/rtf
     text/csv
+    image/gif
     image/jpeg
     image/png
     image/tiff
@@ -105,6 +106,6 @@ class DocumentUpload
   end
 
   def translate(key)
-    I18n.translate("errors.#{key}", file_name: file_name, scope: 'document_upload')
+    I18n.translate("errors.#{key}", scope: 'document_upload', file_name: file_name, max_size: MAX_FILE_SIZE)
   end
 end

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -10,7 +10,7 @@ class DocumentUpload
 
   # TODO: decide on the final allowed max size and content types
   #
-  MAX_FILE_SIZE = 10.megabyte.freeze
+  MAX_FILE_SIZE = 20 # MB
   ALLOWED_CONTENT_TYPES = %w(
     application/pdf
     application/msword
@@ -27,7 +27,7 @@ class DocumentUpload
     image/tiff
     image/bmp
     image/x-bitmap
-  )
+  ).freeze
 
   def initialize(obj, content_type: nil, filename: nil, collection_ref: nil)
     raise ArgumentError.new('Must receive an IO object') unless obj.respond_to?(:read)
@@ -47,7 +47,7 @@ class DocumentUpload
       data: file_data
     ).call
 
-    add_error(:response_error) if response.error?
+    parse_response_errors(response)
     response
   end
 
@@ -86,11 +86,25 @@ class DocumentUpload
   end
 
   def validate
-    add_error(:file_size) if file_size > MAX_FILE_SIZE
+    add_error(:file_size) if file_size > MAX_FILE_SIZE.megabytes
     add_error(:content_type) unless content_type.downcase.in?(ALLOWED_CONTENT_TYPES)
   end
 
   def add_error(code)
-    errors << code unless errors.include?(code)
+    errors << translate(code) unless errors.include?(code)
+  end
+
+  def parse_response_errors(response)
+    return unless response.error?
+
+    if response.body.to_s =~ /Virus scan failed/
+      add_error(:virus_detected)
+    else
+      add_error(:response_error)
+    end
+  end
+
+  def translate(key)
+    I18n.translate("errors.#{key}", file_name: file_name, scope: 'document_upload')
   end
 end

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -13,40 +13,7 @@
       <%= submit_tag 'Upload', class: 'button' %>
     <% end %>
 
-    <div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0">
-      <div class="dz-default dz-message grid-row">
-        <div class="column-one-third arrow-icon">
-          <p></p>
-        </div>
-        <div class="column-one-half">
-          <p class="dz-message-copy">
-            <%= t 'shared.file_upload.dropzone_message_html' %>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="uploaded-files-wrapper">
-      <h2 class="heading-medium"><%= t 'shared.file_upload.uploaded_files_header' %></h2>
-
-      <ol class="list uploaded-files">
-        <% if @document_list&.any? %>
-          <% @document_list.each do |doc| %>
-            <li class="file hide-when-js-is-loaded">
-              <%= doc.name %>
-              <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
-            </li>
-
-            <li class="file js-hidden show-when-js-is-loaded">
-              <%= doc.name %>
-              <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name %>
-            </li>
-          <% end %>
-        <% else %>
-          <li class="no-files"><%= t 'shared.file_upload.no_uploaded_files' %></li>
-        <% end %>
-      </ol>
-    </div>
+    <%= render partial: 'steps/shared/dropzone', locals: { document_list: @document_list } %>
 
     <%= step_form @form_object do |f| %>
       <div class="form-group util_mt-large">

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -8,61 +8,28 @@
 
     <p><%=t 'shared.file_upload.technical_info' %></p>
 
-    <%= fields_for @form_object do |f| %>
-      <div class="form-group">
-        <%= f.label :original_notice_provided, class: 'block-label selection-button-checkbox' do %>
-          <%= f.check_box :original_notice_provided, form: 'new_steps_details_documents_checklist_form' %>
-          <%= t '.original_notice_provided_html' %>
-        <% end %>
-
-        <%= f.label :review_conclusion_provided, class: 'block-label selection-button-checkbox' do %>
-          <%= f.check_box :review_conclusion_provided, form: 'new_steps_details_documents_checklist_form' %>
-          <%= t '.review_conclusion_provided_html' %>
-        <% end %>
-      </div>
-    <% end %>
+    <div id="supplied_letters_placeholder"></div>
 
     <%= form_tag documents_url, multipart: true, class: 'hide-when-js-is-loaded' do %>
         <%= file_field_tag :document %>
         <%= submit_tag 'Upload', class: 'button' %>
     <% end %>
 
-    <div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0">
-      <div class="dz-default dz-message grid-row">
-        <div class="column-one-third arrow-icon">
-          <p></p>
-        </div>
-        <div class="column-one-half">
-          <p class="dz-message-copy">
-            <%= t 'shared.file_upload.dropzone_message_html' %>
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="uploaded-files-wrapper">
-      <h2 class="heading-medium"><%= t 'shared.file_upload.uploaded_files_header' %></h2>
-
-      <ol class="list uploaded-files">
-        <% if @document_list&.any? %>
-            <% @document_list.each do |doc| %>
-                <li class="file hide-when-js-is-loaded">
-                  <%= doc.name %>
-                  <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
-                </li>
-
-                <li class="file js-hidden show-when-js-is-loaded">
-                  <%= doc.name %>
-                  <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name %>
-                </li>
-            <% end %>
-        <% else %>
-            <li class="no-files"><%= t 'shared.file_upload.no_uploaded_files' %></li>
-        <% end %>
-      </ol>
-    </div>
+    <%= render partial: 'steps/shared/dropzone', locals: { document_list: @document_list } %>
 
     <%= step_form @form_object do |f| %>
+        <div class="form-group supplied_letters_checkboxes">
+          <%= f.label :original_notice_provided, class: 'block-label selection-button-checkbox' do %>
+            <%= f.check_box :original_notice_provided, form: 'new_steps_details_documents_checklist_form' %>
+            <%= t '.original_notice_provided_html' %>
+          <% end %>
+
+          <%= f.label :review_conclusion_provided, class: 'block-label selection-button-checkbox' do %>
+            <%= f.check_box :review_conclusion_provided, form: 'new_steps_details_documents_checklist_form' %>
+            <%= t '.review_conclusion_provided_html' %>
+          <% end %>
+        </div>
+
         <div class="form-group util_mt-large">
           <%= f.label :having_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
               <%= f.check_box :having_problems_uploading_documents %>

--- a/app/views/steps/shared/_dropzone.html.erb
+++ b/app/views/steps/shared/_dropzone.html.erb
@@ -1,0 +1,51 @@
+<!-- Some configuration -->
+<%= javascript_tag do %>
+  moj.Modules.docUpload.config.acceptedFiles = '<%= DocumentUpload::ALLOWED_CONTENT_TYPES.join(',') %>';
+  moj.Modules.docUpload.config.maxFilesize = '<%= DocumentUpload::MAX_FILE_SIZE %>';
+<% end %>
+
+<!-- This is used as the file preview template -->
+<div class="dz-preview dz-file-preview">
+  <div class="dz-details">
+    <div class="file-container">
+      <span data-dz-errormessage></span>
+    </div>
+  </div>
+  <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
+  <div class="dz-error-mark js-hidden show-when-js-is-loaded"><span>✘</span></div>
+</div>
+
+<div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0">
+  <div class="dz-default dz-message grid-row">
+    <div class="column-one-third arrow-icon">
+      <p></p>
+    </div>
+    <div class="column-one-half">
+      <p class="dz-message-copy">
+        <%= t 'shared.file_upload.dropzone_message_html' %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="uploaded-files-wrapper">
+  <h2 class="heading-medium"><%= t 'shared.file_upload.uploaded_files_header' %></h2>
+
+  <ol class="list uploaded-files">
+    <% if document_list&.any? %>
+        <% document_list.each do |doc| %>
+            <li class="file hide-when-js-is-loaded">
+              <%= doc.name %>
+              <%= button_to 'Remove', document_path(doc), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
+            </li>
+
+            <li class="file js-hidden show-when-js-is-loaded">
+              <%= doc.name %>
+              <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name %>
+            </li>
+        <% end %>
+    <% else %>
+        <li class="no-files"><%= t 'shared.file_upload.no_uploaded_files' %></li>
+    <% end %>
+  </ol>
+</div>

--- a/config/locales/document_upload.yml
+++ b/config/locales/document_upload.yml
@@ -1,0 +1,7 @@
+en:
+  document_upload:
+    errors:
+      file_size: "%{file_name} is too big. You will need to resubmit a smaller version, less than 20 megabytes (MB)"
+      content_type: "'%{file_name} is in a format we don't accept. You can upload JPG, PNG, GIF, PDF, Word or Excel files'"
+      virus_detected: "%{file_name} has a virus. You will need to resubmit a virus free copy"
+      response_error: "%{file_name} failed to upload. Please try again"

--- a/config/locales/document_upload.yml
+++ b/config/locales/document_upload.yml
@@ -1,7 +1,7 @@
 en:
   document_upload:
     errors:
-      file_size: "%{file_name} is too big. You will need to resubmit a smaller version, less than 20 megabytes (MB)"
-      content_type: "'%{file_name} is in a format we don't accept. You can upload JPG, PNG, GIF, PDF, Word or Excel files'"
+      file_size: "%{file_name} is too big. You will need to resubmit a smaller version, less than %{max_size} megabytes (MB)"
+      content_type: "%{file_name} is in a format we don't accept. You can upload JPG, PNG, GIF, PDF, Word or Excel files"
       virus_detected: "%{file_name} has a virus. You will need to resubmit a virus free copy"
       response_error: "%{file_name} failed to upload. Please try again"

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe DocumentsController, type: :controller do
       context 'HTML format' do
         it 'should create the document and redirect back to the step' do
           expect(subject).to redirect_to('step/to/redirect')
-          expect(flash.alert).to eq([:response_error])
+          expect(flash.alert).not_to be_empty
         end
       end
 
@@ -58,7 +58,8 @@ RSpec.describe DocumentsController, type: :controller do
 
         it 'should respond with an error object' do
           expect(response.status).to eq(422)
-          expect(response.body).to eq('{"error":["response_error"]}')
+          res = JSON.parse(response.body)
+          expect(res).to have_key('error')
         end
       end
     end
@@ -69,7 +70,7 @@ RSpec.describe DocumentsController, type: :controller do
       context 'HTML format' do
         it 'should create the document and redirect back to the step' do
           expect(subject).to redirect_to('step/to/redirect')
-          expect(flash.alert).to eq([:content_type])
+          expect(flash.alert).not_to be_empty
         end
       end
 
@@ -78,7 +79,8 @@ RSpec.describe DocumentsController, type: :controller do
 
         it 'should respond with an error object' do
           expect(response.status).to eq(422)
-          expect(response.body).to eq('{"error":["content_type"]}')
+          res = JSON.parse(response.body)
+          expect(res).to have_key('error')
         end
       end
     end

--- a/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
+++ b/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
         let(:grounds_for_appeal_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
 
         it 'should retrieve the errors from the uploader' do
-          expect(subject.errors).to receive(:add).with(:grounds_for_appeal_document, :content_type).and_call_original
+          expect(subject.errors).to receive(:add).with(:grounds_for_appeal_document, String).and_call_original
           expect(subject).to_not be_valid
         end
       end


### PR DESCRIPTION
This PR will position the letter checkboxes (appeal flow) above the dropzone area
and will work for any browser, granting there is JS available. For non-JS browsers
the checkboxes will remain below the dropzone area, but will also be functional.

In order to do this, the HTML5 `form` attribute is being used in the checkboxes, but
unfortunately this attribute is not supported by IE (none version) so we put in place
a polyfill JS workaround for this. Non-JS browsers, regardless if it is IE, will work
as described previously.

This PR will also change some error copy messages, and validate file size and file type
in the client size if JS available, otherwise backend will be used.

Some other markups changes, styling and improvements. More styling will be required.