### PR TITLE
Handling of unexpected exceptions.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -12,4 +12,11 @@ class ErrorsController < ApplicationController
       format.json { head :unprocessable_entity }
     end
   end
+
+  def unhandled
+    respond_to do |format|
+      format.html
+      format.json { head :internal_server_error }
+    end
+  end
 end

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p class="lede"><%=t '.more_text' %></p>
+
+    <div class="form-group">
+      <%= link_to t('.start_again'), root_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -7,3 +7,8 @@ en:
     case_submitted:
       heading: Case already submitted
       start_again: Start new case
+    unhandled:
+      heading: Sorry, something went wrong
+      start_again: Start again
+      lead_text: "To keep this service secure, any information you've entered hasn't been saved."
+      more_text: "You'll need to start again."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
   resource :errors, only: [] do
     get :case_not_found
     get :case_submitted
+    get :unhandled
   end
 
   root to: 'home#index'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'raven'
+
+RSpec.describe ApplicationController do
+  controller do
+    def case_not_found; raise Errors::CaseNotFound; end
+    def case_submitted; raise Errors::CaseSubmitted; end
+    def another_exception; raise Exception; end
+  end
+
+  context 'Exceptions handling' do
+    before do
+      allow(Rails).to receive(:env).and_return('production'.inquiry)
+    end
+
+    context 'Errors::CaseNotFound' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'case_not_found' => 'anonymous#case_not_found' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :case_not_found
+        expect(response).to redirect_to(case_not_found_errors_path)
+      end
+    end
+
+    context 'Errors::CaseSubmitted' do
+      it 'should not report the exception, and redirect to the error page' do
+        routes.draw { get 'case_submitted' => 'anonymous#case_submitted' }
+
+        expect(Raven).not_to receive(:capture_exception)
+
+        get :case_submitted
+        expect(response).to redirect_to(case_submitted_errors_path)
+      end
+    end
+
+    context 'Other exceptions' do
+      it 'should report the exception, and redirect to the error page' do
+        routes.draw { get 'another_exception' => 'anonymous#another_exception' }
+
+        expect(Raven).to receive(:capture_exception)
+
+        get :another_exception
+        expect(response).to redirect_to(unhandled_errors_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Show the user a nice error page (design/copy TBC) but also report the exception to Sentry.
We are already handling case not found in session/session expired and case already submitted
with a similar approach, but in these scenarios we will not report to Sentry as this is a
recoverable user-error. We can decide otherwise later.