### PR TITLE
remove unsemantic spacer paragraphs

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,3 +55,26 @@
 .js-hidden {
   display: none !important;
 }
+
+
+// Related items
+// (These styles will be moved to GOV.UK elements, duplicating here for now.)
+.govuk-related-items {
+  margin-top: $gutter * 2;
+  border-top: 10px solid $govuk-blue;
+  padding-top: 5px;
+
+  .heading-medium {
+    margin-top: 0.3em;
+    margin-bottom: 0.5em
+  }
+
+  li {
+    margin-bottom: 10px;
+    list-style-type: none;
+  }
+
+  .related-link-hint {
+    color: $grey-1;
+  }
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
 
-    <p class="lede">&nbsp;</p>
+    <div class="breadcrumbs"></div>
 
     <h1 class="heading-large"><%= t '.heading' %></h1>
 

--- a/app/views/steps/shared/_file_upload_sidebar.html.erb
+++ b/app/views/steps/shared/_file_upload_sidebar.html.erb
@@ -1,6 +1,6 @@
-<p class="lede">&nbsp;</p>
-<p class="lede">&nbsp;</p>
-<h2 class="heading-small"><%= t('shared.service_help.need_help') %></h2>
-<nav role="navigation" class="font-xsmall">
-  <p><a href="#"><%= t('shared.service_help.contact_us') %></a></p>
-</nav>
+<aside class="govuk-related-items">
+  <h2 class="heading-small"><%= t('shared.service_help.need_help') %></h2>
+  <nav role="navigation" class="font-xsmall">
+    <p><a href="#"><%= t('shared.service_help.contact_us') %></a></p>
+  </nav>
+</aside>


### PR DESCRIPTION
`<p>&nbsp;</p>` did the job in the prototype, but it's a bit shonky for the real world. 😄 

(Includes CSS pasted in from the prototype – may or may not be superseded in future if it gets added to a future version of elements.)