### PR TITLE
CSS for 'task list' which is still used on start page

### DIFF
--- a/app/assets/stylesheets/local/lists.scss
+++ b/app/assets/stylesheets/local/lists.scss
@@ -4,6 +4,35 @@ ul.buttons {
   }
 }
 
+.task-list {
+  font-size: 24px;
+  border-top: 1px solid $grey-2;
+  list-style-position: inside;
+  padding-left: 0;
+  margin-top: 45px;
+  margin-bottom: 45px;
+
+  li {
+    padding: 15px 0;
+    border-bottom: 1px solid $grey-2;
+    margin: 0;
+    position: relative;
+    vertical-align: top;
+
+    @media (min-width: 641px) {
+      p {
+        width: 75%;
+      }
+    }
+  }
+
+  a.task-link {
+    font-weight: bold;
+    max-width: 70%;
+    display: inline-block;
+  }
+}
+
 .uploaded-files {
   border-top: 1px solid $grey-2;
 


### PR DESCRIPTION
There was a chunk of CSS that presumably didn't get ported across from the prototype since it uses classes like `.task-list`, but these are still used on the current start page even in the FFS.

Before
---
![screen shot 2017-02-09 at 10 58 25](https://cloud.githubusercontent.com/assets/988436/22780499/dcc77fee-eeb6-11e6-8a27-ec12d6488e6e.png)

After
---
![screen shot 2017-02-09 at 10 58 36](https://cloud.githubusercontent.com/assets/988436/22780502/e1b455f4-eeb6-11e6-997b-f8a2e0f1ec39.png)
