### PR TITLE
Change the order of the case_type and challenged_decision steps.

### DIFF
--- a/app/controllers/steps/appeal/case_type_controller.rb
+++ b/app/controllers/steps/appeal/case_type_controller.rb
@@ -1,5 +1,5 @@
 module Steps::Appeal
-  class CaseTypeController < Steps::AppealStepController
+  class CaseTypeController < Steps::AppealFirstStepController
     def edit
       super
       @form_object = CaseTypeForm.new(
@@ -10,23 +10,6 @@ module Steps::Appeal
 
     def update
       update_and_advance(CaseTypeForm)
-    end
-
-    private
-
-    def current_tribunal_case
-      # This step, and only this step, should create a tribunal case if
-      # there isn't one in the session - because it's the first
-      # TODO: Reconsider where this should go - it's not very intuitive
-      #   to be doing this here.
-      super || initialize_tribunal_case(intent: Intent::TAX_APPEAL)
-    end
-
-    def update_navigation_stack
-      # This is the first step in the appeal flow, so reset the navigation stack
-      # before re-initialising it in StepController#update_navigation_stack
-      current_tribunal_case.navigation_stack = []
-      super
     end
   end
 end

--- a/app/controllers/steps/appeal/case_type_controller.rb
+++ b/app/controllers/steps/appeal/case_type_controller.rb
@@ -11,5 +11,22 @@ module Steps::Appeal
     def update
       update_and_advance(CaseTypeForm)
     end
+
+    private
+
+    def current_tribunal_case
+      # This step, and only this step, should create a tribunal case if
+      # there isn't one in the session - because it's the first
+      # TODO: Reconsider where this should go - it's not very intuitive
+      #   to be doing this here.
+      super || initialize_tribunal_case(intent: Intent::TAX_APPEAL)
+    end
+
+    def update_navigation_stack
+      # This is the first step in the appeal flow, so reset the navigation stack
+      # before re-initialising it in StepController#update_navigation_stack
+      current_tribunal_case.navigation_stack = []
+      super
+    end
   end
 end

--- a/app/controllers/steps/appeal/challenged_decision_controller.rb
+++ b/app/controllers/steps/appeal/challenged_decision_controller.rb
@@ -11,22 +11,5 @@ module Steps::Appeal
     def update
       update_and_advance(ChallengedDecisionForm)
     end
-
-    private
-
-    def current_tribunal_case
-      # This step, and only this step, should create a tribunal case if
-      # there isn't one in the session - because it's the first
-      # TODO: Reconsider where this should go - it's not very intuitive
-      #   to be doing this here.
-      super || initialize_tribunal_case(intent: Intent::TAX_APPEAL)
-    end
-
-    def update_navigation_stack
-      # This is the first step in the appeal flow, so reset the navigation stack
-      # before re-initialising it in StepController#update_navigation_stack
-      current_tribunal_case.navigation_stack = []
-      super
-    end
   end
 end

--- a/app/controllers/steps/appeal_first_step_controller.rb
+++ b/app/controllers/steps/appeal_first_step_controller.rb
@@ -1,0 +1,16 @@
+class Steps::AppealFirstStepController < Steps::AppealStepController
+  private
+
+  def current_tribunal_case
+    # Only the step inheriting from this controller should create a tribunal case
+    # if there isn't one in the session - because it's the first
+    super || initialize_tribunal_case(intent: Intent::TAX_APPEAL)
+  end
+
+  def update_navigation_stack
+    # The step inheriting from this controller will reset the navigation stack
+    # before re-initialising it in StepController#update_navigation_stack
+    current_tribunal_case.navigation_stack = []
+    super
+  end
+end

--- a/app/forms/steps/appeal/case_type_form.rb
+++ b/app/forms/steps/appeal/case_type_form.rb
@@ -40,6 +40,7 @@ module Steps::Appeal
       tribunal_case.update(
         case_type: case_type_value,
         # The following are dependent attributes that need to be reset
+        challenged_decision: nil,
         dispute_type: nil,
         penalty_level: nil,
         penalty_amount: nil,

--- a/app/forms/steps/appeal/case_type_show_more_form.rb
+++ b/app/forms/steps/appeal/case_type_show_more_form.rb
@@ -34,6 +34,7 @@ module Steps::Appeal
         case_type: case_type_value,
         case_type_other_value: case_type_other_value,
         # The following are dependent attributes that need to be reset
+        challenged_decision: nil,
         dispute_type: nil,
         penalty_level: nil,
         penalty_amount: nil,

--- a/app/forms/steps/appeal/challenged_decision_form.rb
+++ b/app/forms/steps/appeal/challenged_decision_form.rb
@@ -25,8 +25,6 @@ module Steps::Appeal
       tribunal_case.update(
         challenged_decision: challenged_decision_value,
         # The following are dependent attributes that need to be reset
-        case_type: nil,
-        case_type_other_value: nil,
         dispute_type: nil,
         penalty_level: nil,
         penalty_amount: nil,

--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -20,16 +20,16 @@ class AppealDecisionTree < DecisionTree
 
   private
 
-  def tribunal_case_is_unchallenged_indirect_tax
+  def tribunal_case_is_unchallenged_indirect_tax?
     !tribunal_case.case_type.direct_tax? &&
       tribunal_case.challenged_decision == ChallengedDecision::NO
   end
 
-  def tribunal_case_is_challenged
+  def tribunal_case_is_challenged?
     tribunal_case.challenged_decision == ChallengedDecision::YES
   end
 
-  def tribunal_case_has_penalties_but_not_disputes
+  def tribunal_case_has_penalties_but_not_disputes?
     tribunal_case.case_type.ask_penalty? && !tribunal_case.case_type.ask_dispute_type?
   end
 
@@ -40,7 +40,7 @@ class AppealDecisionTree < DecisionTree
       edit(:challenged_decision)
     elsif tribunal_case.case_type.ask_dispute_type?
       edit(:dispute_type)
-    elsif tribunal_case_has_penalties_but_not_disputes
+    elsif tribunal_case_has_penalties_but_not_disputes?
       edit(:penalty_amount)
     else
       edit('/steps/lateness/in_time')
@@ -48,9 +48,9 @@ class AppealDecisionTree < DecisionTree
   end
 
   def after_challenged_decision_step
-    if tribunal_case_is_challenged
+    if tribunal_case_is_challenged?
       edit(:challenged_decision_status)
-    elsif tribunal_case_is_unchallenged_indirect_tax
+    elsif tribunal_case_is_unchallenged_indirect_tax?
       edit(:dispute_type)
     else
       show(:must_challenge_hmrc)

--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -3,16 +3,16 @@ class AppealDecisionTree < DecisionTree
     return next_step if next_step
 
     case step_name.to_sym
-    when :challenged_decision
-      edit(:case_type)
     when :case_type, :case_type_show_more
       after_case_type_step
+    when :challenged_decision
+      after_challenged_decision_step
+    when :challenged_decision_status
+      after_challenged_decision_status_step
     when :dispute_type
       after_dispute_type_step
     when :penalty_amount, :penalty_and_tax_amounts, :tax_amount
       hardship_or_lateness_step
-    when :challenged_decision_status
-      edit(:dispute_type)
     else
       raise "Invalid step '#{step_params}'"
     end
@@ -20,32 +20,46 @@ class AppealDecisionTree < DecisionTree
 
   private
 
-  def tribunal_case_is_unchallenged_direct_tax
-    tribunal_case.case_type.direct_tax? &&
+  def tribunal_case_is_unchallenged_indirect_tax
+    !tribunal_case.case_type.direct_tax? &&
       tribunal_case.challenged_decision == ChallengedDecision::NO
   end
 
-  def tribunal_case_is_challenged_indirect_tax
-    !tribunal_case.case_type.direct_tax? &&
-      tribunal_case.challenged_decision == ChallengedDecision::YES
+  def tribunal_case_is_challenged
+    tribunal_case.challenged_decision == ChallengedDecision::YES
+  end
+
+  def tribunal_case_has_penalties_but_not_disputes
+    tribunal_case.case_type.ask_penalty? && !tribunal_case.case_type.ask_dispute_type?
   end
 
   def after_case_type_step
     if answer == Steps::Appeal::CaseTypeForm::SHOW_MORE
       edit(:case_type_show_more)
-    elsif tribunal_case_is_unchallenged_direct_tax
-      show(:must_challenge_hmrc)
-    elsif tribunal_case_is_challenged_indirect_tax
-      edit(:challenged_decision_status)
+    elsif tribunal_case.case_type.ask_challenged?
+      edit(:challenged_decision)
     elsif tribunal_case.case_type.ask_dispute_type?
       edit(:dispute_type)
-    elsif tribunal_case.case_type.ask_penalty?
+    elsif tribunal_case_has_penalties_but_not_disputes
       edit(:penalty_amount)
-    elsif tribunal_case.case_type.ask_hardship?
-      edit('/steps/hardship/disputed_tax_paid')
     else
       edit('/steps/lateness/in_time')
     end
+  end
+
+  def after_challenged_decision_step
+    if tribunal_case_is_challenged
+      edit(:challenged_decision_status)
+    elsif tribunal_case_is_unchallenged_indirect_tax
+      edit(:dispute_type)
+    else
+      show(:must_challenge_hmrc)
+    end
+  end
+
+  def after_challenged_decision_status_step
+    # TODO: introduce changes to the challenged status here
+    edit(:dispute_type)
   end
 
   def after_dispute_type_step

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -1,9 +1,10 @@
 class CaseType < ValueObject
-  attr_reader :direct_tax, :ask_dispute_type, :ask_penalty, :ask_hardship, :appeal_or_application
+  attr_reader :direct_tax, :ask_dispute_type, :ask_penalty, :ask_hardship, :ask_challenged, :appeal_or_application
   alias_method :direct_tax?, :direct_tax
   alias_method :ask_dispute_type?, :ask_dispute_type
   alias_method :ask_penalty?, :ask_penalty
   alias_method :ask_hardship?, :ask_hardship
+  alias_method :ask_challenged?, :ask_challenged
 
   def self.find_constant(raw_value)
     const_get(raw_value.upcase)
@@ -14,19 +15,21 @@ class CaseType < ValueObject
     @ask_dispute_type      = params.fetch(:ask_dispute_type, false)
     @ask_penalty           = params.fetch(:ask_penalty, false)
     @ask_hardship          = params.fetch(:ask_hardship, false)
+    @ask_challenged        = params.fetch(:ask_challenged, false)
     @appeal_or_application = params.fetch(:appeal_or_application, :appeal)
 
     super(raw_value)
   end
 
   def self.direct_tax_properties
-    { direct_tax: true, ask_dispute_type: true, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal }
+    { direct_tax: true, ask_dispute_type: true, ask_penalty: true, ask_hardship: false, ask_challenged: true, appeal_or_application: :appeal }
   end
 
   def self.indirect_tax_properties
-    { direct_tax: false, ask_dispute_type: true, ask_penalty: true, ask_hardship: true, appeal_or_application: :appeal }
+    { direct_tax: false, ask_dispute_type: true, ask_penalty: true, ask_hardship: true, ask_challenged: true, appeal_or_application: :appeal }
   end
 
+  # TODO: we need to do an audit of the following case types to make sure they follow the correct path in the decision tree
   VALUES = [
     APN_PENALTY                  = new(:apn_penalty,                  direct_tax: false, ask_dispute_type: false, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
     AGGREGATES_LEVY              = new(:aggregates_levy,              indirect_tax_properties),
@@ -58,13 +61,13 @@ class CaseType < ValueObject
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),
     REMOTE_GAMING_DUTY           = new(:remote_gaming_duty,           indirect_tax_properties),
     REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :application),
-    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :application),
+    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, ask_challenged: true, appeal_or_application: :application),
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),
     TOBACCO_PRODUCTS_DUTY        = new(:tobacco_products_duty,        indirect_tax_properties),
     VAT                          = new(:vat,                          indirect_tax_properties),
