### PR TITLE
Redirect to survey after user cliking 'Finish' button.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -63,7 +63,7 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
-    redirect_to appeal_path
+    redirect_to params[:survey] ? Rails.configuration.survey_link : root_path
   end
 
   private

--- a/app/views/steps/closure/confirmation/show.html.erb
+++ b/app/views/steps/closure/confirmation/show.html.erb
@@ -17,5 +17,3 @@
 <%= t '.what_happens_next_html' %>
 
 <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
-
-<%= render partial: 'steps/shared/survey' %>

--- a/app/views/steps/details/confirmation/show.html.erb
+++ b/app/views/steps/details/confirmation/show.html.erb
@@ -17,5 +17,3 @@
 <%= t '.what_happens_next_html' %>
 
 <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
-
-<%= render partial: 'steps/shared/survey' %>

--- a/app/views/steps/shared/_finish_button.html.erb
+++ b/app/views/steps/shared/_finish_button.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= link_to name, session_path, method: :delete, class: 'button' %>
+  <%= link_to name, session_path(survey: true), method: :delete, class: 'button' %>
 </div>

--- a/app/views/steps/shared/_survey.html.erb
+++ b/app/views/steps/shared/_survey.html.erb
@@ -1,8 +1,0 @@
-<!--
-  All public beta or live services must have a feedback page so you can collect comments and measure user satisfaction.
-  The page must be hosted on GOV.UK but if your service is in alpha or private beta, you can create your own feedback page.
-  https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html
--->
-<div class="util_mt-large">
-  <%=t 'shared.survey_link_html' %>
-</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,6 @@ module TaxTribunalsDatacapture
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 
     config.session_expire_after = 30 # minutes
+    config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
   end
 end

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -25,8 +25,6 @@ en:
     service_help:
       need_help: Need help using the online service?
       contact_us: Contact us
-    survey_link_html: |
-      <a href="https://goo.gl/forms/5MeKnK5kGJH99Fsn2">What did you think of this service?</a> (takes 30 seconds)
     finish: Finish
   steps:
     details:

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -7,9 +7,16 @@ RSpec.describe SessionsController, type: :controller do
       expect(session).to be_empty
     end
 
-    it 'redirects to the appeal page' do
+    it 'redirects to the home page' do
       get :destroy
-      expect(subject).to redirect_to(appeal_path)
+      expect(subject).to redirect_to(root_path)
+    end
+
+    context 'when survey param is provided' do
+      it 'redirects to the home page' do
+        get :destroy, params: {survey: true}
+        expect(response.location).to match(/goo\.gl\/forms/)
+      end
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context 'when survey param is provided' do
-      it 'redirects to the home page' do
+      it 'redirects to the survey page' do
         get :destroy, params: {survey: true}
         expect(response.location).to match(/goo\.gl\/forms/)
       end


### PR DESCRIPTION
This will maintain the expiring of the session as before, but redirect to the
survey link instead of the home page (except for developer tools footer).

The link to the survey has been removed from the confirmation pages.