### PR TITLE
Add link to case PDF in the `case submitted` error page.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,6 +7,8 @@ class ErrorsController < ApplicationController
   end
 
   def case_submitted
+    @tribunal_case = current_tribunal_case
+
     respond_to do |format|
       format.html
       format.json { head :unprocessable_entity }

--- a/app/views/errors/case_submitted.html.erb
+++ b/app/views/errors/case_submitted.html.erb
@@ -2,8 +2,17 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t '.heading' %></h1>
 
-    <div class="form-group">
-      <%= link_to t('.start_again'), session_path, method: :delete, class: 'button' %>
-    </div>
+    <h1 class="heading-large">
+      <span class="heading-secondary"><%= t '.case_reference' %></span>
+      <span><%= @tribunal_case.case_reference %></span>
+    </h1>
+
+    <p><%= t '.note_number' %></p>
+
+    <h2 class="heading-medium">
+      <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>
+    </h2>
+
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('.start_again')} %>
   </div>
 </div>

--- a/app/views/steps/closure/confirmation/show.html.erb
+++ b/app/views/steps/closure/confirmation/show.html.erb
@@ -16,6 +16,6 @@
 
 <%= t '.what_happens_next_html' %>
 
-<%= render partial: 'steps/shared/finish_button' %>
+<%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
 
 <%= render partial: 'steps/shared/survey' %>

--- a/app/views/steps/details/confirmation/show.html.erb
+++ b/app/views/steps/details/confirmation/show.html.erb
@@ -16,6 +16,6 @@
 
 <%= t '.what_happens_next_html' %>
 
-<%= render partial: 'steps/shared/finish_button' %>
+<%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
 
 <%= render partial: 'steps/shared/survey' %>

--- a/app/views/steps/shared/_finish_button.html.erb
+++ b/app/views/steps/shared/_finish_button.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= link_to t('shared.finish'), session_path, method: :delete, class: 'button' %>
+  <%= link_to name, session_path, method: :delete, class: 'button' %>
 </div>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -5,8 +5,11 @@ en:
       heading: No tribunal case in session
       start_again: Start again
     case_submitted:
-      heading: Case already submitted
-      start_again: Start new case
+      heading: Case already submitted - COPY NEEDED
+      start_again: Start again
+      case_reference: "Your case reference number is:"
+      note_number: Please make a note of this number in case you need to contact us.
+      save_or_print_pdf: Save or print your case details
     unhandled:
       heading: Sorry, something went wrong
       start_again: Start again


### PR DESCRIPTION
If the user mistakenly goes back without writing down/printing the case PDF, and
tries to resubmit the case, an error page will tell them the case was already submitted
and will give them the link to download/print the PDF.