### PR TITLE
Add before_action validations to controllers not inheriting from StepController

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -1,6 +1,5 @@
 class CasesController < ApplicationController
-  # TODO: to be completed as part of another PR
-  #before_action :check_tribunal_case_presence, :check_tribunal_case_status
+  before_action :check_tribunal_case_presence, :check_tribunal_case_status
 
   def create
     new_case = CaseCreator.new(current_tribunal_case).call

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,5 @@
 class DocumentsController < ApplicationController
-  # TODO: to be completed as part of another PR
-  #before_action :check_tribunal_case_presence, :check_tribunal_case_status
+  before_action :check_tribunal_case_presence, :check_tribunal_case_status
 
   respond_to :html, :json, :js
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,15 @@
 class ErrorsController < ApplicationController
-  def case_not_found; end
-  def case_submitted; end
+  def case_not_found
+    respond_to do |format|
+      format.html
+      format.json { head :not_found }
+    end
+  end
+
+  def case_submitted
+    respond_to do |format|
+      format.html
+      format.json { head :unprocessable_entity }
+    end
+  end
 end

--- a/spec/controllers/appeal_cases_controller_spec.rb
+++ b/spec/controllers/appeal_cases_controller_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe AppealCasesController, type: :controller do
 
-  let(:current_tribunal_case) { instance_double(TribunalCase) }
+  let(:current_tribunal_case) { instance_double(TribunalCase, case_status: nil) }
   let(:case_creator_double) { instance_double(CaseCreator, call: case_creator_result) }
+
+  include_examples 'checks the validity of the current tribunal case on create'
 
   describe 'POST #create' do
     before do

--- a/spec/controllers/closure_cases_controller_spec.rb
+++ b/spec/controllers/closure_cases_controller_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ClosureCasesController, type: :controller do
 
-  let(:current_tribunal_case) { instance_double(TribunalCase) }
+  let(:current_tribunal_case) { instance_double(TribunalCase, case_status: nil) }
   let(:case_creator_double) { instance_double(CaseCreator, call: case_creator_result) }
+
+  include_examples 'checks the validity of the current tribunal case on create'
 
   describe 'POST #create' do
     before do

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -7,7 +7,14 @@ RSpec.describe DocumentsController, type: :controller do
   let(:collection_ref) { '12345' }
   let(:filename) { 'dGVzdCBmaWxlLnR4dA==\n' } # 'test file.txt' - base64 encoded
   let(:another_filename) { 'YW5vdGhlcg==\n' } # 'another' - base64 encoded
-  let(:current_tribunal_case) { instance_double(TribunalCase, grounds_for_appeal_file_name: 'test file.txt', files_collection_ref: collection_ref) }
+  let(:current_tribunal_case) {
+    instance_double(
+      TribunalCase,
+      grounds_for_appeal_file_name: 'test file.txt',
+      files_collection_ref: collection_ref,
+      case_status: nil
+    )
+  }
   let(:file) { fixture_file_upload('files/image.jpg', 'image/jpeg') }
 
   let(:upload_response) { double(code: 200, body: {}, error?: false) }
@@ -17,6 +24,8 @@ RSpec.describe DocumentsController, type: :controller do
     allow(MojFileUploaderApiClient::AddFile).to receive(:new).and_return(double(call: upload_response))
     session[:current_step_path] = 'step/to/redirect'
   end
+
+  include_examples 'checks the validity of the current tribunal case on create'
 
   describe '#create' do
     let(:format) { :html }
@@ -85,6 +94,8 @@ RSpec.describe DocumentsController, type: :controller do
       end
     end
   end
+
+  include_examples 'checks the validity of the current tribunal case on destroy'
 
   describe '#destroy' do
     context 'deleting a different document to the grounds_for_appeal document' do

--- a/spec/support/current_tribunal_case_shared_examples.rb
+++ b/spec/support/current_tribunal_case_shared_examples.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'checks the validity of the current tribunal case' do
+  context 'when there is no case in the session' do
+    let(:current_tribunal_case) { nil }
+
+    it 'redirects to the case not found error page' do
+      expect(response).to redirect_to(case_not_found_errors_path)
+    end
+  end
+
+  context 'when there is an already submitted case in the session' do
+    let(:current_tribunal_case) { instance_double(TribunalCase, case_status: CaseStatus::SUBMITTED) }
+
+    it 'redirects to the case already submitted error page' do
+      expect(response).to redirect_to(case_submitted_errors_path)
+    end
+  end
+end
+
+RSpec.shared_examples 'checks the validity of the current tribunal case on create' do
+  describe 'tribunal case checks on create' do
+    before do
+      allow(subject).to receive(:current_tribunal_case).and_return(current_tribunal_case)
+      post :create
+    end
+
+    include_examples 'checks the validity of the current tribunal case'
+  end
+end
+
+RSpec.shared_examples 'checks the validity of the current tribunal case on destroy' do
+  describe 'tribunal case checks on destroy' do
+    before do
+      allow(subject).to receive(:current_tribunal_case).and_return(current_tribunal_case)
+      delete :destroy, params: {id: 'anything'}
+    end
+
+    include_examples 'checks the validity of the current tribunal case'
+  end
+end


### PR DESCRIPTION
This PR is a follow up to the previous one to add the before_filter validations to some
controllers not covered by the StepController superclass.

Although there is a bit of repetition, this ensures the code is more readable and we know
always which controllers implement which filters. In case we were to have more non-step
controllers in the future, a better solution might be inheritance or a concern, but
currently we only have 2 of these non-step controllers.