### PR TITLE
Add back links to kickout pages.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,12 @@ module ApplicationHelper
     }
   end
 
+  # Renders a back link without the progress information, as kickout pages are not
+  # really question pages, but the end of a journey
+  def kickout_step_header
+    step_header(nil, nil)
+  end
+
   def translate_for_user_type(key, params={})
     suffix = '_html' if key.end_with?('_html')
     translate_with_appeal_or_application("#{key}.as_#{current_tribunal_case.user_type}#{suffix}", params)

--- a/app/views/application/_step_header.html.erb
+++ b/app/views/application/_step_header.html.erb
@@ -1,4 +1,4 @@
 <p class="step-info">
   <%= link_to t('generic.back_link'), path, class: 'link-back' %>
-  <%= t("steps.#{task}.step_header", step: step_number) %>
+  <%= t("steps.#{task}.step_header", step: step_number) if task %>
 </p>

--- a/app/views/steps/appeal/must_challenge_hmrc/show.html.erb
+++ b/app/views/steps/appeal/must_challenge_hmrc/show.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= kickout_step_header %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
     <p class="lede">
       <%=t '.lead_text' %>

--- a/app/views/steps/appeal/must_wait_for_challenge_decision/show.html.erb
+++ b/app/views/steps/appeal/must_wait_for_challenge_decision/show.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= kickout_step_header %>
+
     <h1 class="heading-large"><%=t '.heading' %></h1>
     <p class="lede">
       <%=t '.lead_text' %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#kickout_step_header' do
+    it 'renders the expected content' do
+      expect(helper).to receive(:render).with(partial: 'step_header', locals: {
+        task:        nil,
+        step_number: nil,
+        path:        '/foo/bar'
+      })
+      helper.kickout_step_header
+    end
+  end
+
   describe '#translate_for_user_type' do
     let(:user_type) { UserType.new(:humanoid) }
     let(:tribunal_case) { instance_double(TribunalCase, user_type: user_type) }


### PR DESCRIPTION
I could only find 2 kickout pages so far. We might need some more later on. Unless we also
want to add these back links to the confirmation pages but it doesn't make too much sense to me.

A new helper method introduced for readability, but the only thing it does is call the existing
method `step_header` with nil values. We render the same partial but without the progress copy.

https://www.pivotaltracker.com/story/show/139361459