-    OTHER                        = new(:other,                        direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true, appeal_or_application: :appeal)
+    OTHER                        = new(:other,                        direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true, ask_challenged: false, appeal_or_application: :appeal)
   ].freeze
 
   def self.values

--- a/app/views/steps/appeal/start/show.html.erb
+++ b/app/views/steps/appeal/start/show.html.erb
@@ -29,7 +29,7 @@
       %>
 
     <p>
-    <%= link_to t('.continue'), edit_steps_appeal_challenged_decision_path, class: 'button button-start', role: 'button' %>
+    <%= link_to t('.continue'), edit_steps_appeal_case_type_path, class: 'button button-start', role: 'button' %>
     </p>
   </div>
 </div>

--- a/spec/controllers/steps/appeal/case_type_controller_spec.rb
+++ b/spec/controllers/steps/appeal/case_type_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Appeal::CaseTypeController, type: :controller do
-  it_behaves_like 'an intermediate step controller', Steps::Appeal::CaseTypeForm, AppealDecisionTree
+  it_behaves_like 'a start point step controller', Steps::Appeal::CaseTypeForm, AppealDecisionTree
 end

--- a/spec/controllers/steps/appeal/challenged_decision_controller_spec.rb
+++ b/spec/controllers/steps/appeal/challenged_decision_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Appeal::ChallengedDecisionController, type: :controller do
-  it_behaves_like 'a start point step controller', Steps::Appeal::ChallengedDecisionForm, AppealDecisionTree
+  it_behaves_like 'an intermediate step controller', Steps::Appeal::ChallengedDecisionForm, AppealDecisionTree
 end

