### PR TITLE
Distinguish between appeal and application in i18n

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,13 @@ module ApplicationHelper
   end
 
   def translate_for_user_type(key, params={})
-    translate("#{key}.as_#{current_tribunal_case.user_type}", params)
+    translate_with_appeal_or_application("#{key}.as_#{current_tribunal_case.user_type}", params)
+  end
+
+  def translate_with_appeal_or_application(key, params={})
+    appeal_or_application = I18n.translate("generic.appeal_or_application.#{current_tribunal_case.appeal_or_application}")
+    params_with_appeal_or_application = params.merge(appeal_or_application: appeal_or_application)
+
+    translate(key, params_with_appeal_or_application)
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,5 +1,7 @@
 class TribunalCase < ApplicationRecord
-  # Cost task
+  has_value_object :intent
+
+  # Appeal task
   has_value_object :challenged_decision
   has_value_object :case_type, constructor: :find_constant
   has_value_object :dispute_type
@@ -20,7 +22,6 @@ class TribunalCase < ApplicationRecord
   has_value_object :representative_type, class_name: 'ContactableEntityType'
 
   # Closure task
-  has_value_object :intent
   has_value_object :closure_case_type
 
   def mapping_code
@@ -41,5 +42,12 @@ class TribunalCase < ApplicationRecord
 
   def representative_is_organisation?
     representative_type.organisation?
+  end
+
+  def appeal_or_application
+    return :application if intent.eql?(Intent::CLOSE_ENQUIRY)
+    return :appeal      unless case_type
+
+    case_type.appeal_or_application
   end
 end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -1,5 +1,5 @@
 class CaseType < ValueObject
-  attr_reader :direct_tax, :ask_dispute_type, :ask_penalty, :ask_hardship
+  attr_reader :direct_tax, :ask_dispute_type, :ask_penalty, :ask_hardship, :appeal_or_application
   alias_method :direct_tax?, :direct_tax
   alias_method :ask_dispute_type?, :ask_dispute_type
   alias_method :ask_penalty?, :ask_penalty
@@ -9,22 +9,26 @@ class CaseType < ValueObject
     const_get(raw_value.upcase)
   end
 
-  def initialize(raw_value, direct_tax: false, ask_dispute_type: false, ask_penalty: false, ask_hardship: false)
-    @direct_tax, @ask_dispute_type, @ask_penalty, @ask_hardship = direct_tax, ask_dispute_type, ask_penalty, ask_hardship
+  def initialize(raw_value, params = {})
+    @direct_tax            = params.fetch(:direct_tax, false)
+    @ask_dispute_type      = params.fetch(:ask_dispute_type, false)
+    @ask_penalty           = params.fetch(:ask_penalty, false)
+    @ask_hardship          = params.fetch(:ask_hardship, false)
+    @appeal_or_application = params.fetch(:appeal_or_application, :appeal)
 
     super(raw_value)
   end
 
   def self.direct_tax_properties
-    { direct_tax: true, ask_dispute_type: true, ask_penalty: true, ask_hardship: false }
+    { direct_tax: true, ask_dispute_type: true, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal }
   end
 
   def self.indirect_tax_properties
