### PR TITLE
New dispute type options, and reintroduce Appeal presenters.

### DIFF
--- a/app/forms/steps/appeal/dispute_type_form.rb
+++ b/app/forms/steps/appeal/dispute_type_form.rb
@@ -14,8 +14,8 @@ module Steps::Appeal
       when CaseType::INCOME_TAX
         [
           DisputeType::PENALTY,
-          DisputeType::AMOUNT_OF_TAX,
-          DisputeType::AMOUNT_OF_TAX_OWED,
+          DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
+          DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
           DisputeType::AMOUNT_AND_PENALTY,
           DisputeType::PAYE_CODING_NOTICE,
           DisputeType::OTHER
@@ -23,8 +23,8 @@ module Steps::Appeal
       else
         [
           DisputeType::PENALTY,
-          DisputeType::AMOUNT_OF_TAX,
-          DisputeType::AMOUNT_OF_TAX_OWED,
+          DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
+          DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
           DisputeType::AMOUNT_AND_PENALTY,
           DisputeType::OTHER
         ]

--- a/app/forms/steps/appeal/dispute_type_form.rb
+++ b/app/forms/steps/appeal/dispute_type_form.rb
@@ -15,6 +15,7 @@ module Steps::Appeal
         [
           DisputeType::PENALTY,
           DisputeType::AMOUNT_OF_TAX,
+          DisputeType::AMOUNT_OF_TAX_OWED,
           DisputeType::AMOUNT_AND_PENALTY,
           DisputeType::PAYE_CODING_NOTICE,
           DisputeType::OTHER
@@ -23,6 +24,7 @@ module Steps::Appeal
         [
           DisputeType::PENALTY,
           DisputeType::AMOUNT_OF_TAX,
+          DisputeType::AMOUNT_OF_TAX_OWED,
           DisputeType::AMOUNT_AND_PENALTY,
           DisputeType::OTHER
         ]

--- a/app/presenters/appeal_type_answers_presenter.rb
+++ b/app/presenters/appeal_type_answers_presenter.rb
@@ -1,0 +1,99 @@
+class AppealTypeAnswersPresenter < BaseAnswersPresenter
+  def rows
+    [
+      challenged_decision_question,
+      case_type_question,
+      dispute_type_question,
+      challenged_decision_status_question,
+      penalty_level_question,
+      penalty_amount_question,
+      tax_amount_question,
+      disputed_tax_paid_question,
+      hardship_review_requested_question,
+      hardship_review_status_question
+    ].compact
+  end
+
+  def challenged_decision_question
+    row(
+      tribunal_case.challenged_decision,
+      as: :challenged_decision,
+      change_path: edit_steps_appeal_challenged_decision_path
+    )
+  end
+
+  def challenged_decision_status_question
+    row(
+      tribunal_case.challenged_decision_status,
+      as: :challenged_decision_status
+    )
+  end
+
+  def case_type_question
+    return case_type_other_value_question if tribunal_case.case_type == CaseType::OTHER
+
+    row(
+      tribunal_case.case_type,
+      as: :case_type
+    )
+  end
+
+  def case_type_other_value_question
+    row(
+      tribunal_case.case_type_other_value,
+      as: :case_type,
+      i18n_value: false
+    )
+  end
+
+  def dispute_type_question
+    row(
+      tribunal_case.dispute_type,
+      as: :dispute_type
+    )
+  end
+
+  def penalty_level_question
+    row(
+      tribunal_case.penalty_level,
+      as: :penalty_level
+    )
+  end
+
+  def penalty_amount_question
+    row(
+      tribunal_case.penalty_amount,
+      as: :penalty_amount,
+      i18n_value: false
+    )
+  end
+
+  def tax_amount_question
+    row(
+      tribunal_case.tax_amount,
+      as: :tax_amount,
+      i18n_value: false
+    )
+  end
+
+  def disputed_tax_paid_question
+    row(
+      tribunal_case.disputed_tax_paid,
+      as: :disputed_tax_paid
+    )
+  end
+
+  def hardship_review_requested_question
+    row(
+      tribunal_case.hardship_review_requested,
+      as: :hardship_review_requested
+    )
+  end
+
+  def hardship_review_status_question
+    row(
+      tribunal_case.hardship_review_status,
+      as: :hardship_review_status
+    )
+  end
+end

--- a/app/presenters/case_details_presenter.rb
+++ b/app/presenters/case_details_presenter.rb
@@ -21,6 +21,10 @@ class CaseDetailsPresenter < SimpleDelegator
     @documents ||= DocumentsSubmittedPresenter.new(tribunal_case)
   end
 
+  def appeal_type_answers
+    @appeal_type_answers ||= AppealTypeAnswersPresenter.new(tribunal_case)
+  end
+
   def appeal_lateness_answers
     @appeal_lateness_answers ||= AppealLatenessAnswersPresenter.new(tribunal_case)
   end

--- a/app/services/mapping_code_determiner.rb
+++ b/app/services/mapping_code_determiner.rb
@@ -43,7 +43,8 @@ class MappingCodeDeterminer
       MappingCode::APPEAL_PAYECODING
     when DisputeType::INFORMATION_NOTICE
       MappingCode::APPEAL_INFONOTICE
-    when DisputeType::AMOUNT_OF_TAX,
+    when DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
+         DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
          DisputeType::AMOUNT_AND_PENALTY,
          DisputeType::OTHER
       MappingCode::APPEAL_OTHER

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -1,12 +1,12 @@
 class DisputeType < ValueObject
   VALUES = [
-    PENALTY             = new(:penalty),
-    AMOUNT_OF_TAX       = new(:amount_of_tax),
-    AMOUNT_OF_TAX_OWED  = new(:amount_of_tax_owed),
-    AMOUNT_AND_PENALTY  = new(:amount_and_penalty),
-    PAYE_CODING_NOTICE  = new(:paye_coding_notice),
-    INFORMATION_NOTICE  = new(:information_notice),
-    OTHER               = new(:other)
+    PENALTY                        = new(:penalty),
+    AMOUNT_OF_TAX_OWED_BY_HMRC     = new(:amount_of_tax_owed_by_hmrc),
+    AMOUNT_OF_TAX_OWED_BY_TAXPAYER = new(:amount_of_tax_owed_by_taxpayer),
+    AMOUNT_AND_PENALTY             = new(:amount_and_penalty),
+    PAYE_CODING_NOTICE             = new(:paye_coding_notice),
+    INFORMATION_NOTICE             = new(:information_notice),
+    OTHER                          = new(:other)
   ].freeze
 
   def self.values
@@ -18,7 +18,7 @@ class DisputeType < ValueObject
   end
 
   def ask_tax?
-    [AMOUNT_OF_TAX, AMOUNT_OF_TAX_OWED].include?(self)
+    [AMOUNT_OF_TAX_OWED_BY_HMRC, AMOUNT_OF_TAX_OWED_BY_TAXPAYER].include?(self)
   end
 
   def ask_penalty_and_tax?

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -2,6 +2,7 @@ class DisputeType < ValueObject
   VALUES = [
     PENALTY             = new(:penalty),
     AMOUNT_OF_TAX       = new(:amount_of_tax),
+    AMOUNT_OF_TAX_OWED  = new(:amount_of_tax_owed),
     AMOUNT_AND_PENALTY  = new(:amount_and_penalty),
     PAYE_CODING_NOTICE  = new(:paye_coding_notice),
     INFORMATION_NOTICE  = new(:information_notice),
@@ -17,7 +18,7 @@ class DisputeType < ValueObject
   end
 
   def ask_tax?
-    self == AMOUNT_OF_TAX
+    [AMOUNT_OF_TAX, AMOUNT_OF_TAX_OWED].include?(self)
   end
 
   def ask_penalty_and_tax?
@@ -25,6 +26,6 @@ class DisputeType < ValueObject
   end
 
   def ask_hardship?
-    [AMOUNT_OF_TAX, AMOUNT_AND_PENALTY].include?(self)
+    ask_tax? || ask_penalty_and_tax?
   end
 end

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -123,6 +123,19 @@
 <h3><%= pdf_t '.appeal_type_heading' %></h3>
 
 <hr/>
+<table>
+  <tbody>
+  <% tribunal_case.appeal_type_answers.rows.each do |row| %>
+    <tr>
+      <td class="section"><%= pdf_t row.question %></td>
+      <td class="content"><%= row.i18n_value ? pdf_t(row.answer) : row.answer %></td>
+    </tr>
+    <tr>
+      <td colspan="2"></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
 
 <h3><%= pdf_t '.appeal_timeliness_heading' %></h3>
 

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -8,6 +8,15 @@
   <tr>
     <th colspan="3"><h2 class="heading-medium"><%= t '.appeal_type_heading' %></h2></th>
   </tr>
+  <% @tribunal_case.appeal_type_answers.rows.each do |row| %>
+      <tr>
+        <td><%= t row.question %></td>
+        <td><%= row.i18n_value ? t(row.answer) : row.answer %></td>
+        <td class="change-answer">
+          <%= row.change_link t('.change') %>
+        </td>
+      </tr>
+  <% end %>
 
   <tr>
     <th colspan="3"><h2 class="heading-medium"><%= t '.appeal_timeliness_heading' %></h2></th>

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -167,8 +167,8 @@ en:
       steps_appeal_dispute_type_form:
         dispute_type:
           penalty_html: <strong>Penalty or surcharge</strong>
-          amount_of_tax_html: <strong>HMRC should repay tax to you</strong>
-          amount_of_tax_owed_html: <strong>HMRC claim you owe tax</strong>
+          amount_of_tax_owed_by_hmrc_html: <strong>HMRC should repay tax to you</strong>
+          amount_of_tax_owed_by_taxpayer_html: <strong>HMRC claim you owe tax</strong>
           amount_and_penalty_html: <strong>HMRC claim you owe tax and a penalty or surcharge</strong><br>both must be shown on the same letter
           paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
           information_notice_html: <strong>Appeal against an information notice</strong>

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -49,7 +49,7 @@ en:
       dispute_type:
         edit:
           heading: What is your dispute about?
-          lead_text: You will find this information on either the original notice letter or review conclusion letter.
+          lead_text: You will find this information on either the original notice letter or review conclusion letter from HMRC.
       penalty_amount:
         edit:
           heading: What is the penalty or surcharge amount?
@@ -166,10 +166,11 @@ en:
           other_html: <strong>None of the above</strong>
       steps_appeal_dispute_type_form:
         dispute_type:
-          paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
           penalty_html: <strong>Penalty or surcharge</strong>
-          amount_of_tax_html: <strong>Amount of tax</strong>
-          amount_and_penalty_html: <strong>Amount of tax and a penalty or surcharge</strong><br>both must be stated on the same letter
+          amount_of_tax_html: <strong>HMRC should repay tax to you</strong>
+          amount_of_tax_owed_html: <strong>HMRC claim you owe tax</strong>
+          amount_and_penalty_html: <strong>HMRC claim you owe tax and a penalty or surcharge</strong><br>both must be shown on the same letter
+          paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
           information_notice_html: <strong>Appeal against an information notice</strong>
           other_html: <strong>None of the above</strong>
       steps_appeal_penalty_amount_form:

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -145,8 +145,9 @@ en:
             dispute_type:
               paye_coding_notice: Pay As You Earn (PAYE) coding notice
               penalty: Penalty or surcharge
-              amount_of_tax: Amount of tax
-              amount_and_penalty: Amount of tax and a penalty or surcharge
+              amount_of_tax: HMRC should repay tax to you
+              amount_of_tax_owed: HMRC claim you owe tax
+              amount_and_penalty: HMRC claim you owe tax and a penalty or surcharge
               other: Other
             penalty_level:
               penalty_level_1: £100 or less

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -145,8 +145,8 @@ en:
             dispute_type:
               paye_coding_notice: Pay As You Earn (PAYE) coding notice
               penalty: Penalty or surcharge
-              amount_of_tax: HMRC should repay tax to you
-              amount_of_tax_owed: HMRC claim you owe tax
+              amount_of_tax_owed_by_hmrc: HMRC should repay tax to you
+              amount_of_tax_owed_by_taxpayer: HMRC claim you owe tax
               amount_and_penalty: HMRC claim you owe tax and a penalty or surcharge
               other: Other
             penalty_level:

--- a/spec/forms/steps/appeal/dispute_type_form_spec.rb
+++ b/spec/forms/steps/appeal/dispute_type_form_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Steps::Appeal::DisputeTypeForm do
       it 'shows only the relevant choices' do
         expect(subject.choices).to eq(%w(
           penalty
-          amount_of_tax
-          amount_of_tax_owed
+          amount_of_tax_owed_by_hmrc
+          amount_of_tax_owed_by_taxpayer
           amount_and_penalty
           paye_coding_notice
           other
@@ -50,8 +50,8 @@ RSpec.describe Steps::Appeal::DisputeTypeForm do
       it 'shows only the relevant choices' do
         expect(subject.choices).to eq(%w(
           penalty
-          amount_of_tax
-          amount_of_tax_owed
+          amount_of_tax_owed_by_hmrc
+          amount_of_tax_owed_by_taxpayer
           amount_and_penalty
           other
         ))

--- a/spec/forms/steps/appeal/dispute_type_form_spec.rb
+++ b/spec/forms/steps/appeal/dispute_type_form_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Steps::Appeal::DisputeTypeForm do
         expect(subject.choices).to eq(%w(
           penalty
           amount_of_tax
+          amount_of_tax_owed
           amount_and_penalty
           paye_coding_notice
           other
@@ -50,6 +51,7 @@ RSpec.describe Steps::Appeal::DisputeTypeForm do
         expect(subject.choices).to eq(%w(
           penalty
           amount_of_tax
+          amount_of_tax_owed
           amount_and_penalty
           other
         ))

--- a/spec/presenters/appeal_type_answers_presenter_spec.rb
+++ b/spec/presenters/appeal_type_answers_presenter_spec.rb
@@ -1,0 +1,307 @@
+require 'spec_helper'
+
+RSpec.describe AppealTypeAnswersPresenter do
+  subject { described_class.new(tribunal_case) }
+
+  let(:tribunal_case) {
+    instance_double(
+      TribunalCase,
+      challenged_decision: challenged_decision,
+      challenged_decision_status: challenged_decision_status,
+      case_type: case_type,
+      case_type_other_value: case_type_other_value,
+      dispute_type: dispute_type,
+      penalty_level: penalty_level,
+      penalty_amount: penalty_amount,
+      tax_amount: tax_amount,
+      disputed_tax_paid: disputed_tax_paid,
+      hardship_review_requested: hardship_review_requested,
+      hardship_review_status: hardship_review_status
+    )
+  }
+
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  let(:challenged_decision)        { nil }
+  let(:challenged_decision_status) { nil }
+  let(:case_type)                  { nil }
+  let(:case_type_other_value)      { nil }
+  let(:dispute_type)               { nil }
+  let(:penalty_level)              { nil }
+  let(:penalty_amount)             { nil }
+  let(:tax_amount)                 { nil }
+  let(:disputed_tax_paid)          { nil }
+  let(:hardship_review_requested)  { nil }
+  let(:hardship_review_status)     { nil }
+
+  let(:declared_rows) {
+    [
+        :challenged_decision_question,
+        :case_type_question,
+        :dispute_type_question,
+        :challenged_decision_status_question,
+        :penalty_level_question,
+        :penalty_amount_question,
+        :tax_amount_question,
+        :disputed_tax_paid_question,
+        :hardship_review_requested_question,
+        :hardship_review_status_question
+    ].freeze
+  }
+
+  describe '#rows' do
+    before do
+      declared_rows.each do |row_method|
+        expect(subject).to receive(row_method).and_return(row_method)
+      end
+    end
+
+    it 'should have the correct order' do
+      expect(subject.rows).to eq(declared_rows)
+    end
+  end
+
+  describe '`challenged_decision` question' do
+    let(:row) { subject.challenged_decision_question }
+    let(:challenged_decision) { true }
+
+    context 'when appeal is challenged' do
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.challenged_decision')
+        expect(row.answer).to      eq('.answers.challenged_decision.true')
+        expect(row.change_path).to eq(paths.edit_steps_appeal_challenged_decision_path)
+      end
+    end
+
+    context 'when appeal is unchallenged' do
+      let(:challenged_decision) { false }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.challenged_decision')
+        expect(row.answer).to      eq('.answers.challenged_decision.false')
+        expect(row.change_path).to eq(paths.edit_steps_appeal_challenged_decision_path)
+      end
+    end
+
+    it 'has a change link' do
+      expect(row.change_link('test')).to eq('<a href="/steps/appeal/challenged_decision">test</a>')
+    end
+  end
+
+  describe '`challenged_decision_status` question' do
+    let(:row) { subject.challenged_decision_status_question }
+
+    context 'when appeal is challenged' do
+      context 'for a received status' do
+        let(:challenged_decision_status) { ChallengedDecisionStatus::RECEIVED }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.challenged_decision_status')
+          expect(row.answer).to      eq('.answers.challenged_decision_status.received')
+          expect(row.change_path).to be_nil
+        end
+      end
+
+      context 'for a overdue status' do
+        let(:challenged_decision_status) { ChallengedDecisionStatus::OVERDUE }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.challenged_decision_status')
+          expect(row.answer).to      eq('.answers.challenged_decision_status.overdue')
+          expect(row.change_path).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '`case_type` question' do
+    let(:row) { subject.case_type_question }
+
+    context 'for a specific case type' do
+      let(:case_type) { 'foo' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.case_type')
+        expect(row.answer).to      eq('.answers.case_type.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+
+    context 'for `other` case type' do
+      let(:case_type) { CaseType::OTHER }
+      let(:case_type_other_value) { 'my tax issue' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.case_type')
+        expect(row.answer).to      eq('my tax issue')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`dispute_type` question' do
+    let(:row) { subject.dispute_type_question }
+
+    context 'when `dispute_type` is nil' do
+      let(:dispute_type) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `case_type` is income_tax' do
+      let(:dispute_type) { 'foo' }
+      let(:case_type) { 'income_tax' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.dispute_type')
+        expect(row.answer).to      eq('.answers.dispute_type.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+
+    context 'when `case_type` is vat' do
+      let(:dispute_type) { 'foo' }
+      let(:case_type)  { 'vat' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.dispute_type')
+        expect(row.answer).to      eq('.answers.dispute_type.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`penalty_level` question' do
+    let(:row) { subject.penalty_level_question }
+
+    context 'when `penalty_level` is nil' do
+      let(:penalty_level) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `penalty_level` is given' do
+      let(:penalty_level) { 'foo' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.penalty_level')
+        expect(row.answer).to      eq('.answers.penalty_level.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`penalty_amount` question' do
+    let(:row) { subject.penalty_amount_question }
+
+    context 'when `penalty_amount` is nil' do
+      let(:penalty_amount) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `penalty_amount` is given' do
+      let(:penalty_amount)  { 'about 12345' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.penalty_amount')
+        expect(row.answer).to      eq('about 12345')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`tax_amount` question' do
+    let(:row) { subject.tax_amount_question }
+
+    context 'when `tax_amount` is nil' do
+      let(:tax_amount) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `tax_amount` is given' do
+      let(:tax_amount)  { 'about 12345' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.tax_amount')
+        expect(row.answer).to      eq('about 12345')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`disputed_tax_paid` question' do
+    let(:row) { subject.disputed_tax_paid_question }
+
+    context 'when `disputed_tax_paid` is nil' do
+      let(:disputed_tax_paid) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `disputed_tax_paid` is given' do
+      let(:disputed_tax_paid)  { 'foo' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.disputed_tax_paid')
+        expect(row.answer).to      eq('.answers.disputed_tax_paid.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`hardship_review_requested` question' do
+    let(:row) { subject.hardship_review_requested_question }
+
+    context 'when `hardship_review_requested` is nil' do
+      let(:hardship_review_requested) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `hardship_review_requested` is given' do
+      let(:hardship_review_requested)  { 'foo' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.hardship_review_requested')
+        expect(row.answer).to      eq('.answers.hardship_review_requested.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+
+  describe '`hardship_review_status` row' do
+    let(:row) { subject.hardship_review_status_question }
+
+    context 'when `hardship_review_status` is nil' do
+      let(:hardship_review_status) { nil }
+
+      it 'is not included' do
+        expect(row).to be_nil
+      end
+    end
+
+    context 'when `hardship_review_status` is given' do
+      let(:hardship_review_status) { 'foo' }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.hardship_review_status')
+        expect(row.answer).to      eq('.answers.hardship_review_status.foo')
+        expect(row.change_path).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/case_details_presenter_spec.rb
+++ b/spec/presenters/case_details_presenter_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe CaseDetailsPresenter do
     end
   end
 
+  context '#appeal_type_answers' do
+    it 'returns an appeal type answers presenter instance' do
+      expect(subject.appeal_type_answers).to be_an_instance_of(AppealTypeAnswersPresenter)
+    end
+  end
+
   context '#appeal_lateness_answers' do
     it 'returns a appeal lateness answers presenter instance' do
       expect(subject.appeal_lateness_answers).to be_an_instance_of(AppealLatenessAnswersPresenter)

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe CaseDetailsPdf do
       expect(decorated_tribunal_case).to receive(:taxpayer).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:representative).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:documents).at_least(:once).and_call_original
+      expect(decorated_tribunal_case).to receive(:appeal_type_answers).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:appeal_lateness_answers).at_least(:once).and_call_original
       expect(decorated_tribunal_case).to receive(:outcome).at_least(:once).and_call_original
 

--- a/spec/services/mapping_code_determiner_spec.rb
+++ b/spec/services/mapping_code_determiner_spec.rb
@@ -58,8 +58,14 @@ RSpec.describe MappingCodeDeterminer do
     it { is_expected.to have_mapping_code(:appeal_infonotice) }
   end
 
-  context 'when the dispute is about amount of tax' do
-    let(:dispute_type) { DisputeType::AMOUNT_OF_TAX }
+  context 'when the dispute is about amount of tax owed by HMRC' do
+    let(:dispute_type) { DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC }
+
+    it { is_expected.to have_mapping_code(:appeal_other) }
+  end
+
+  context 'when the dispute is about amount of tax owed by the taxpayer' do
+    let(:dispute_type) { DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER }
 
     it { is_expected.to have_mapping_code(:appeal_other) }
   end

--- a/spec/value_objects/dispute_type_spec.rb
+++ b/spec/value_objects/dispute_type_spec.rb
@@ -6,8 +6,14 @@ RSpec.describe DisputeType do
 
   describe '.values' do
     it 'returns all dispute types' do
-      expect(described_class.values.map(&:to_s)).to \
-        eq(%w(penalty amount_of_tax amount_and_penalty paye_coding_notice information_notice other))
+      expect(described_class.values.map(&:to_s)).to eq(%w(
+        penalty
+        amount_of_tax
+        amount_of_tax_owed
+        amount_and_penalty
+        paye_coding_notice
+        information_notice other
+      ))
     end
   end
 
@@ -37,6 +43,14 @@ RSpec.describe DisputeType do
         expect(subject.ask_tax?).to be(true)
       end
     end
+
+    context 'when the dispute type is AMOUNT_OF_TAX_OWED' do
+      let(:type) { :amount_of_tax_owed }
+
+      it 'returns true' do
+        expect(subject.ask_tax?).to be(true)
+      end
+    end
   end
 
   describe '#ask_penalty_and_tax?' do
@@ -60,6 +74,14 @@ RSpec.describe DisputeType do
 
     context 'when the dispute type is AMOUNT_OF_TAX' do
       let(:type) { :amount_of_tax }
+
+      it 'returns true' do
+        expect(subject.ask_hardship?).to be(true)
+      end
+    end
+
+    context 'when the dispute type is AMOUNT_OF_TAX_OWED' do
+      let(:type) { :amount_of_tax_owed }
 
       it 'returns true' do
         expect(subject.ask_hardship?).to be(true)

--- a/spec/value_objects/dispute_type_spec.rb
+++ b/spec/value_objects/dispute_type_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe DisputeType do
     it 'returns all dispute types' do
       expect(described_class.values.map(&:to_s)).to eq(%w(
         penalty
-        amount_of_tax
-        amount_of_tax_owed
+        amount_of_tax_owed_by_hmrc
+        amount_of_tax_owed_by_taxpayer
         amount_and_penalty
         paye_coding_notice
         information_notice other
@@ -36,16 +36,16 @@ RSpec.describe DisputeType do
       expect(subject.ask_tax?).to be(false)
     end
 
-    context 'when the dispute type is AMOUNT_OF_TAX' do
-      let(:type) { :amount_of_tax }
+    context 'when the dispute type is AMOUNT_OF_TAX_OWED_BY_HMRC' do
+      let(:type) { :amount_of_tax_owed_by_hmrc }
 
       it 'returns true' do
         expect(subject.ask_tax?).to be(true)
       end
     end
 
-    context 'when the dispute type is AMOUNT_OF_TAX_OWED' do
-      let(:type) { :amount_of_tax_owed }
+    context 'when the dispute type is AMOUNT_OF_TAX_OWED_BY_TAXPAYER' do
+      let(:type) { :amount_of_tax_owed_by_taxpayer }
 
       it 'returns true' do
         expect(subject.ask_tax?).to be(true)
@@ -72,16 +72,16 @@ RSpec.describe DisputeType do
       expect(subject.ask_hardship?).to be(false)
     end
 
-    context 'when the dispute type is AMOUNT_OF_TAX' do
-      let(:type) { :amount_of_tax }
+    context 'when the dispute type is AMOUNT_OF_TAX_OWED_BY_HMRC' do
+      let(:type) { :amount_of_tax_owed_by_hmrc }
 
       it 'returns true' do
         expect(subject.ask_hardship?).to be(true)
       end
     end
 
-    context 'when the dispute type is AMOUNT_OF_TAX_OWED' do
-      let(:type) { :amount_of_tax_owed }
+    context 'when the dispute type is AMOUNT_OF_TAX_OWED_BY_TAXPAYER' do
+      let(:type) { :amount_of_tax_owed_by_taxpayer }
 
       it 'returns true' do
         expect(subject.ask_hardship?).to be(true)


### PR DESCRIPTION
This PR updates the `What is your dispute about` question as the prototype changed, and
reintroduce the appeal presenters that were removed as part of the `cost/fee` spring cleaning.