--- a/spec/forms/steps/appeal/case_type_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_form_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Steps::Appeal::CaseTypeForm do
         allow(CaseType).to receive(:find_constant).with('income_tax').and_return(case_type_object)
         expect(tribunal_case).to receive(:update).with(
           case_type: case_type_object,
+          challenged_decision: nil,
           dispute_type: nil,
           penalty_level: nil,
           penalty_amount: nil,

--- a/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
           expect(tribunal_case).to receive(:update).with(
               case_type: case_type_object,
               case_type_other_value: nil,
+              challenged_decision: nil,
               dispute_type: nil,
               penalty_level: nil,
               penalty_amount: nil,
@@ -119,6 +120,7 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
             expect(tribunal_case).to receive(:update).with(
                 case_type: case_type_object,
                 case_type_other_value: 'my tax issue',
+                challenged_decision: nil,
                 dispute_type: nil,
                 penalty_level: nil,
                 penalty_amount: nil,

--- a/spec/forms/steps/appeal/challenged_decision_form_spec.rb
+++ b/spec/forms/steps/appeal/challenged_decision_form_spec.rb
@@ -50,8 +50,6 @@ RSpec.describe Steps::Appeal::ChallengedDecisionForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           challenged_decision: ChallengedDecision::NO,
-          case_type: nil,
-          case_type_other_value: nil,
           dispute_type: nil,
           penalty_level: nil,
           penalty_amount: nil,

--- a/spec/services/appeal_decision_tree/case_type_step_spec.rb
+++ b/spec/services/appeal_decision_tree/case_type_step_spec.rb
@@ -1,68 +1,43 @@
 require 'spec_helper'
 
 RSpec.describe AppealDecisionTree, '#destination' do
-  let(:tribunal_case) { double('TribunalCase') }
-  let(:step_params)   { double('Step') }
+  let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type) }
   let(:next_step)     { nil }
+  let(:case_type)     { nil }
+
   subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
-  context 'when the step is `case_type`' do
-    let(:step_params)         { { case_type: 'anything' } }
-    let(:tribunal_case)       { instance_double(TribunalCase, case_type: case_type, challenged_decision: challenged_decision) }
-    let(:challenged_decision) { nil }
+  context 'for a `show more` option' do
+    let(:step_params) { {case_type: '_show_more'} }
+    it { is_expected.to have_destination(:case_type_show_more, :edit) }
+  end
 
-    context 'and the case type is a challenged indirect tax' do
-      let(:case_type) { CaseType.new(:dummy, direct_tax: false) }
-      let(:challenged_decision) { ChallengedDecision::YES }
+  context 'for a case asking asking `challenged question`' do
+    let(:step_params) { {case_type: 'anything'} }
+    let(:case_type)   { CaseType.new(:dummy, ask_challenged: true) }
 
-      it { is_expected.to have_destination(:challenged_decision_status, :edit) }
-    end
+    it { is_expected.to have_destination(:challenged_decision, :edit) }
+  end
 
-    context 'and the case type is a direct tax' do
-      let(:case_type) { CaseType.new(:dummy, direct_tax: true, ask_dispute_type: true) }
+  context 'for a case not asking `challenged question`' do
+    let(:step_params) { {case_type: 'anything'} }
 
-      context 'and the case has been challenged' do
-        let(:challenged_decision) { ChallengedDecision::YES }
-
-        it { is_expected.to have_destination(:dispute_type, :edit) }
-      end
-
-      context 'and the case has not been challenged' do
-        let(:challenged_decision) { ChallengedDecision::NO }
-
-        it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
-      end
-    end
-
-    context 'and the case type is one that should ask dispute type' do
-      let(:case_type) { CaseType.new(:dummy, ask_dispute_type: true) }
+    context 'when the case type is one that should ask dispute type' do
+      let(:case_type) { CaseType.new(:dummy, ask_challenged: false, ask_dispute_type: true) }
 
       it { is_expected.to have_destination(:dispute_type, :edit) }
     end
 
-    context 'and the case type is one that should only ask penalty' do
-      let(:case_type) { CaseType.new(:dummy, ask_dispute_type: false, ask_penalty: true) }
+    context 'when the case type is one that should only ask penalty' do
+      let(:case_type) { CaseType.new(:dummy, ask_challenged: false, ask_dispute_type: false, ask_penalty: true) }
 
       it { is_expected.to have_destination(:penalty_amount, :edit) }
     end
 
-    context 'and the case type is one that should only ask hardship' do
-      let(:case_type) { CaseType.new(:dummy, ask_dispute_type: false, ask_penalty: false, ask_hardship: true) }
-
-      it { is_expected.to have_destination('/steps/hardship/disputed_tax_paid', :edit) }
-    end
-
-    context 'and the case type is one that should ask neither dispute type nor penalty' do
-      let(:case_type) { CaseType.new(:dummy, ask_dispute_type: false, ask_penalty: false) }
+    context 'when the case type is OTHER' do
+      let(:case_type) { CaseType::OTHER }
 
       it { is_expected.to have_destination('/steps/lateness/in_time', :edit) }
-    end
-
-    context 'and the answer is show more' do
-      let(:step_params) { { case_type: '_show_more' } }
-      let(:case_type)   { nil }
-
-      it { is_expected.to have_destination(:case_type_show_more, :edit) }
     end
   end
 end

--- a/spec/services/appeal_decision_tree/challenged_decision_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_spec.rb
@@ -1,13 +1,44 @@
 require 'spec_helper'
 
 RSpec.describe AppealDecisionTree, '#destination' do
-  let(:tribunal_case) { double('TribunalCase') }
+  let(:step_params)   { double('Step') }
   let(:next_step)     { nil }
+  let(:step_params)   { {challenged_decision: 'anything'} }
+  let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type, challenged_decision: challenged_decision) }
+
+  let(:challenged_decision) { nil }
+
   subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