-    { direct_tax: false, ask_dispute_type: true, ask_penalty: true, ask_hardship: true }
+    { direct_tax: false, ask_dispute_type: true, ask_penalty: true, ask_hardship: true, appeal_or_application: :appeal }
   end
 
   VALUES = [
-    APN_PENALTY                  = new(:apn_penalty,                  direct_tax: false, ask_dispute_type: false, ask_penalty: true,  ask_hardship: false),
+    APN_PENALTY                  = new(:apn_penalty,                  direct_tax: false, ask_dispute_type: false, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
     AGGREGATES_LEVY              = new(:aggregates_levy,              indirect_tax_properties),
     AIR_PASSENGER_DUTY           = new(:air_passenger_duty,           indirect_tax_properties),
     ALCOHOLIC_LIQUOR_DUTIES      = new(:alcoholic_liquor_duties,      indirect_tax_properties),
@@ -34,33 +38,33 @@ class CaseType < ValueObject
     CORPORATION_TAX              = new(:corporation_tax,              direct_tax_properties),
     CLIMATE_CHANGE_LEVY          = new(:climate_change_levy,          indirect_tax_properties),
     CONSTRUCTION_INDUSTRY_SCHEME = new(:construction_industry_scheme, direct_tax_properties),
-    COUNTER_TERRORISM            = new(:counter_terrorism,            direct_tax: true, ask_dispute_type: false,  ask_penalty: false,  ask_hardship: false),
+    COUNTER_TERRORISM            = new(:counter_terrorism,            direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :appeal),
     CUSTOMS_DUTY                 = new(:customs_duty,                 indirect_tax_properties),
     DOTAS_PENALTY                = new(:dotas_penalty,                direct_tax_properties),
     GAMING_DUTY                  = new(:gaming_duty,                  indirect_tax_properties),
     GENERAL_BETTING_DUTY         = new(:general_betting_duty,         indirect_tax_properties),
     EXPORT_REGULATIONS_PENALTY   = new(:export_regulations_penalty,   indirect_tax_properties),
     HYDROCARBON_OIL_DUTIES       = new(:hydrocarbon_oil_duties,       indirect_tax_properties),
-    INACCURATE_RETURN_PENALTY    = new(:inaccurate_return_penalty,    direct_tax: false, ask_dispute_type: false, ask_penalty: true,  ask_hardship: false),
+    INACCURATE_RETURN_PENALTY    = new(:inaccurate_return_penalty,    direct_tax: false, ask_dispute_type: false, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
     INCOME_TAX                   = new(:income_tax,                   direct_tax_properties),
-    INFORMATION_NOTICE           = new(:information_notice,           direct_tax: false, ask_dispute_type: true,  ask_penalty: true,  ask_hardship: false),
+    INFORMATION_NOTICE           = new(:information_notice,           direct_tax: false, ask_dispute_type: true, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
     INHERITANCE_TAX              = new(:inheritance_tax,              direct_tax_properties),
     INSURANCE_PREMIUM_TAX        = new(:insurance_premium_tax,        indirect_tax_properties),
     LANDFILL_TAX                 = new(:landfill_tax,                 indirect_tax_properties),
     LOTTERY_DUTY                 = new(:lottery_duty,                 indirect_tax_properties),
-    MONEY_LAUNDERING_DECISIONS   = new(:money_laundering_decisions,   direct_tax: true, ask_dispute_type: false,  ask_penalty: false,  ask_hardship: true),
+    MONEY_LAUNDERING_DECISIONS   = new(:money_laundering_decisions,   direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true, appeal_or_application: :appeal),
     NI_CONTRIBUTIONS             = new(:ni_contributions,             direct_tax_properties),
     PETROLEUM_REVENUE_TAX        = new(:petroleum_revenue_tax,        direct_tax_properties),
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),
     REMOTE_GAMING_DUTY           = new(:remote_gaming_duty,           indirect_tax_properties),
-    REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, ask_dispute_type: false,  ask_penalty: false,  ask_hardship: false),
-    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_dispute_type: false,  ask_penalty: false,  ask_hardship: false),
+    REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :application),
+    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :application),
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),
     TOBACCO_PRODUCTS_DUTY        = new(:tobacco_products_duty,        indirect_tax_properties),
     VAT                          = new(:vat,                          indirect_tax_properties),
-    OTHER                        = new(:other,                        direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true)
+    OTHER                        = new(:other,                        direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true, appeal_or_application: :appeal)
   ].freeze
 
   def self.values

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -23,7 +23,7 @@
         <% end %>
 
         <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
-          <p><%= t('shared.file_upload.having_problems_explanation_html') %></p>
+          <p><%= translate_with_appeal_or_application('shared.file_upload.having_problems_explanation_html') %></p>
           <%= f.text_area :closure_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
         </div>
       </div>

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -10,7 +10,7 @@
   </tr>
   <% @tribunal_case.appeal_type_answers.rows.each do |row| %>
       <tr>
