### PR TITLE
Navigation stack for "back" navigation in steps

### DIFF
--- a/app/controllers/steps/appeal/challenged_decision_controller.rb
+++ b/app/controllers/steps/appeal/challenged_decision_controller.rb
@@ -21,5 +21,12 @@ module Steps::Appeal
       #   to be doing this here.
       super || initialize_tribunal_case(intent: Intent::TAX_APPEAL)
     end
+
+    def update_navigation_stack
+      # This is the first step in the appeal flow, so reset the navigation stack
+      # before re-initialising it in StepController#update_navigation_stack
+      current_tribunal_case.navigation_stack = []
+      super
+    end
   end
 end

--- a/app/controllers/steps/closure/case_type_controller.rb
+++ b/app/controllers/steps/closure/case_type_controller.rb
@@ -21,5 +21,12 @@ module Steps::Closure
       #   to be doing this here.
       super || initialize_tribunal_case(intent: Intent::CLOSE_ENQUIRY)
     end
+
+    def update_navigation_stack
+      # This is the first step in the closure flow, so reset the navigation stack
+      # before re-initialising it in StepController#update_navigation_stack
+      current_tribunal_case.navigation_stack = []
+      super
+    end
   end
 end

--- a/app/controllers/steps/closure/check_answers_controller.rb
+++ b/app/controllers/steps/closure/check_answers_controller.rb
@@ -19,5 +19,9 @@ module Steps::Closure
       pdf = CaseDetailsPdf.new(tribunal_case, self)
       send_data pdf.generate, filename: pdf.filename, type: 'application/pdf', disposition: 'inline'
     end
+
+    def update_navigation_stack
+      current_tribunal_case&.update(navigation_stack: [])
+    end
   end
 end

--- a/app/controllers/steps/details/check_answers_controller.rb
+++ b/app/controllers/steps/details/check_answers_controller.rb
@@ -19,5 +19,9 @@ module Steps::Details
       pdf = CaseDetailsPdf.new(tribunal_case, self)
       send_data pdf.generate, filename: pdf.filename, type: 'application/pdf', disposition: 'inline'
     end
+
+    def update_navigation_stack
+      current_tribunal_case&.update(navigation_stack: [])
+    end
   end
 end

--- a/db/migrate/20170210140438_add_navigation_stack_to_tribunal_case.rb
+++ b/db/migrate/20170210140438_add_navigation_stack_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddNavigationStackToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :navigation_stack, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170203154438) do
+ActiveRecord::Schema.define(version: 20170210140438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 20170203154438) do
     t.string   "representative_organisation_registration_number"
     t.text     "having_problems_uploading_details"
     t.string   "user_type"
+    t.string   "navigation_stack",                                default: [],                                       array: true
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/step_controller_spec.rb
+++ b/spec/controllers/step_controller_spec.rb
@@ -1,25 +1,78 @@
 require 'rails_helper'
 
 class DummyStepController < StepController
-  private
-
-  def decision_tree_class; end
-  def current_tribunal_case; end
+  def show
+    head(:ok)
+  end
 end
 
-RSpec.describe StepController, type: :controller do
-  subject { DummyStepController.new }
+RSpec.describe DummyStepController, type: :controller do
+  before do
+    TaxTribunalsDatacapture::Application.routes.draw do
+      get '/dummy_step' => 'dummy_step#show'
+      root to: 'dummy_root#index'
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  describe 'navigation stack' do
+    let!(:tribunal_case) { TribunalCase.create(navigation_stack: navigation_stack) }
+
+    before do
+      get :show, session: { tribunal_case_id: tribunal_case.id }
+      tribunal_case.reload
+    end
+
+    context 'when the stack is empty' do
+      let(:navigation_stack) { [] }
+
+      it 'adds the page to the stack' do
+        expect(tribunal_case.navigation_stack).to eq(['/dummy_step'])
+      end
+    end
+
+    context 'when the current page is on the stack' do
+      let(:navigation_stack) { ['/foo', '/bar', '/dummy_step', '/baz'] }
+
+      it 'rewinds the stack to the appropriate point' do
+        expect(tribunal_case.navigation_stack).to eq(['/foo', '/bar', '/dummy_step'])
+      end
+    end
+
+    context 'when the current page is not on the stack' do
+      let(:navigation_stack) { ['/foo', '/bar', '/baz'] }
+
+      it 'adds it to the end of the stack' do
+        expect(tribunal_case.navigation_stack).to eq(['/foo', '/bar', '/baz', '/dummy_step'])
+      end
+    end
+  end
 
   describe '#previous_step_path' do
-    let(:decision_tree_class) { double('Decision tree class', new: decision_tree) }
-    let(:decision_tree)       { double(DecisionTree, previous: previous) }
-    let(:previous)            { double('Previous step') }
+    let!(:tribunal_case) { TribunalCase.create(navigation_stack: navigation_stack) }
 
