### PR TITLE
Fix case PDF translation to use correct appeal/application naming.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,9 +31,10 @@ module ApplicationHelper
   end
 
   def translate_with_appeal_or_application(key, params={})
-    appeal_or_application = I18n.translate("generic.appeal_or_application.#{current_tribunal_case.appeal_or_application}")
-    params_with_appeal_or_application = params.merge(appeal_or_application: appeal_or_application)
+    translate(key, params.merge(appeal_or_application_params))
+  end
 
-    translate(key, params_with_appeal_or_application)
+  def appeal_or_application_params
+    {appeal_or_application: I18n.translate("generic.appeal_or_application.#{current_tribunal_case.appeal_or_application}")}
   end
 end

--- a/app/helpers/check_answers_helper.rb
+++ b/app/helpers/check_answers_helper.rb
@@ -18,7 +18,8 @@ module CheckAnswersHelper
   #   en.steps.details.check_answers.show.questions.case_type
   #
   def pdf_t(key, options = {})
-    translate key, options.merge(cascade: {offset: key.count('.') + 1})
+    cascade_params = {cascade: {offset: key.count('.') + 1}}
+    translate(key, options.merge(cascade_params).merge(appeal_or_application_params))
   end
 
 end

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -2,14 +2,18 @@ require 'rails_helper'
 
 RSpec.describe CheckAnswersHelper do
   describe '#pdf_t' do
-    # These are just 2 keys to perform a quick sanity check of the method.
+    # These are just a few keys to perform a quick sanity check of the method.
     # If ever changed or removed, any other keys can be used instead.
     let(:found_key) { '.questions.penalty_level' }
     let(:cascaded_key) { '.questions.lateness_reason' }
+    let(:interpolation_key) { '.questions.case_type' }
 
     before do
       # Without setting this virtual path, we cannot mimic the lazy lookup of the view
       helper.instance_variable_set(:@virtual_path, 'steps.details.check_answers.pdf.show')
+      expect_any_instance_of(ApplicationHelper).to receive(:appeal_or_application_params).and_return(
+        {appeal_or_application: 'headache'}
+      )
     end
 
     it 'returns a found key' do
@@ -20,6 +24,11 @@ RSpec.describe CheckAnswersHelper do
     it 'cascades a not found key' do
       result = helper.pdf_t(cascaded_key)
       expect(result).to eq('Reason for lateness?')
+    end
+
+    it 'interpolates the appeal_or_application params' do
+      result = helper.pdf_t(interpolation_key)
+      expect(result).to eq('What is your headache about?')
     end
   end
 end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe CaseDetailsPdf do
   describe '#generate' do
     before do
       allow(tribunal_case).to receive(:documents).and_return([])
+      allow(controller_ctx).to receive(:current_tribunal_case).and_return(tribunal_case)
     end
 
     context 'for a tax appeal application' do


### PR DESCRIPTION
As we are using a custom `t()` for the PDF (so it has cascading), we forgot to add
the capability to know when to use appeal or application.