-        <td><%= t row.question %></td>
+        <td><%= translate_with_appeal_or_application row.question %></td>
         <td><%= row.i18n_value ? t(row.answer) : row.answer %></td>
         <td class="change-answer">
           <%= row.change_link t('.change') %>
@@ -23,7 +23,7 @@
   </tr>
   <% @tribunal_case.appeal_lateness_answers.rows.each do |row| %>
       <tr>
-        <td><%= t row.question %></td>
+        <td><%= translate_with_appeal_or_application row.question %></td>
         <td><%= row.i18n_value ? t(row.answer) : row.answer %></td>
         <td class="change-answer">
           <%= row.change_link t('.change') %>
@@ -76,7 +76,7 @@
     </tr>
 
   <tr>
-    <th><%= t '.questions.grounds_for_appeal' %></th>
+    <th><%= translate_with_appeal_or_application '.questions.grounds_for_appeal' %></th>
     <td>
       <span>
         <%= @tribunal_case.documents.grounds_for_appeal_text(default: t('.answers.no_grounds_for_appeal_text')) %>
@@ -118,7 +118,7 @@
 
 <h2 class="heading-medium"><%= t '.declaration_of_truth' %></h2>
 
-<p><%= t '.declaration_of_truth_message' %></p>
+<p><%= translate_with_appeal_or_application '.declaration_of_truth_message' %></p>
 
 <p class="notice util_mt-large">
   <i class="icon icon-important">

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -37,7 +37,7 @@
           <% end %>
 
           <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
-            <p><%= t('shared.file_upload.having_problems_explanation_html') %></p>
+            <p><%= translate_with_appeal_or_application('shared.file_upload.having_problems_explanation_html') %></p>
             <%= f.text_area :having_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
           </div>
         </div>

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <%= step_header(:details, 3) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 
     <p class="lede"><%=t '.lead_text' %></p>
 

--- a/app/views/steps/details/has_representative/edit.html.erb
+++ b/app/views/steps/details/has_representative/edit.html.erb
@@ -17,7 +17,7 @@
         <%=t '.details_heading' %>
       </summary>
       <div class="panel" id="details-content-0" aria-hidden="false">
-        <%=t '.details_content_html' %>
+        <%= translate_with_appeal_or_application '.details_content_html' %>
       </div>
     </details>
   </div>

--- a/app/views/steps/details/outcome/edit.html.erb
+++ b/app/views/steps/details/outcome/edit.html.erb
@@ -2,9 +2,9 @@
   <div class="column-two-thirds">
     <%= step_header(:details, 4) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 
-    <p class="lede"><%=t '.lead_text' %></p>
+    <p class="lede"><%= translate_with_appeal_or_application '.lead_text' %></p>
 
     <%= step_form @form_object do |f| %>
       <%= f.text_area :outcome, size: '40x6', class: 'form-control form-control-3-4' %>

--- a/app/views/steps/details/user_type/edit.html.erb
+++ b/app/views/steps/details/user_type/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <%= step_header(:details, 0) %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :user_type,
@@ -13,7 +13,7 @@
     <details role="group">
       <summary role="button" aria-controls="details-content" aria-expanded="false"><%=t '.representative_heading' %></summary>
       <div class="panel" id="details-content" aria-hidden="true">
-        <%=t '.representative_content_html' %>
+        <%= translate_with_appeal_or_application '.representative_content_html' %>
       </div>
     </details>
   </div>

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -3,11 +3,11 @@
     <%= step_header(:lateness, 2) %>
 
     <h1 class="heading-large">
-      <%= @form_object.lateness_unknown? ? t('.heading_unsure') : t('.heading') %>
+      <%= @form_object.lateness_unknown? ? translate_with_appeal_or_application('.heading_unsure') : translate_with_appeal_or_application('.heading') %>
     </h1>
 
     <p class="lede">
-      <%= @form_object.lateness_unknown? ? t('.lead_text_unsure') : t('.lead_text') %>
+      <%= @form_object.lateness_unknown? ? translate_with_appeal_or_application('.lead_text_unsure') : translate_with_appeal_or_application('.lead_text') %>
     </p>
 
     <%= step_form @form_object do |f| %>