-  context 'when the step is `challenged_decision`' do
-    let(:step_params) { { challenged_decision: 'anything' } }
+  context 'for a direct tax' do
+    let(:case_type) { CaseType.new(:dummy, direct_tax: true) }
 
-    it { is_expected.to have_destination(:case_type, :edit) }
+    context 'and the case has not been challenged' do
+      let(:challenged_decision) { ChallengedDecision::NO }
+
+      it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
+    end
+
+    context 'and the case has been challenged' do
+      let(:challenged_decision) { ChallengedDecision::YES }
+
+      it { is_expected.to have_destination(:challenged_decision_status, :edit) }
+    end
+  end
+
+  context 'for an indirect tax' do
+    let(:case_type) { CaseType.new(:dummy, direct_tax: false) }
+
+    context 'and the case has not been challenged' do
+      let(:challenged_decision) { ChallengedDecision::NO }
+
+      it { is_expected.to have_destination(:dispute_type, :edit) }
+    end
+
+    context 'and the case has been challenged' do
+      let(:challenged_decision) { ChallengedDecision::YES }
+
+      it { is_expected.to have_destination(:challenged_decision_status, :edit) }
+    end
   end
 end


### PR DESCRIPTION
Also, to be able to mimic the new decision tree more easily, a new `ask_challenged` attr
has been added to the CaseType value objects so we can trigger the challenged step for the
case types that need it.

We need to audit all the case types to make sure all the possible combinations are covered
and matches the decision tree. Also the `challenged_status` step need to change as right now
is pretty much a placeholder. This will be made as separate PRs.