### PR TITLE
Ensure we send email to the correct party

### DIFF
--- a/app/forms/steps/details/representative_details_form.rb
+++ b/app/forms/steps/details/representative_details_form.rb
@@ -12,11 +12,7 @@ module Steps::Details
 
     private
 
-    def started_by_representative?
-      raise 'No TribunalCase given' unless tribunal_case
-
-      tribunal_case.started_by_representative?
-    end
+    delegate :started_by_representative?, to: :tribunal_case
 
     def persist!(additional_attributes)
       raise 'No TribunalCase given' unless tribunal_case

--- a/app/forms/steps/details/representative_details_form.rb
+++ b/app/forms/steps/details/representative_details_form.rb
@@ -6,10 +6,17 @@ module Steps::Details
     attribute :representative_contact_phone, String
 
     validates_presence_of :representative_contact_address,
-                          :representative_contact_postcode,
-                          :representative_contact_email
+                          :representative_contact_postcode
+
+    validates_presence_of :representative_contact_email, if: :started_by_representative?
 
     private
+
+    def started_by_representative?
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.started_by_representative?
+    end
 
     def persist!(additional_attributes)
       raise 'No TribunalCase given' unless tribunal_case

--- a/app/forms/steps/details/taxpayer_details_form.rb
+++ b/app/forms/steps/details/taxpayer_details_form.rb
@@ -6,10 +6,17 @@ module Steps::Details
     attribute :taxpayer_contact_phone, String
 
     validates_presence_of :taxpayer_contact_address,
-                          :taxpayer_contact_postcode,
-                          :taxpayer_contact_email
+                          :taxpayer_contact_postcode
 
-    private
+    validates_presence_of :taxpayer_contact_email, if: :started_by_taxpayer?
+
+  private
+
+    def started_by_taxpayer?
+      raise 'No TribunalCase given' unless tribunal_case
+
+      tribunal_case.started_by_taxpayer?
+    end
 
     def persist!(additional_attributes)
       raise 'No TribunalCase given' unless tribunal_case

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -53,4 +53,12 @@ class TribunalCase < ApplicationRecord
 
     case_type.appeal_or_application
   end
+
+  def started_by_taxpayer?
+    user_type.equal?(UserType::TAXPAYER)
+  end
+
+  def started_by_representative?
+    user_type.equal?(UserType::REPRESENTATIVE)
+  end
 end

--- a/spec/forms/steps/details/representative_individual_details_form_spec.rb
+++ b/spec/forms/steps/details/representative_individual_details_form_spec.rb
@@ -19,4 +19,34 @@ RSpec.describe Steps::Details::RepresentativeIndividualDetailsForm do
   describe '#show_registration_number?' do
     specify { expect(subject.show_registration_number?).to eq(false) }
   end
+
+  context 'when the case is started by a representative' do
+    subject { described_class.new(tribunal_case: tribunal_case) }
+
+    describe '#representative_contact_email' do
+      let(:tribunal_case) { instance_double(TribunalCase, started_by_representative?: true) }
+      before do
+        subject.valid?
+      end
+
+      it 'is required' do
+        expect(subject.errors[:representative_contact_email]).not_to be_blank
+      end
+    end
+  end
+
+  context 'when the case is not started by a representative' do
+    subject { described_class.new(tribunal_case: tribunal_case) }
+
+    describe '#representative_contact_email' do
+      let(:tribunal_case) { instance_double(TribunalCase, started_by_representative?: false) }
+      before do
+        subject.valid?
+      end
+
+      it 'is not required' do
+        expect(subject.errors[:representative_contact_email]).to be_blank
+      end
+    end
+  end
 end

--- a/spec/forms/steps/details/taxpayer_individual_details_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_individual_details_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Details::TaxpayerIndividualDetailsForm do
     additional_fields: [
       :taxpayer_individual_first_name,
       :taxpayer_individual_last_name
-    ]
+  ]
 
   describe '#name_fields' do
     specify { expect(subject.name_fields).to eq([:taxpayer_individual_first_name, :taxpayer_individual_last_name]) }