@@ -18,12 +18,12 @@
     <details>
       <summary>
         <span class="summary">
-          <%=t '.details_title' %>
+          <%= translate_with_appeal_or_application '.details_title' %>
         </span>
       </summary>
       <div class="panel panel-border-narrow">
         <p>
-          <%=t '.details_content' %>
+          <%= translate_with_appeal_or_application '.details_content' %>
         </p>
       </div>
     </details>

--- a/config/locales/default.yml
+++ b/config/locales/default.yml
@@ -6,6 +6,9 @@ en:
         precision: 0
   generic:
     back_link: Back
+    appeal_or_application:
+      appeal: appeal
+      application: application
   errors:
     # WARNING: This means every possible error message must be a full
     #  English sentence because the attribute name won't be prepended!

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -18,7 +18,7 @@ en:
         <strong>What to do next</strong>
         <ul class="list list-bullet">
           <li>enter reasons why you can't upload documents</li>
-          <li>continue your appeal online</li>
+          <li>continue your %{appeal_or_application} online</li>
           <li>print out your case details</li>
           <li>post your documents and case details</li>
         </ul>
@@ -30,8 +30,8 @@ en:
       step_header: Question %{step} of ?
       start:
         show:
-          heading: 3. Enter appeal details
-          lead_text: You will need to include grounds for your appeal and upload a scan or photo of the letters from HMRC.
+          heading: 3. Enter %{appeal_or_application} details
+          lead_text: You will need to include grounds for your %{appeal_or_application} and upload a scan or photo of the letters from HMRC.
           description_html: |
             <h4 class="heading-small">What to get ready before you start</h4>
             <ul class="list list-bullet">
@@ -47,23 +47,23 @@ en:
                 You can't save details as you go. Please get everything ready before you start.
               </strong>
             </p>
-          previous_step_not_completed: You must complete Step 1 and Step 2 before you can enter your appeal details.
+          previous_step_not_completed: You must complete Step 1 and Step 2 before you can enter your %{appeal_or_application} details.
           continue: Continue
       user_type:
         edit:
-          heading: Are you the taxpayer making the appeal?
+          heading: Are you the taxpayer making the %{appeal_or_application}?
           representative_heading: What is a representative and what can they do?
           representative_content_html: |
             <p>A representative is someone who can act on your behalf when dealing with the tax tribunal.</p>
-            <p>You may want to use one if you need help or advice, or need assistance submitting an appeal or application.</p>
+            <p>You may want to use one if you need help or advice, or need assistance submitting an %{appeal_or_application}.</p>
             <p>A representative could be a lawyer, tax adviser or accountant. It could also be a friend or family relative who you approve to act on your behalf.</p>
-            <p>If a representative is not a certified legal professional they will need to be authorised by the taxpayer to act on their behalf to handle any matters related to an appeal or application.</p>
+            <p>If a representative is not a certified legal professional they will need to be authorised by the taxpayer to act on their behalf to handle any matters related to an %{appeal_or_application}.</p>
             <p>An authorised representative will be able to receive any correspondence from the tax tribunal and can represent the taxpayer at a hearing with the judge.</p>
       taxpayer_type:
         edit:
           heading:
-            as_taxpayer: Who is making the appeal?
-            as_representative: Who is the appeal for?
+            as_taxpayer: Who is making the %{appeal_or_application}?
+            as_representative: Who is the %{appeal_or_application} for?
       taxpayer_details:
         edit:
           heading: Enter taxpayer's details
@@ -74,9 +74,9 @@ en:
           details_heading: What is a representative and what can they do?
           details_content_html: |
             <p>A representative is someone who can act on your behalf when dealing with the tax tribunal.</p>
-            <p>You may want to use one if you need help or advice, or need assistance submitting an appeal or application.</p>
+            <p>You may want to use one if you need help or advice, or need assistance submitting an %{appeal_or_application}.</p>
             <p>A representative could be a lawyer, tax adviser or accountant. It could also be a friend or family relative who you approve to act on your behalf.</p>
