### PR TITLE
Enable flexible translations for repellant flow

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,8 @@ module ApplicationHelper
       path:        controller.previous_step_path
     }
   end
+
+  def translate_for_user_type(key, params={})
+    translate("#{key}.as_#{current_tribunal_case.user_type}", params)
+  end
 end

--- a/app/views/steps/details/representative_details/edit.html.erb
+++ b/app/views/steps/details/representative_details/edit.html.erb
@@ -4,7 +4,7 @@
 
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="lede"><%= translate_for_user_type '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
       <% @form_object.name_fields.each do |name_field| %>

--- a/app/views/steps/details/representative_type/edit.html.erb
+++ b/app/views/steps/details/representative_type/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <%= step_header(:details, 0) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="heading-large"><%= translate_for_user_type '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :representative_type,

--- a/app/views/steps/details/taxpayer_type/edit.html.erb
+++ b/app/views/steps/details/taxpayer_type/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <%= step_header(:details, 1) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="heading-large"><%= translate_for_user_type '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :taxpayer_type,

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -54,7 +54,9 @@ en:
           heading: Are you the taxpayer making the appeal?
       taxpayer_type:
         edit:
-          heading: Who is making the appeal?
+          heading:
+            as_taxpayer: Who is making the appeal?
+            as_representative: Who is the appeal for?
       taxpayer_details:
         edit:
           heading: Enter taxpayer's details
@@ -71,11 +73,15 @@ en:
             <p>An authorised representative will be able to receive any correspondence from the tax tribunal and can represent the taxpayer at a hearing with the judge.</p>
       representative_type:
         edit:
-          heading: Is your representative an individual, company or other type of organisation?
+          heading:
+            as_taxpayer: Is your representative an individual, company or other type of organisation?
+            as_representative: Are you representing the taxpayer as an individual, company or other type of organisation?
       representative_details:
         edit:
           heading: Representative's details
-          lead_text: If you have approved your representative to act on your behalf, all correspondence will be sent to the address, or email address, you enter below.
+          lead_text:
+            as_taxpayer: If you have approved your representative to act on your behalf, all correspondence will be sent to the address, or email address, you enter below.
+            as_representative: If you are approved to act on behalf of the taxpayer all correspondence will be sent to the address, or email address, you enter below.
       grounds_for_appeal:
         edit:
           heading: Grounds for appeal

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe ApplicationHelper do
       helper.step_header(:my_task, 999)
     end
   end
+
+  describe '#translate_for_user_type' do
+    let(:user_type) { UserType.new(:humanoid) }
+    let(:tribunal_case) { instance_double(TribunalCase, user_type: user_type) }
+
+    it 'translates for the correct user type' do
+      expect(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
+      expect(helper).to receive(:translate).with('.foobar.as_humanoid', random_param: 'Nein')
+
+      helper.translate_for_user_type('.foobar', random_param: 'Nein')
+    end
+  end
 end


### PR DESCRIPTION
As part of the repellant flow, we want to sometimes show different copy
depending on whether the user is the taxpayer or the representative.

- Add `ApplicationHelper#translate_for_user_type` method to pick
  translation appropriate to the current case's user type
- Split relevant translations into appellant/representative
- Update views to use new translations