@@ -18,5 +18,35 @@ RSpec.describe Steps::Details::TaxpayerIndividualDetailsForm do
 
   describe '#show_registration_number?' do
     specify { expect(subject.show_registration_number?).to eq(false) }
+  end
+
+  context 'when the case is started by the taxpayer' do
+    subject { described_class.new(tribunal_case: tribunal_case) }
+
+    describe '#taxpayer_contact_email' do
+      let(:tribunal_case) { instance_double(TribunalCase, started_by_taxpayer?: true) }
+      before do
+        subject.valid?
+      end
+
+      it 'is required' do
+        expect(subject.errors[:taxpayer_contact_email]).not_to be_blank
+      end
+    end
+  end
+
+  context 'when the case is not started by the taxpayer' do
+    subject { described_class.new(tribunal_case: tribunal_case) }
+
+    describe '#taxpayer_contact_email' do
+      let(:tribunal_case) { instance_double(TribunalCase, started_by_taxpayer?: false) }
+      before do
+        subject.valid?
+      end
+
+      it 'is not required' do
+        expect(subject.errors[:taxpayer_contact_email]).to be_blank
+      end
+    end
   end
 end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -52,6 +52,28 @@ RSpec.describe TribunalCase, type: :model do
     end
   end
 
+  context 'when the user is the taxpayer' do
+    let(:attributes) { { user_type: UserType::TAXPAYER } }
+    describe '#started_by_taxpayer?' do
+      specify { expect(subject.started_by_taxpayer?).to be(true) }
+    end
+
+    describe '#started_by_representative?' do
+      specify { expect(subject.started_by_representative?).to be(false) }
+    end
+  end
+
+  context 'when the user is a representative' do
+    let(:attributes) { { user_type: UserType::REPRESENTATIVE} }
+    describe '#started_by_taxpayer?' do
+      specify { expect(subject.started_by_taxpayer?).to be(false) }
+    end
+
+    describe '#started_by_representative?' do
+      specify { expect(subject.started_by_representative?).to be(true) }
+    end
+  end
+
   describe '#appeal_or_application' do
     context 'when the intent is CLOSE_ENQUIRY' do
       let(:case_type)  { CaseType.new(:random, appeal_or_application: :whatever) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require_relative '../spec/support/view_spec_helpers'
 
 ActiveRecord::Migration.maintain_test_schema!
 
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/support/contactable_entity_shared_examples.rb
+++ b/spec/support/contactable_entity_shared_examples.rb
@@ -11,6 +11,7 @@ RSpec.shared_examples 'a contactable entity form' do |params|
   ].map(&:to_sym)
 
   optional_fields += [
+    "#{entity_type}_contact_email",
     "#{entity_type}_contact_phone"
   ].map(&:to_sym)
 
@@ -19,7 +20,7 @@ RSpec.shared_examples 'a contactable entity form' do |params|
 
   let(:fields_with_dummy_values) { fields.map {|k| [k, 'dummy_value'] }.to_h }
   let(:arguments) { fields_with_dummy_values.merge({ tribunal_case: tribunal_case }) }
-  let(:tribunal_case) { instance_double(TribunalCase) }
+  let(:tribunal_case) { instance_double(TribunalCase).as_null_object }
 
   subject { described_class.new(arguments) }
 

--- a/spec/support/contactable_entity_shared_examples.rb
+++ b/spec/support/contactable_entity_shared_examples.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples 'a contactable entity form' do |params|
       let(:tribunal_case)  { nil }
 
       it 'raises an error' do
-        expect { subject.save }.to raise_error(RuntimeError)
+        expect { subject.save }.to raise_exception
       end
     end
 


### PR DESCRIPTION
The notification should go to the party that fills out the request;
either the taxpayer or their representative.  These changes make the
contact email associated with `tribunal_case.user_type` mandatory.  In
the current configuration of the app, this *should* be the email
associated with the first set of contact details.

Emails entered subsequently that do not belong to the same
`user_type` (`taxpayer` or `representative`) are not required.