### PR TITLE
Kickout page for users having problems uploading documents.

### DIFF
--- a/app/controllers/steps/details/documents_upload_problems_controller.rb
+++ b/app/controllers/steps/details/documents_upload_problems_controller.rb
@@ -1,0 +1,6 @@
+module Steps::Details
+  class DocumentsUploadProblemsController < Steps::DetailsStepController
+    def show
+    end
+  end
+end

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -24,7 +24,7 @@ class DetailsDecisionTree < DecisionTree
     when :outcome
       edit(:documents_checklist)
     when :documents_checklist
-      show(:check_answers)
+      after_documents_checklist
     when :check_answers
       home_path
     else
@@ -85,6 +85,14 @@ class DetailsDecisionTree < DecisionTree
       edit(:grounds_for_appeal)
     when Intent::CLOSE_ENQUIRY
       edit('/steps/closure/enquiry_details')
+    end
+  end
+
+  def after_documents_checklist
+    if tribunal_case.having_problems_uploading_documents?
+      show(:documents_upload_problems)
+    else
+      show(:check_answers)
     end
   end
 end

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -88,33 +88,35 @@
   </tbody>
 </table>
 
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.grounds_for_appeal' %></td>
-    <td class="content">
-      <%= tribunal_case.documents.grounds_for_appeal_text(default: pdf_t('.answers.no_grounds_for_appeal_text')) %>
-    </td>
-  </tr>
-  </tbody>
-</table>
+<% unless tribunal_case.having_problems_uploading_documents? %>
+  <hr/>
+  <table>
+    <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.grounds_for_appeal' %></td>
+      <td class="content">
+        <%= tribunal_case.documents.grounds_for_appeal_text(default: pdf_t('.answers.no_grounds_for_appeal_text')) %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
 
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
-    <td class="content">
-      <ul class="documents">
-        <% tribunal_case.documents.list.each do |document| %>
-            <li><%= document.title %></li>
-        <% end %>
-      </ul>
-    </td>
-  </tr>
-  </tbody>
-</table>
+  <hr/>
+  <table>
+    <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
+      <td class="content">
+        <ul class="documents">
+          <% tribunal_case.documents.list.each do |document| %>
+              <li><%= document.title %></li>
+          <% end %>
+        </ul>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<% end %>
 
 <div class="newpage"></div>
 

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -88,7 +88,21 @@
   </tbody>
 </table>
 
-<% unless tribunal_case.having_problems_uploading_documents? %>
+<% if tribunal_case.having_problems_uploading_documents? %>
+  <hr/>
+  <table>
+    <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.problems_uploading_documents' %></td>
+    </tr>
+    <tr>
+      <td class="content with-padding">
+        <%= simple_format(tribunal_case.having_problems_uploading_details) %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<% else %>
   <hr/>
   <table>
     <tbody>

--- a/app/views/steps/details/documents_upload_problems/show.html.erb
+++ b/app/views/steps/details/documents_upload_problems/show.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= kickout_step_header %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <h2 class="heading-medium">
+      <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>
+    </h2>
+
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
+  </div>
+</div>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -258,6 +258,11 @@ en:
               If you have any questions, you can contact the tax tribunal on 0300 123 1024 (find out about
               <a href="https://www.gov.uk/call-charges">call charges</a>).
             </p>
+      documents_upload_problems:
+        show:
+          heading: Having problems uploading documents?
+          lead_text: You need to do the following - COPY NEEDED
+          save_or_print_pdf: Save or print your case details
   activemodel:
     errors:
       models:

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -169,6 +169,7 @@ en:
             documents_submitted: Documents submitted
             legal_representative: Legal representative
             desired_outcome: Desired outcome
+            problems_uploading_documents: Problems uploading documents
           answers:
             challenged_decision:
               'yes': 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
       edit_step :grounds_for_appeal
       edit_step :outcome
       edit_step :documents_checklist
+      show_step :documents_upload_problems
       show_step :check_answers
       show_step :confirmation
       edit_step :user_type

--- a/spec/controllers/steps/details/documents_upload_problems_controller_spec.rb
+++ b/spec/controllers/steps/details/documents_upload_problems_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::DocumentsUploadProblemsController, type: :controller do
+  it_behaves_like 'an end point step controller'
+end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe CaseDetailsPdf do
         expect(decorated_tribunal_case).to receive(:appeal_type_answers).at_least(:once).and_call_original
         expect(decorated_tribunal_case).to receive(:appeal_lateness_answers).at_least(:once).and_call_original
         expect(decorated_tribunal_case).to receive(:outcome).at_least(:once).and_call_original
+        expect(decorated_tribunal_case).not_to receive(:having_problems_uploading_details)
 
         expect(subject.generate).to match(/%PDF/)
       end
@@ -68,6 +69,7 @@ RSpec.describe CaseDetailsPdf do
 
         it 'should not show previously uploaded documents' do
           expect(decorated_tribunal_case).not_to receive(:documents)
+          expect(decorated_tribunal_case).to receive(:having_problems_uploading_details)
           expect(subject.generate).to match(/%PDF/)
         end
       end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe CaseDetailsPdf do
 
   let(:intent) { Intent::TAX_APPEAL }
   let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
+  let(:having_problems_uploading_documents) { false }
+
   let(:case_attributes) do
     {
       case_type: CaseType::OTHER,
@@ -23,6 +25,7 @@ RSpec.describe CaseDetailsPdf do
       files_collection_ref: 'd29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
       case_reference: 'TC/2016/12345',
       outcome: 'my desired outcome',
+      having_problems_uploading_documents: having_problems_uploading_documents,
       intent: intent
     }
   end
@@ -58,6 +61,15 @@ RSpec.describe CaseDetailsPdf do
         expect(decorated_tribunal_case).to receive(:outcome).at_least(:once).and_call_original
 
         expect(subject.generate).to match(/%PDF/)
+      end
+
+      context 'when user had problems uploading documents' do
+        let(:having_problems_uploading_documents) { true }
+
+        it 'should not show previously uploaded documents' do
+          expect(decorated_tribunal_case).not_to receive(:documents)
+          expect(subject.generate).to match(/%PDF/)
+        end
       end
     end
 

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -144,7 +144,17 @@ RSpec.describe DetailsDecisionTree do
     context 'when the step is `documents_checklist`' do
       let(:step_params) { { documents_checklist: 'anything'  } }
 
-      it { is_expected.to have_destination(:check_answers, :show) }
+      context 'and user had no problems uploading' do
+        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: false) }
+
+        it { is_expected.to have_destination(:check_answers, :show) }
+      end
+
+      context 'and user had problems uploading' do
+        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: true) }
+
+        it { is_expected.to have_destination(:documents_upload_problems, :show) }
+      end
     end
 
     context 'when the step is `check_answers`' do


### PR DESCRIPTION
This page will allow to download/print the case PDF but will hide previously uploaded
documents, if any. Copy TBC.

When clicking Finish button, the session will be reset and the user will be redirected
to the survey page, as we do with the confirmation page.

This PR is only for the appeal journey. A similar PR will be created for the closure.