-            <p>If a representative is not a certified legal professional they will need to be authorised by the taxpayer to act on their behalf to handle any matters related to an appeal or application.</p>
+            <p>If a representative is not a certified legal professional they will need to be authorised by the taxpayer to act on their behalf to handle any matters related to an %{appeal_or_application}.</p>
             <p>An authorised representative will be able to receive any correspondence from the tax tribunal and can represent the taxpayer at a hearing with the judge.</p>
       representative_type:
         edit:
@@ -91,7 +91,7 @@ en:
             as_representative: If you are approved to act on behalf of the taxpayer all correspondence will be sent to the address, or email address, you enter below.
       grounds_for_appeal:
         edit:
-          heading: Grounds for appeal
+          heading: Grounds for %{appeal_or_application}
           lead_text: Clearly explain why you are appealing, giving reasons for each decision you dispute. The judge will want to hear things from your side.
           description_text: Clearly explain in your own words. The judge will want to know things from your side and understand how any evidence you provide supports your case.
           footer_description_text: You will next have to upload any supporting documents including any correspondence with HMRC and evidence to support your case.
@@ -119,26 +119,26 @@ en:
             been deliberately untruthful or dishonest, criminal proceedings for
             fraud can be brought against me. I understand that if I have given
             false information or I do not provide further evidence if
-            requested, my appeal may be rejected.
+            requested, my %{appeal_or_application} may be rejected.
           appeal_type_heading: Appeal type
           appeal_timeliness_heading: Appeal deadline
           appeal_details_heading: Appeal details
           questions:
             challenged_decision: Did you challenge the original decision?
-            case_type: What is your appeal about?
+            case_type: What is your %{appeal_or_application} about?
             dispute_type: What is your dispute about?
             penalty_level: What is the penalty or surcharge amount?
             penalty_amount: What is the penalty or surcharge amount?
             tax_amount: What is the amount of tax?
-            in_time: Is the appeal late?
-            lateness_reason: Reason(s) for late appeal
+            in_time: Is the %{appeal_or_application} late?
+            lateness_reason: Reason(s) for late %{appeal_or_application}
             appellant_details: "Taxpayer's details"
             appellant_phone: "Tel:"
             appellant_email: "Email:"
             representative_details: "Representative's details"
             representative_phone: "Tel:"
             representative_email: "Email:"
-            grounds_for_appeal: Grounds for appeal
+            grounds_for_appeal: Grounds for %{appeal_or_application}
             documents_submitted: Documents submitted
             legal_representative: Legal representative
             desired_outcome: Desired outcome
@@ -174,15 +174,15 @@ en:
             no_representative: I don't have a representative
       outcome:
         edit:
-          heading: What outcome do you want from your appeal?
-          lead_text: Give a summary of the decisions you think should be made in regards to your appeal. Write no more than 2-3 sentences which clearly outline the result you want.
+          heading: What outcome do you want from your %{appeal_or_application}?
+          lead_text: Give a summary of the decisions you think should be made in regards to your %{appeal_or_application}. Write no more than 2-3 sentences which clearly outline the result you want.
   activemodel:
     errors:
       models:
         steps/details/user_type_form:
           attributes:
             user_type:
-              inclusion: Select whether you are the taxpayer involved in the appeal
+              inclusion: Select whether you are the taxpayer involved
         steps/details/taxpayer_type_form:
           attributes:
             taxpayer_type:
@@ -194,7 +194,7 @@ en:
         steps/details/representative_type_form:
           attributes:
             representative_type:
-              inclusion: Select whether your representative is an individual, company or organisation
+              inclusion: Select whether the representative is an individual, company or organisation
         steps/details/grounds_for_appeal_form:
           attributes:
             grounds_for_appeal:

--- a/config/locales/lateness.yml
+++ b/config/locales/lateness.yml
@@ -23,12 +23,12 @@ en:
           lead_text: Use the date shown on either the original notice letter or review conclusion letter.
       lateness_reason:
         edit:
-          heading: Why are you late with your appeal?
-          heading_unsure: Are there reasons why your appeal might be late?
-          lead_text: You must provide reasonable grounds for appealing late. If the judge rejects your reasons, your appeal will not proceed.
-          lead_text_unsure: To help us process your case quickly, you should give reasons why your appeal might be late. The judge will look at your reasons and decide whether to accept your appeal if it is late.
-          details_title: Help with late appeals
-          details_content: You must provide reasonable grounds for submitting your appeal late. These are usually unforeseen circumstances or events beyond your control which meant you weren't able to meet the tax tribunal deadlines.
+          heading: Why are you late with your %{appeal_or_application}?
+          heading_unsure: Are there reasons why your %{appeal_or_application} might be late?
+          lead_text: You must provide reasonable grounds for appealing late. If the judge rejects your reasons, your %{appeal_or_application} will not proceed.
+          lead_text_unsure: To help us process your case quickly, you should give reasons why your %{appeal_or_application} might be late. The judge will look at your reasons and decide whether to accept your %{appeal_or_application} if it is late.
+          details_title: Help with late %{appeal_or_application}
+          details_content: You must provide reasonable grounds for submitting your %{appeal_or_application} late. These are usually unforeseen circumstances or events beyond your control which meant you weren't able to meet the tax tribunal deadlines.
   activemodel:
     errors:
       models:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -50,9 +50,21 @@ RSpec.describe ApplicationHelper do
 
     it 'translates for the correct user type' do
       expect(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
-      expect(helper).to receive(:translate).with('.foobar.as_humanoid', random_param: 'Nein')
+      expect(helper).to receive(:translate_with_appeal_or_application).with('.foobar.as_humanoid', random_param: 'Nein').and_return('Foo!')
 
-      helper.translate_for_user_type('.foobar', random_param: 'Nein')
+      expect(helper.translate_for_user_type('.foobar', random_param: 'Nein')).to eq('Foo!')
+    end
+  end
+
+  describe '#translate_with_appeal_or_application' do
+    let(:tribunal_case) { instance_double(TribunalCase, appeal_or_application: :whatever) }
+
+    it 'adds appeal_or_application to params and calls the original implementation' do
+      expect(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
+      expect(I18n).to receive(:translate).with('generic.appeal_or_application.whatever').and_return('wibble')
+      expect(helper).to receive(:translate).with('.foobar', random_param: 'something', appeal_or_application: 'wibble').and_return('Yay!')
+
+      expect(helper.translate_with_appeal_or_application('.foobar', random_param: 'something')).to eq('Yay!')
     end
   end
 end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -51,4 +51,35 @@ RSpec.describe TribunalCase, type: :model do
       expect(subject.representative_is_organisation?).to eq(true)
     end
   end
+
+  describe '#appeal_or_application' do
+    context 'when the intent is CLOSE_ENQUIRY' do
+      let(:case_type)  { CaseType.new(:random, appeal_or_application: :whatever) }
+      let(:attributes) { { intent: Intent.new(:close_enquiry), case_type: case_type } }
+
+      it 'returns application regardless of case type' do
+        expect(subject.appeal_or_application).to eq(:application)
+      end
+    end
+
+    context 'when the intent is TAX_APPEAL' do
+      let(:attributes) { { intent: Intent.new(:tax_appeal), case_type: case_type } }
+
+      context 'when there is no case type' do
+        let(:case_type) { nil }
+
+        it 'returns appeal by default' do
+          expect(subject.appeal_or_application).to eq(:appeal)
+        end
+      end
+
+      context 'when there is a case type' do
+        let(:case_type)  { CaseType.new(:random, appeal_or_application: :whatever) }
+
+        it 'delegates to the case type' do
+          expect(subject.appeal_or_application).to eq(:whatever)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The application copy needs to be slightly different depending on whether
the case is about an appeal or an application.

- Add `appeal_or_application` property to `CaseType` value object and
  clean up initialisation
- Add `TribunalCase#appeal_or_application` to determine type based on
  intent and case type
- Add `ApplicationHelper#translate_with_appeal_or_application` to allow
  translations with `appeal_or_application` injected into the params
  hash, and use this where appropriate