### PR TITLE
Ask for a free-text `dispute type` when user selectes `other`.

### DIFF
--- a/app/controllers/steps/appeal/dispute_type_controller.rb
+++ b/app/controllers/steps/appeal/dispute_type_controller.rb
@@ -4,7 +4,8 @@ module Steps::Appeal
       super
       @form_object = DisputeTypeForm.new(
         tribunal_case: current_tribunal_case,
-        dispute_type: current_tribunal_case.dispute_type
+        dispute_type: current_tribunal_case.dispute_type,
+        dispute_type_other_value: current_tribunal_case.dispute_type_other_value
       )
     end
 

--- a/app/forms/steps/appeal/case_type_form.rb
+++ b/app/forms/steps/appeal/case_type_form.rb
@@ -40,8 +40,10 @@ module Steps::Appeal
       tribunal_case.update(
         case_type: case_type_value,
         # The following are dependent attributes that need to be reset
+        case_type_other_value: nil,
         challenged_decision: nil,
         dispute_type: nil,
+        dispute_type_other_value: nil,
         penalty_level: nil,
         penalty_amount: nil,
         tax_amount: nil

--- a/app/forms/steps/appeal/case_type_show_more_form.rb
+++ b/app/forms/steps/appeal/case_type_show_more_form.rb
@@ -36,6 +36,7 @@ module Steps::Appeal
         # The following are dependent attributes that need to be reset
         challenged_decision: nil,
         dispute_type: nil,
+        dispute_type_other_value: nil,
         penalty_level: nil,
         penalty_amount: nil,
         tax_amount: nil

--- a/app/forms/steps/appeal/challenged_decision_form.rb
+++ b/app/forms/steps/appeal/challenged_decision_form.rb
@@ -26,6 +26,7 @@ module Steps::Appeal
         challenged_decision: challenged_decision_value,
         # The following are dependent attributes that need to be reset
         dispute_type: nil,
+        dispute_type_other_value: nil,
         penalty_level: nil,
         penalty_amount: nil,
         tax_amount: nil

--- a/app/forms/steps/appeal/dispute_type_form.rb
+++ b/app/forms/steps/appeal/dispute_type_form.rb
@@ -1,15 +1,18 @@
 module Steps::Appeal
   class DisputeTypeForm < BaseForm
     attribute :dispute_type, String
+    attribute :dispute_type_other_value, String
 
     validates_inclusion_of :dispute_type, in: proc { |record| record.choices }
+    validates_presence_of  :dispute_type_other_value, if: :other_dispute_type?
 
     def choices
       case tribunal_case&.case_type
       when CaseType::INFORMATION_NOTICE
         [
           DisputeType::PENALTY,
-          DisputeType::INFORMATION_NOTICE
+          DisputeType::INFORMATION_NOTICE,
+          DisputeType::OTHER
         ]
       when CaseType::INCOME_TAX
         [
@@ -37,8 +40,13 @@ module Steps::Appeal
       DisputeType.new(dispute_type)
     end
 
+    def other_dispute_type?
+      dispute_type == DisputeType::OTHER.to_s
+    end
+
     def changed?
-      tribunal_case.dispute_type != dispute_type_value
+      tribunal_case.dispute_type != dispute_type_value ||
+        tribunal_case.dispute_type_other_value != dispute_type_other_value
     end
 
     def persist!
@@ -47,6 +55,7 @@ module Steps::Appeal
 
       tribunal_case.update(
         dispute_type: dispute_type_value,
+        dispute_type_other_value: dispute_type_other_value,
         # The following are dependent attributes that need to be reset
         penalty_level: nil,
         penalty_amount: nil,

--- a/app/presenters/appeal_type_answers_presenter.rb
+++ b/app/presenters/appeal_type_answers_presenter.rb
@@ -47,9 +47,19 @@ class AppealTypeAnswersPresenter < BaseAnswersPresenter
   end
 
   def dispute_type_question
+    return dispute_type_other_value_question if tribunal_case.dispute_type == DisputeType::OTHER
+
     row(
       tribunal_case.dispute_type,
       as: :dispute_type
+    )
+  end
+
+  def dispute_type_other_value_question
+    row(
+      tribunal_case.dispute_type_other_value,
+      as: :dispute_type,
+      i18n_value: false
     )
   end
 

--- a/app/views/steps/appeal/dispute_type/edit.html.erb
+++ b/app/views/steps/appeal/dispute_type/edit.html.erb
@@ -9,7 +9,22 @@
     <%= step_form @form_object do |f| %>
       <%= f.radio_button_fieldset :dispute_type,
         choices: @form_object.choices %>
+
+      <div class="panel toggleable" id="dispute_type_other_value" aria-hidden="true">
+        <%= f.text_field :dispute_type_other_value, class: 'form-control' %>
+      </div>
+
       <%= f.submit class: 'button' %>
+    <% end %>
+
+    <%= javascript_tag do %>
+      //
+      // This is a hack because we want just the last of the radio buttons to show a text field,
+      // and that is not possible to do with the current gov.uk elements form builder version.
+      //
+      moj.Modules.customRadioToggles.config.$targetElement = $('#dispute_type_other_value');
+      moj.Modules.customRadioToggles.config.$showElements  = $('form input:radio:last');
+      moj.Modules.customRadioToggles.config.$hideElements  = $('form input:radio:not(:last)');
     <% end %>
   </div>
 </div>

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -98,6 +98,8 @@ en:
           attributes:
             dispute_type:
               inclusion: Select what your dispute is about
+            dispute_type_other_value:
+              blank: Enter the dispute
         steps/appeal/penalty_amount_form:
           attributes:
             penalty_level:
@@ -165,6 +167,7 @@ en:
           tobacco_products_duty_html: <strong>Tobacco Products Duty</strong>
           other_html: <strong>None of the above</strong>
       steps_appeal_dispute_type_form:
+        dispute_type_other_value: What is your dispute about?
         dispute_type:
           penalty_html: <strong>Penalty or surcharge</strong>
           amount_of_tax_owed_by_hmrc_html: <strong>HMRC should repay tax to you</strong>

--- a/db/migrate/20170214171358_add_dispute_type_other_value_to_tribunal_case.rb
+++ b/db/migrate/20170214171358_add_dispute_type_other_value_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddDisputeTypeOtherValueToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :dispute_type_other_value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170213145741) do
+ActiveRecord::Schema.define(version: 20170214171358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20170213145741) do
     t.string   "user_type"
     t.string   "navigation_stack",                                default: [],                                       array: true
     t.string   "representative_is_legal_professional"
+    t.string   "dispute_type_other_value"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/forms/steps/appeal/case_type_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_form_spec.rb
@@ -67,8 +67,10 @@ RSpec.describe Steps::Appeal::CaseTypeForm do
         allow(CaseType).to receive(:find_constant).with('income_tax').and_return(case_type_object)
         expect(tribunal_case).to receive(:update).with(
           case_type: case_type_object,
+          case_type_other_value: nil,
           challenged_decision: nil,
           dispute_type: nil,
+          dispute_type_other_value: nil,
           penalty_level: nil,
           penalty_amount: nil,
           tax_amount: nil

--- a/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
               case_type_other_value: nil,
               challenged_decision: nil,
               dispute_type: nil,
+              dispute_type_other_value: nil,
               penalty_level: nil,
               penalty_amount: nil,
               tax_amount: nil
@@ -122,6 +123,7 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
                 case_type_other_value: 'my tax issue',
                 challenged_decision: nil,
                 dispute_type: nil,
+                dispute_type_other_value: nil,
                 penalty_level: nil,
                 penalty_amount: nil,
                 tax_amount: nil

--- a/spec/forms/steps/appeal/challenged_decision_form_spec.rb
+++ b/spec/forms/steps/appeal/challenged_decision_form_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Steps::Appeal::ChallengedDecisionForm do
         expect(tribunal_case).to receive(:update).with(
           challenged_decision: ChallengedDecision::NO,
           dispute_type: nil,
+          dispute_type_other_value: nil,
           penalty_level: nil,
           penalty_amount: nil,
           tax_amount: nil

--- a/spec/presenters/appeal_type_answers_presenter_spec.rb
+++ b/spec/presenters/appeal_type_answers_presenter_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AppealTypeAnswersPresenter do
       case_type: case_type,
       case_type_other_value: case_type_other_value,
       dispute_type: dispute_type,
+      dispute_type_other_value: dispute_type_other_value,
       penalty_level: penalty_level,
       penalty_amount: penalty_amount,
       tax_amount: tax_amount,
@@ -27,6 +28,7 @@ RSpec.describe AppealTypeAnswersPresenter do
   let(:case_type)                  { nil }
   let(:case_type_other_value)      { nil }
   let(:dispute_type)               { nil }
+  let(:dispute_type_other_value)   { nil }
   let(:penalty_level)              { nil }
   let(:penalty_amount)             { nil }
   let(:tax_amount)                 { nil }
@@ -141,6 +143,7 @@ RSpec.describe AppealTypeAnswersPresenter do
 
   describe '`dispute_type` question' do
     let(:row) { subject.dispute_type_question }
+    let(:case_type) { 'income_tax' }
 
     context 'when `dispute_type` is nil' do
       let(:dispute_type) { nil }
@@ -150,9 +153,8 @@ RSpec.describe AppealTypeAnswersPresenter do
       end
     end
 
-    context 'when `case_type` is income_tax' do
+    context 'for a specific dispute type' do
       let(:dispute_type) { 'foo' }
-      let(:case_type) { 'income_tax' }
 
       it 'has the correct attributes' do
         expect(row.question).to    eq('.questions.dispute_type')
@@ -161,13 +163,13 @@ RSpec.describe AppealTypeAnswersPresenter do
       end
     end
 
-    context 'when `case_type` is vat' do
-      let(:dispute_type) { 'foo' }
-      let(:case_type)  { 'vat' }
+    context 'for `other` dispute type' do
+      let(:dispute_type) { DisputeType::OTHER }
+      let(:dispute_type_other_value) { 'my dispute' }
 
       it 'has the correct attributes' do
         expect(row.question).to    eq('.questions.dispute_type')
-        expect(row.answer).to      eq('.answers.dispute_type.foo')
+        expect(row.answer).to      eq('my dispute')
         expect(row.change_path).to be_nil
       end
     end


### PR DESCRIPTION
This will mimic the same behaviour already introduced in the `case type` step,
where the user can select an `other` option that will expand a free-text input field.

Views, presenters and form objects updated accordingly.