### PR TITLE
Closure journey `Check your answers` page, presenters and PDF.

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -16,7 +16,7 @@ class CasesController < ApplicationController
   private
 
   def generate_and_upload_pdf
-    tribunal_case = CaseDetailsPresenter.new(current_tribunal_case)
+    tribunal_case = AppealPresenter.new(current_tribunal_case)
     CaseDetailsPdf.new(tribunal_case, self).generate_and_upload
   end
 end

--- a/app/controllers/steps/closure/check_answers_controller.rb
+++ b/app/controllers/steps/closure/check_answers_controller.rb
@@ -1,11 +1,11 @@
-module Steps::Details
-  class CheckAnswersController < Steps::DetailsStepController
+module Steps::Closure
+  class CheckAnswersController < Steps::ClosureStepController
     respond_to :html, :pdf
 
     def show
       raise 'No tribunal case in session' unless current_tribunal_case
 
-      @tribunal_case = AppealPresenter.new(current_tribunal_case)
+      @tribunal_case = ClosurePresenter.new(current_tribunal_case)
 
       respond_to do |format|
         format.html

--- a/app/presenters/appeal_presenter.rb
+++ b/app/presenters/appeal_presenter.rb
@@ -1,9 +1,9 @@
-class CaseDetailsPresenter < SimpleDelegator
+class AppealPresenter < SimpleDelegator
 
   # Initialise with a TribunalCase instance and any method not
   # defined in this class will be forwarded automatically to that instance.
   #
-  #   details = CaseDetailsPresenter.new(tribunal_case_instance)
+  #   details = AppealPresenter.new(tribunal_case_instance)
   #
   #   details.taxpayer -> this class method
   #   details.case_reference -> tribunal_case_instance method

--- a/app/presenters/closure_enquiry_answers_presenter.rb
+++ b/app/presenters/closure_enquiry_answers_presenter.rb
@@ -1,0 +1,48 @@
+class ClosureEnquiryAnswersPresenter < BaseAnswersPresenter
+  def rows
+    [
+      hmrc_reference_question,
+      years_under_enquiry_question,
+      hmrc_officer_question,
+      additional_info_question
+    ].compact
+  end
+
+  private
+
+  def hmrc_reference_question
+    row(
+      tribunal_case.closure_hmrc_reference,
+      as: :hmrc_reference,
+      i18n_value: false,
+      change_path: edit_steps_closure_enquiry_details_path
+    )
+  end
+
+  def years_under_enquiry_question
+    row(
+      tribunal_case.closure_years_under_enquiry,
+      as: :years_under_enquiry,
+      i18n_value: false,
+      change_path: edit_steps_closure_enquiry_details_path
+    )
+  end
+
+  def hmrc_officer_question
+    row(
+      tribunal_case.closure_hmrc_officer,
+      as: :hmrc_officer,
+      i18n_value: false,
+      change_path: edit_steps_closure_enquiry_details_path
+    )
+  end
+
+  def additional_info_question
+    row(
+      tribunal_case.closure_additional_info,
+      as: :additional_info,
+      i18n_value: false,
+      change_path: edit_steps_closure_additional_info_path
+    )
+  end
+end

--- a/app/presenters/closure_presenter.rb
+++ b/app/presenters/closure_presenter.rb
@@ -1,0 +1,33 @@
+class ClosurePresenter < SimpleDelegator
+
+  # Initialise with a TribunalCase instance and any method not
+  # defined in this class will be forwarded automatically to that instance.
+  #
+  #   details = ClosurePresenter.new(tribunal_case_instance)
+  #
+  #   details.taxpayer -> this class method
+  #   details.case_reference -> tribunal_case_instance method
+  #   details.foobar -> NoMethodError
+
+  def taxpayer
+    @taxpayer ||= TaxpayerDetailsPresenter.new(tribunal_case)
+  end
+
+  def representative
+    @representative ||= RepresentativeDetailsPresenter.new(tribunal_case)
+  end
+
+  def documents
+    @documents ||= DocumentsSubmittedPresenter.new(tribunal_case)
+  end
+
+  def enquiry_answers
+    @enquiry_answers ||= ClosureEnquiryAnswersPresenter.new(tribunal_case)
+  end
+
+  private
+
+  def tribunal_case
+    __getobj__
+  end
+end

