### PR TITLE
add a fake gov.uk start page for user research

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,11 @@ class HomeController < ApplicationController
     @link_sections = link_sections
   end
 
+  # TODO: This page is only used for user research. It should be removed
+  # before the service goes live.
+  def dummy_start_page
+  end
+
   private
 
   # [task name (used for i18n), estimated minutes to complete this task, path/url to the task]

--- a/app/views/home/dummy_start_page.html.erb
+++ b/app/views/home/dummy_start_page.html.erb
@@ -1,0 +1,63 @@
+<div class="grid-row">
+    <div class="column-two-thirds">
+
+      <form class="js_route" action="/">
+
+        <h1 class="heading-large">Appeal to the tax tribunal</h1>
+
+        <p class="lede">The tax tribunal is run by the Ministry of Justice.</p>
+        <p>Try and settle your dispute directly first. If you can't, a judge will make an impartial decision on your case.</p>
+        <p>The tribunal is independent and uses the information you provide to hear things from your side.</p>
+        <h2 class="heading-medium">You will need:</h2>
+        <ul class="list list-bullet">
+        <li><strong>a scan or photo</strong> of the original notice or review conclusion letter</li>
+        <li><strong>reasons for your appeal</strong> to copy and paste or attach as a document</li>
+        <li data-dependent="fees=yes" class="js-hidden"><strong>a way to pay your tribunal fee</strong> such as a debit or credit card, unless you are on a <a href="https://www.gov.uk/get-help-with-court-fees">low income or certain benefits</a></li>
+        <li><strong><a href="https://drive.google.com/open?id=0B-4PgEZDV9SBczhkbGNDanJEa28">signed approval (PDF, 58Kb)</a></strong> if you want someone to represent you</li>
+      </ul>
+
+      <p class="notice util_mt-large">
+        <i class="icon icon-important">
+          <span class="visuallyhidden">Warning</span>
+        </i>
+        <strong class="bold-small">
+          You can't save details so get everything ready before you start
+        </strong>
+      </p>
+
+      <p>
+        <input type="submit" class="button button-start" value="Start now">
+      </p>
+      <h2 class="heading-medium">Other ways to submit an appeal</h2>
+      <ul class="list list-bullet">
+        <li>You can use <a class="external" rel="external" href="http://hmctsformfinder.justice.gov.uk/HMCTS/GetForms.do?court_forms_category=Tax%20(First-tier%20Tribunal)">paper forms</a> to submit an appeal (T240) or close an enquiry (T245)</li>
+        <li>
+          Send your form by post to First-tier Tribunal (Tax Chamber), PO Box 16972, Birmingham, B16 6TZ
+        </li>
+      </ul>
+      </form>
+
+    </div>
+
+    <div class="column-one-third">
+      <aside class="govuk-related-items">
+
+        <h2 class="heading-medium">Courts, sentencing and tribunals</h2>
+        <nav role="navigation">
+          <ul class="font-xsmall">
+              <li><a href="https://www.gov.uk/court-fees-what-they-are">Court and tribunal fees</a></li>
+              <li><a href="https://www.gov.uk/tax-tribunal">Guide to tax tribunals</a></li>
+          </ul>
+        </nav>
+
+        <h2 class="heading-medium">Elsewhere on GOV.UK</h2>
+        <nav role="navigation">
+          <ul class="font-xsmall">
+            <li><a href="https://www.gov.uk/tax-appeals">Disagree with a tax decision</a></li>
+            <li><a href="https://www.gov.uk/government/publications/tax-chamber-tribunal-procedure-rules">Tax tribunal procedure rules</a></li>
+          </ul>
+        </nav>
+
+      </aside>
+    </div>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,4 +84,5 @@ Rails.application.routes.draw do
 
   root to: 'home#index'
   get :appeal, to: 'home#index'
+  get :dummy_start_page, to: 'home#dummy_start_page'
 end


### PR DESCRIPTION
The page is at /dummy_start_page

This is only supposed to be for user research, so 
I haven't bothered to use i18n for the copy.