### PR TITLE
Ensure we run through the penalty/dispute decisions after challenged.

### DIFF
--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -29,21 +29,13 @@ class AppealDecisionTree < DecisionTree
     tribunal_case.challenged_decision == ChallengedDecision::YES
   end
 
-  def tribunal_case_has_penalties_but_not_disputes?
-    tribunal_case.case_type.ask_penalty? && !tribunal_case.case_type.ask_dispute_type?
-  end
-
   def after_case_type_step
     if answer == Steps::Appeal::CaseTypeForm::SHOW_MORE
       edit(:case_type_show_more)
     elsif tribunal_case.case_type.ask_challenged?
       edit(:challenged_decision)
-    elsif tribunal_case.case_type.ask_dispute_type?
-      edit(:dispute_type)
-    elsif tribunal_case_has_penalties_but_not_disputes?
-      edit(:penalty_amount)
     else
-      edit('/steps/lateness/in_time')
+      dispute_or_penalties_decision
     end
   end
 
@@ -61,7 +53,7 @@ class AppealDecisionTree < DecisionTree
     if tribunal_case.challenged_decision_status.pending?
       show(:must_wait_for_challenge_decision)
     else
-      edit(:dispute_type)
+      dispute_or_penalties_decision
     end
   end
 
@@ -82,6 +74,16 @@ class AppealDecisionTree < DecisionTree
       edit('/steps/hardship/disputed_tax_paid')
     else
       edit('steps/lateness/in_time')
+    end
+  end
+
+  def dispute_or_penalties_decision
+    if tribunal_case.case_type.ask_dispute_type?
+      edit(:dispute_type)
+    elsif tribunal_case.case_type.ask_penalty?
+      edit(:penalty_amount)
+    else
+      edit('/steps/lateness/in_time')
     end
   end
 end

--- a/spec/services/appeal_decision_tree/challenged_decision_status_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_status_spec.rb
@@ -25,19 +25,19 @@ RSpec.describe AppealDecisionTree, '#destination' do
       let(:challenged_decision_status) { ChallengedDecisionStatus::RECEIVED }
 
       context 'for a case with disputes' do
-        let(:case_type) { CaseType::BINGO_DUTY }
+        let(:case_type) { CaseType.new(:anything, ask_dispute_type: true, ask_penalty: false) }
 
         it { is_expected.to have_destination(:dispute_type, :edit) }
       end
 
       context 'for a case with penalties' do
-        let(:case_type) { CaseType::APN_PENALTY }
+        let(:case_type) { CaseType.new(:anything, ask_dispute_type: false, ask_penalty: true) }
 
         it { is_expected.to have_destination(:penalty_amount, :edit) }
       end
 
       context 'for a case that has neither penalties or disputes' do
-        let(:case_type) { CaseType::COUNTER_TERRORISM }
+        let(:case_type) { CaseType.new(:anything, ask_dispute_type: false, ask_penalty: false) }
 
         it { is_expected.to have_destination('/steps/lateness/in_time', :edit) }
       end

--- a/spec/services/appeal_decision_tree/challenged_decision_status_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_status_spec.rb
@@ -3,7 +3,14 @@ require 'spec_helper'
 RSpec.describe AppealDecisionTree, '#destination' do
   let(:next_step)     { nil }
   let(:step_params)   { {challenged_decision_status: 'anything'} }
-  let(:tribunal_case) { instance_double(TribunalCase, challenged_decision_status: challenged_decision_status) }
+  let(:case_type)     { nil }
+  let(:tribunal_case) {
+    instance_double(
+      TribunalCase,
+      challenged_decision_status: challenged_decision_status,
+      case_type: case_type
+    )
+  }
 
   subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
@@ -17,7 +24,23 @@ RSpec.describe AppealDecisionTree, '#destination' do
     context 'and the status is other than `pending`' do
       let(:challenged_decision_status) { ChallengedDecisionStatus::RECEIVED }
 
-      it { is_expected.to have_destination(:dispute_type, :edit) }
+      context 'for a case with disputes' do
+        let(:case_type) { CaseType::BINGO_DUTY }
+
+        it { is_expected.to have_destination(:dispute_type, :edit) }
+      end
+
+      context 'for a case with penalties' do
+        let(:case_type) { CaseType::APN_PENALTY }
+
+        it { is_expected.to have_destination(:penalty_amount, :edit) }
+      end
+
+      context 'for a case that has neither penalties or disputes' do
+        let(:case_type) { CaseType::COUNTER_TERRORISM }
+
+        it { is_expected.to have_destination('/steps/lateness/in_time', :edit) }
+      end
     end
   end
 end


### PR DESCRIPTION
There was a condition where the penalty/dispute decisions would not be validated after a combination of challenged steps.