--- a/app/services/case_details_pdf.rb
+++ b/app/services/case_details_pdf.rb
@@ -4,7 +4,6 @@ class CaseDetailsPdf
   attr_reader :tribunal_case, :controller_ctx, :pdf
 
   PDF_CONFIG = {
-    template: 'steps/details/check_answers/pdf/show',
     formats: [:pdf],
     pdf: true,
     encoding: 'UTF-8'
@@ -42,7 +41,18 @@ class CaseDetailsPdf
   end
 
   def render_options
-    {locals: {tribunal_case: tribunal_case}}.merge(PDF_CONFIG)
+    {template: template, locals: {tribunal_case: tribunal_case}}.merge(PDF_CONFIG)
+  end
+
+  def template
+    case tribunal_case.intent
+    when Intent::TAX_APPEAL
+      'steps/details/check_answers/pdf/show'
+    when Intent::CLOSE_ENQUIRY
+      'steps/closure/check_answers/pdf/show'
+    else
+      raise "Invalid intent '#{tribunal_case.intent}'"
+    end
   end
 
   def upload!

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -10,7 +10,9 @@ class ClosureDecisionTree < DecisionTree
     when :additional_info
       edit(:support_documents)
     when :support_documents
-      show(:start) # TODO: check your answers step
+      show(:check_answers)
+    when :check_answers
+      task_list
     else
       raise "Invalid step '#{step_params}'"
     end
@@ -26,6 +28,8 @@ class ClosureDecisionTree < DecisionTree
       edit(:enquiry_details)
     when :support_documents
       edit(:additional_info)
+    when :check_answers
+      edit(:support_documents)
     else
       raise "Invalid step '#{step_params}'"
     end

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -12,7 +12,7 @@ class ClosureDecisionTree < DecisionTree
     when :support_documents
       show(:check_answers)
     when :check_answers
-      task_list
+      home_path
     else
       raise "Invalid step '#{step_params}'"
     end

--- a/app/services/decision_tree.rb
+++ b/app/services/decision_tree.rb
@@ -28,7 +28,7 @@ class DecisionTree
     { controller: step_controller, action: :edit }
   end
 
-  def task_list
-    { controller: '/task_list', action: :index }
+  def home_path
+    { controller: '/home', action: :index }
   end
 end

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -22,7 +22,7 @@ class DetailsDecisionTree < DecisionTree
     when :documents_checklist
       show(:check_answers)
     when :check_answers
-      task_list
+      home_path
     else
       raise "Invalid step '#{step_params}'"
     end

--- a/app/views/steps/closure/check_answers/pdf/_header.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/_header.pdf.erb
@@ -1,0 +1,4 @@
+<p>
+  <span class="case-reference"><%= tribunal_case.case_reference || 'NO REF' %></span>
+</p>
+<br/>

--- a/app/views/steps/closure/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/show.pdf.erb
@@ -1,0 +1,131 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <%= stylesheet_link_tag wicked_pdf_asset_base64('local/case_details_pdf') -%>
+</head>
+
+<body id="case-details-pdf">
+<%= render partial: 'steps/closure/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
+
+<h3><%= pdf_t '.application_details_heading' %></h3>
+
+<hr/>
+<table>
+  <tbody>
+  <tr>
+    <td class="section"><%= pdf_t '.questions.appellant_details' %></td>
+    <td class="content">
+      <div><%= tribunal_case.taxpayer.name %></div>
+      <div>
+        <%= simple_format(tribunal_case.taxpayer.address) %>
+      </div>
+      <div>
+        <%= pdf_t '.questions.appellant_phone' %>
+        <span><%= tribunal_case.taxpayer.phone %></span>
+      </div>
+      <div>
+        <%= pdf_t '.questions.appellant_email' %>
+        <span><%= tribunal_case.taxpayer.email %></span>
+      </div>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<hr/>
+<table>
+  <tbody>
+  <tr>
+    <td class="section"><%= pdf_t '.questions.representative_details' %></td>
+    <td class="content">
+      <% if tribunal_case.representative.present? %>
+        <div><%= tribunal_case.representative.name %></div>
+        <div>
+          <%= simple_format(tribunal_case.representative.address) %>
+        </div>
+        <div>
+          <%= pdf_t '.questions.representative_phone' %>
+          <span><%= tribunal_case.representative.phone %></span>
+        </div>
+        <div>
+          <%= pdf_t '.questions.representative_email' %>
+          <span><%= tribunal_case.representative.email %></span>
+        </div>
+      <% else %>
+        <div>
+          <%= pdf_t '.answers.no_representative' %>
+        </div>
+      <% end %>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<hr/>
+<table>
+  <tbody>
+  <tr>
+    <td class="section"><%= pdf_t '.questions.legal_representative' %></td>
+    <td class="content">
+      Not yet implemented in data capture.
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<hr/>
+<table>
+  <tbody>
+  <tr>
+    <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
+    <td class="content">
+      <ul class="documents">
+        <% tribunal_case.documents.list.each do |document| %>
+            <li><%= document.title %></li>
+        <% end %>
+      </ul>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<div class="newpage"></div>
+
+<%= render partial: 'steps/closure/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
+
+<h3><%= pdf_t '.application_type_heading' %></h3>
+
+<hr/>
+<table>
+  <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.case_type' %></td>
+      <td class="content"><%= pdf_t ".answers.case_type.#{tribunal_case.closure_case_type}" %></td>
+    </tr>
+    <tr>
+      <td colspan="2"></td>
+    </tr>
+  </tbody>
+</table>
+
+
+<h3><%= pdf_t '.enquiry_details_heading' %></h3>
+
+<hr/>
+<table>
+  <tbody>
+  <% tribunal_case.enquiry_answers.rows.each do |row| %>
+    <tr>
+      <td class="section"><%= pdf_t row.question %></td>
+      <td class="content"><%= row.answer %></td>
+    </tr>
+    <tr>
+      <td colspan="2"></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+</body>
+</html>

--- a/app/views/steps/closure/check_answers/show.html.erb
+++ b/app/views/steps/closure/check_answers/show.html.erb
@@ -1,0 +1,107 @@
+<%= step_header(:closure, 0) %>
+
+<h1 class="heading-large"><%= t '.heading' %></h1>
+
+<table class="check-your-answers">
+  <tbody>
+
+  <tr>
+    <th colspan="3"><h2 class="heading-medium"><%= t '.application_type_heading' %></h2></th>
+  </tr>
+  <tr>
+    <td><%= t '.questions.case_type' %></td>
+    <td><%= t ".answers.case_type.#{@tribunal_case.closure_case_type}" %></td>
+    <td class="change-answer">
+      <%= link_to t('.change'), edit_steps_closure_case_type_path %>
+    </td>
+  </tr>
+
+  <tr>
+    <th colspan="3"><h2 class="heading-medium"><%= t '.enquiry_details_heading' %></h2></th>
+  </tr>
+  <% @tribunal_case.enquiry_answers.rows.each do |row| %>
+    <tr>
+      <td><%= t row.question %></td>
+      <td><%= row.i18n_value ? t(row.answer) : row.answer %></td>
+      <td class="change-answer">
+        <%= row.change_link t('.change') %>
+      </td>
+    </tr>
+  <% end %>
+
+  <tr>
+    <th colspan="3"><h2 class="heading-medium"><%= t '.application_details_heading' %></h2></th>
+  </tr>
+  <tr>
+    <th><%= t '.questions.appellant_details' %></th>
+    <td>
+      <div><%= @tribunal_case.taxpayer.name %></div>
+      <div class="js_breaklines">
+        <%= simple_format(@tribunal_case.taxpayer.address) %>
+      </div>
+      <div>
+        <%= t '.questions.appellant_phone' %> <span><%= @tribunal_case.taxpayer.phone %></span>
+      </div>
+      <div>
+        <%= t '.questions.appellant_email' %> <span><%= @tribunal_case.taxpayer.email %></span>
+      </div>
+    </td>
+    <td class="change-answer">
+      <%= link_to t('.change'), edit_steps_details_taxpayer_type_path %>
+    </td>
+  </tr>
+    <tr>
+      <th><%= t '.questions.representative_details' %></th>
+      <td>
+        <% if @tribunal_case.representative.present? %>
+          <div><%= @tribunal_case.representative.name %></div>
+          <div class="js_breaklines">
+            <%= simple_format(@tribunal_case.representative.address) %>
+          </div>
+          <div>
+            <%= t '.questions.representative_phone' %> <span><%= @tribunal_case.representative.phone %></span>
+          </div>
+          <div>
+            <%= t '.questions.representative_email' %> <span><%= @tribunal_case.representative.email %></span>
+          </div>
+        <% else %>
+          <%= t '.answers.no_representative' %>
+        <% end %>
+      </td>
+      <td class="change-answer">
+        <%= link_to t('.change'), edit_steps_details_has_representative_path %>
+      </td>
+    </tr>
+
+    <tr>
+      <th><%= t '.questions.documents_submitted' %></th>
+      <td>
+        <ul class="list-bullet uploaded-docs">
+          <% @tribunal_case.documents.list.each do |document| %>
+            <li><%= document.title %></li>
+          <% end %>
+        </ul>
+      </td>
+      <td class="change-answer">
+        <%= link_to t('.change'), edit_steps_details_documents_checklist_path %>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 class="heading-medium"><%= t '.declaration_of_truth' %></h2>
+
+<p><%= t '.declaration_of_truth_message' %></p>
+
+<p class="notice util_mt-large">
+  <i class="icon icon-important">
+    <span class="visuallyhidden"><%= t '.warning' %></span>
+  </i>
+  <strong class="bold-small">
+    <%= t '.warning_message' %>
+  </strong>
+</p>
+
+<p>
+  <%= button_to t('.submit_and_continue'), cases_path, class: 'button' %>
+</p>

--- a/app/views/steps/lateness/start/show.html.erb
+++ b/app/views/steps/lateness/start/show.html.erb
@@ -15,6 +15,6 @@
 <% else %>
   <p>
     <strong><%=t '.previous_step_not_completed' %></strong><br>
-    <%= link_to t('.back_to_start'), task_list_path, class: 'link-back' %>
+    <%= link_to t('.back_to_start'), home_path, class: 'link-back' %>
   </p>
 <% end %>

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -31,6 +31,47 @@ en:
           heading: Add documents to support your application (optional)
           lead_text: The tax tribunal is independent and doesn't have access to files from HMRC.
           having_problems_uploading_documents_html: I am having trouble uploading my documents
+      check_answers:
+        show:
+          submit_and_continue: Submit and continue
+          change: Change
+          heading: Check your answers
+          warning: Warning
+          warning_message: "Once you click 'Submit and continue', you cannot change your answers"
+          declaration_of_truth: Declaration and statement of truth
+          declaration_of_truth_message: |
+            By completing this Application to Close an Enquiry and clicking the ‘Submit and
+            continue’ button, I believe the information I have given in this
+            form is true to the best of my knowledge. If I am found to have
+            been deliberately untruthful or dishonest, criminal proceedings for
+            fraud can be brought against me. I understand that if I have given
+            false information or I do not provide further evidence if
+            requested, my application may be rejected.
+          application_type_heading: Application type
+          application_details_heading: Application details
+          enquiry_details_heading: Enquiry details
+          questions:
+            case_type: What type of enquiry do you want to close?
+            hmrc_reference: HMRC reference number
+            years_under_enquiry: Years under enquiry
+            hmrc_officer: HMRC officer conducting enquiry
+            additional_info: Additional information
+            appellant_details: "Taxpayer's details"
+            appellant_phone: "Tel:"
+            appellant_email: "Email:"
+            representative_details: "Representative's details"
+            representative_phone: "Tel:"
+            representative_email: "Email:"
+            documents_submitted: Documents submitted
+            legal_representative: Legal representative
+          answers:
+            case_type:
+              capital_gains_tax_closure: Capital Gains Tax
+              corporation_tax_closure: Corporation Tax
+              income_tax_closure: Income Tax
+              partnership_tax_closure: Partnership Tax
+              stamp_duty_land_tax_closure: Stamp Duty Land Tax
+            no_representative: I don't have a representative
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -108,7 +108,7 @@ en:
         show:
           submit_and_continue: Submit and continue
           change: Change
-          heading: Check answers
+          heading: Check your answers
           warning: Warning
           warning_message: "Once you click 'Submit and continue', you cannot change your answers"
           declaration_of_truth: Declaration and statement of truth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
       edit_step :enquiry_details
       edit_step :additional_info
       edit_step :support_documents
+      show_step :check_answers
     end
 
     namespace :details do

--- a/spec/controllers/steps/closure/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/closure/check_answers_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Steps::Details::CheckAnswersController, type: :controller do
+RSpec.describe Steps::Closure::CheckAnswersController, type: :controller do
   it_behaves_like 'an end point step controller'
 
   context 'case details presenter' do
@@ -10,7 +10,7 @@ RSpec.describe Steps::Details::CheckAnswersController, type: :controller do
       get :show, session: {tribunal_case_id: tribunal_case.id}
 
       presenter = assigns[:tribunal_case]
-      expect(presenter).to be_an_instance_of(AppealPresenter)
+      expect(presenter).to be_an_instance_of(ClosurePresenter)
     end
   end
 

--- a/spec/presenters/appeal_presenter_spec.rb
+++ b/spec/presenters/appeal_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe CaseDetailsPresenter do
+RSpec.describe AppealPresenter do
   subject { described_class.new(tribunal_case) }
 
   let(:tribunal_case) { instance_double(TribunalCase) }

--- a/spec/presenters/closure_enquiry_answers_presenter_spec.rb
+++ b/spec/presenters/closure_enquiry_answers_presenter_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe ClosureEnquiryAnswersPresenter do
+  subject { described_class.new(tribunal_case) }
+
+  let(:tribunal_case) {
+    instance_double(
+      TribunalCase,
+      closure_hmrc_reference: closure_hmrc_reference,
+      closure_years_under_enquiry: closure_years_under_enquiry,
+      closure_hmrc_officer: closure_hmrc_officer,
+      closure_additional_info: closure_additional_info
+    )
+  }
+
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  let(:closure_hmrc_reference)      { 'reference' }
+  let(:closure_years_under_enquiry) { '2 years' }
+  let(:closure_hmrc_officer)        { nil }
+  let(:closure_additional_info)     { nil }
+
+  describe '#rows' do
+    describe '`closure_hmrc_reference` row' do
+      let(:row) { subject.rows[0] }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.hmrc_reference')
+        expect(row.answer).to      eq('reference')
+        expect(row.change_path).to eq(paths.edit_steps_closure_enquiry_details_path)
+      end
+    end
+
+    describe '`closure_years_under_enquiry` row' do
+      let(:row) { subject.rows[1] }
+
+      it 'has the correct attributes' do
+        expect(row.question).to    eq('.questions.years_under_enquiry')
+        expect(row.answer).to      eq('2 years')
+        expect(row.change_path).to eq(paths.edit_steps_closure_enquiry_details_path)
+      end
+    end
+
+    describe '`closure_hmrc_officer` row' do
+      let(:row) { subject.rows[2] }
+
+      context 'when present' do
+        let(:closure_hmrc_officer) { 'officer' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.hmrc_officer')
+          expect(row.answer).to      eq('officer')
+          expect(row.change_path).to eq(paths.edit_steps_closure_enquiry_details_path)
+        end
+      end
+
+      context 'when no present' do
+        it 'has no row' do
+          expect(row).to be_nil
+        end
+      end
+    end
+
+    describe '`closure_additional_info` row' do
+      let(:row) { subject.rows[3] }
+      let(:closure_hmrc_officer) { 'officer' }
+
+      context 'when present' do
+        let(:closure_additional_info) { 'more info' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.additional_info')
+          expect(row.answer).to      eq('more info')
+          expect(row.change_path).to eq(paths.edit_steps_closure_additional_info_path)
+        end
+      end
+
+      context 'when no present' do
+        it 'has no row' do
+          expect(row).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/closure_presenter_spec.rb
+++ b/spec/presenters/closure_presenter_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe ClosurePresenter do
+  subject { described_class.new(tribunal_case) }
+
+  let(:tribunal_case) { instance_double(TribunalCase) }
+
+  context '#taxpayer' do
+    it 'returns a taxpayer presenter instance' do
+      expect(subject.taxpayer).to be_an_instance_of(TaxpayerDetailsPresenter)
+    end
+  end
+
+  context '#representative' do
+    it 'returns a representative presenter instance' do
+      expect(subject.representative).to be_an_instance_of(RepresentativeDetailsPresenter)
+    end
+  end
+
+  context '#documents' do
+    it 'returns a documents presenter instance' do
+      expect(subject.documents).to be_an_instance_of(DocumentsSubmittedPresenter)
+    end
+  end
+
+  context '#enquiry' do
+    it 'returns a closure enquiry answers presenter instance' do
+      expect(subject.enquiry_answers).to be_an_instance_of(ClosureEnquiryAnswersPresenter)
+    end
+  end
+end

--- a/spec/services/closure_decision_tree_spec.rb
+++ b/spec/services/closure_decision_tree_spec.rb
@@ -26,11 +26,16 @@ RSpec.describe ClosureDecisionTree do
       it { is_expected.to have_destination(:support_documents, :edit) }
     end
 
-    # TODO: change once we have the `check your answers` step
     context 'when the step is `support_documents`' do
       let(:step_params) { { support_documents: 'anything' } }
 
-      it { is_expected.to have_destination(:start, :show) }
+      it { is_expected.to have_destination(:check_answers, :show) }
+    end
+
+    context 'when the step is `check_answers`' do
+      let(:step_params) { {check_answers: 'anything'} }
+
+      it { is_expected.to have_destination('/task_list', :index) }
     end
 
     context 'when the step is invalid' do
@@ -83,6 +88,12 @@ RSpec.describe ClosureDecisionTree do
       let(:step_params) { { support_documents: 'anything' } }
 
       it { is_expected.to have_previous(:additional_info, :edit) }
+    end
+
+    context 'when the step is `check_answers`' do
+      let(:step_params) { { check_answers: 'anything' } }
+
+      it { is_expected.to have_previous(:support_documents, :edit) }
     end
 
     context 'when the step is invalid' do

--- a/spec/services/closure_decision_tree_spec.rb
+++ b/spec/services/closure_decision_tree_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ClosureDecisionTree do
     context 'when the step is `check_answers`' do
       let(:step_params) { {check_answers: 'anything'} }
 
-      it { is_expected.to have_destination('/task_list', :index) }
+      it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is invalid' do

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe DetailsDecisionTree do
     context 'when the step is `check_answers`' do
       let(:step_params) { {check_answers: 'anything'} }
 
-      it { is_expected.to have_destination('/task_list', :index) }
+      it { is_expected.to have_destination('/home', :index) }
     end
 
     context 'when the step is invalid' do


### PR DESCRIPTION
This PR will add the `Check your answers` page to the Closure flow. A bit of refactor
was done in the presenters, and a new one for Closure has been created. Also some minor
changes were needed in the PDF creator service object to be able to handle the two
different `answer` pages we have now (appeal and closure).

Please note submitting will not work yet, that will be part of a follow up PR, but better
to get this merged as otherwise it could cause conflicts if delayed too much.