### PR TITLE
Reset the session when visiting the home page.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   def index
+    reset_session
     @link_sections = link_sections
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe HomeController do
   describe '#index' do
+    it 'resets the session' do
+      expect(subject).to receive(:reset_session)
+      get :index
+    end
+
     it 'assigns the expected link sections' do
       get :index
 


### PR DESCRIPTION
This solves the issue where a user, could potentially start an appeal, and half way
through they realize they really wanted a closure, starting the closure flow and leaving
some of the details and steps left overs from the appeal flow.