-    it 'queries the decision tree for the previous step path' do
-      expect(subject).to receive(:decision_tree_class).and_return(decision_tree_class)
-      expect(subject).to receive(:url_for).with(previous).and_return('/somewhere')
+    before do
+      get :show, session: { tribunal_case_id: tribunal_case.id }
+    end
 
-      expect(subject.previous_step_path).to eq('/somewhere')
+    context 'when the stack is empty' do
+      let(:navigation_stack) { [] }
+
+      it 'returns the root path' do
+        expect(subject.previous_step_path).to eq('/')
+      end
+    end
+
+    context 'when the stack has elements' do
+      let(:navigation_stack) { ['/somewhere', '/over', '/the', '/rainbow'] }
+
+      it 'returns the element before the current page' do
+        # Not '/the', as we've performed a page load and thus added '/dummy_page' at the end
+        expect(subject.previous_step_path).to eq('/rainbow')
+      end
     end
   end
 end

--- a/spec/controllers/steps/closure/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/closure/check_answers_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::Closure::CheckAnswersController, type: :controller do
   it_behaves_like 'an end point step controller'
 
   context 'case details presenter' do
-    let(:tribunal_case) { TribunalCase.create(case_type: CaseType::OTHER) }
+    let(:tribunal_case) { TribunalCase.create(case_type: CaseType::OTHER, navigation_stack: ['/not', '/empty']) }
 
     it 'assigns the presenter' do
       get :show, session: {tribunal_case_id: tribunal_case.id}
@@ -12,10 +12,17 @@ RSpec.describe Steps::Closure::CheckAnswersController, type: :controller do
       presenter = assigns[:tribunal_case]
       expect(presenter).to be_an_instance_of(ClosurePresenter)
     end
+
+    it 'clears the navigation stack' do
+      get :show, session: {tribunal_case_id: tribunal_case.id}
+
+      tribunal_case.reload
+      expect(tribunal_case.navigation_stack).to be_empty
+    end
   end
 
   context 'PDF format' do
-    let(:current_tribunal_case) { instance_double(TribunalCase) }
+    let(:current_tribunal_case) { instance_double(TribunalCase, update: nil) }
     let(:pdf_creator_double) { instance_double(CaseDetailsPdf, generate: 'some pdf content', filename: 'filename123.pdf') }
 
     before do

--- a/spec/controllers/steps/details/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/details/check_answers_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::Details::CheckAnswersController, type: :controller do
   it_behaves_like 'an end point step controller'
 
   context 'case details presenter' do
-    let(:tribunal_case) { TribunalCase.create(case_type: CaseType::OTHER) }
+    let(:tribunal_case) { TribunalCase.create(case_type: CaseType::OTHER, navigation_stack: ['/not', '/empty']) }
 
     it 'assigns the presenter' do
       get :show, session: {tribunal_case_id: tribunal_case.id}
@@ -12,10 +12,17 @@ RSpec.describe Steps::Details::CheckAnswersController, type: :controller do
       presenter = assigns[:tribunal_case]
       expect(presenter).to be_an_instance_of(AppealPresenter)
     end
+
+    it 'clears the navigation stack' do
+      get :show, session: {tribunal_case_id: tribunal_case.id}
+
+      tribunal_case.reload
+      expect(tribunal_case.navigation_stack).to be_empty
+    end
   end
 
   context 'PDF format' do
-    let(:current_tribunal_case) { instance_double(TribunalCase) }
+    let(:current_tribunal_case) { instance_double(TribunalCase, update: nil) }
     let(:pdf_creator_double) { instance_double(CaseDetailsPdf, generate: 'some pdf content', filename: 'filename123.pdf') }
 
     before do

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -59,7 +59,7 @@ RSpec.shared_examples 'a start point step controller' do |form_class, decision_t
     end
 
     context 'when a case exists in the session' do
-      let!(:existing_case) { TribunalCase.create }
+      let!(:existing_case) { TribunalCase.create(navigation_stack: ['/not', '/empty']) }
 
       it 'does not create a new case' do
         expect {
@@ -75,6 +75,13 @@ RSpec.shared_examples 'a start point step controller' do |form_class, decision_t
       it 'does not change the case ID in the session' do
         get :edit, session: { tribunal_case_id: existing_case.id }
         expect(session[:tribunal_case_id]).to eq(existing_case.id)
+      end
+
+      it 'clears the navigation stack in the session' do
+        get :edit, session: { tribunal_case_id: existing_case.id }
+        existing_case.reload
+
+        expect(existing_case.navigation_stack).to eq([controller.request.fullpath])
       end
     end
   end


### PR DESCRIPTION
Instead of the current complex "back" button logic, where we need to
figure out for each step what the previous step would be given the state
of the `TribunalCase`, add a navigation stack that keeps track of the
path the user took through the steps to arrive at the current step.

This does not yet include the removal of the old logic (will be done
separately to get this change in ASAP).