### PR TITLE
Kickout page for users having problems uploading documents (closure).

### DIFF
--- a/app/controllers/steps/closure/documents_upload_problems_controller.rb
+++ b/app/controllers/steps/closure/documents_upload_problems_controller.rb
@@ -1,0 +1,6 @@
+module Steps::Closure
+  class DocumentsUploadProblemsController < Steps::ClosureStepController
+    def show
+    end
+  end
+end

--- a/app/controllers/steps/closure/support_documents_controller.rb
+++ b/app/controllers/steps/closure/support_documents_controller.rb
@@ -5,8 +5,8 @@ module Steps::Closure
     def edit
       @form_object = SupportDocumentsForm.new(
         tribunal_case: current_tribunal_case,
-        closure_problems_uploading_documents: current_tribunal_case.closure_problems_uploading_documents,
-        closure_problems_uploading_details: current_tribunal_case.closure_problems_uploading_details
+        having_problems_uploading_documents: current_tribunal_case.having_problems_uploading_documents,
+        having_problems_uploading_details: current_tribunal_case.having_problems_uploading_details
       )
     end
 

--- a/app/forms/steps/closure/support_documents_form.rb
+++ b/app/forms/steps/closure/support_documents_form.rb
@@ -1,10 +1,10 @@
 module Steps::Closure
   class SupportDocumentsForm < BaseForm
-    attribute :closure_problems_uploading_documents, Boolean
-    attribute :closure_problems_uploading_details, String
+    attribute :having_problems_uploading_documents, Boolean
+    attribute :having_problems_uploading_details, String
 
-    validates_length_of :closure_problems_uploading_details, minimum: 2,
-                        if: :closure_problems_uploading_documents
+    validates_length_of :having_problems_uploading_details, minimum: 2,
+                        if: :having_problems_uploading_documents
 
     private
 
@@ -12,8 +12,8 @@ module Steps::Closure
       raise 'No TribunalCase given' unless tribunal_case
 
       tribunal_case.update(
-        closure_problems_uploading_documents: closure_problems_uploading_documents,
-        closure_problems_uploading_details: closure_problems_uploading_details
+        having_problems_uploading_documents: having_problems_uploading_documents,
+        having_problems_uploading_details: having_problems_uploading_details
       )
     end
   end

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -10,11 +10,21 @@ class ClosureDecisionTree < DecisionTree
     when :additional_info
       edit(:support_documents)
     when :support_documents
-      show(:check_answers)
+      after_support_documents
     when :check_answers
       home_path
     else
       raise "Invalid step '#{step_params}'"
+    end
+  end
+
+  private
+
+  def after_support_documents
+    if tribunal_case.having_problems_uploading_documents?
+      show(:documents_upload_problems)
+    else
+      show(:check_answers)
     end
   end
 end

--- a/app/views/steps/closure/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/show.pdf.erb
@@ -74,21 +74,37 @@
   </tbody>
 </table>
 
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
-    <td class="content">
-      <ul class="documents">
-        <% tribunal_case.documents.list.each do |document| %>
-            <li><%= document.title %></li>
-        <% end %>
-      </ul>
-    </td>
-  </tr>
-  </tbody>
-</table>
+<% if tribunal_case.having_problems_uploading_documents? %>
+  <hr/>
+  <table>
+    <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.problems_uploading_documents' %></td>
+    </tr>
+    <tr>
+      <td class="content with-padding">
+        <%= simple_format(tribunal_case.having_problems_uploading_details) %>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<% else %>
+  <hr/>
+  <table>
+    <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
+      <td class="content">
+        <ul class="documents">
+          <% tribunal_case.documents.list.each do |document| %>
+              <li><%= document.title %></li>
+          <% end %>
+        </ul>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+<% end %>
 
 <div class="newpage"></div>
 

--- a/app/views/steps/closure/documents_upload_problems/show.html.erb
+++ b/app/views/steps/closure/documents_upload_problems/show.html.erb
@@ -1,0 +1,15 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= endpoint_step_header %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <h2 class="heading-medium">
+      <%= link_to t('.save_or_print_pdf'), steps_closure_check_answers_path(format: :pdf), target: '_blank' %>
+    </h2>
+
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
+  </div>
+</div>

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -17,14 +17,14 @@
 
     <%= step_form @form_object do |f| %>
       <div class="form-group util_mt-large">
-        <%= f.label :closure_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
-          <%= f.check_box :closure_problems_uploading_documents, 'aria-controls': 'unable_to_upload_panel' %>
+        <%= f.label :having_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
+          <%= f.check_box :having_problems_uploading_documents, 'aria-controls': 'unable_to_upload_panel' %>
           <%= t('shared.file_upload.having_problems') %>
         <% end %>
 
         <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
           <p><%= translate_with_appeal_or_application('shared.file_upload.having_problems_explanation_html') %></p>
-          <%= f.text_area :closure_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
+          <%= f.text_area :having_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
         </div>
       </div>
 

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -64,6 +64,7 @@ en:
             representative_email: "Email:"
             documents_submitted: Documents submitted
             legal_representative: Legal representative
+            problems_uploading_documents: Problems uploading documents
           answers:
             case_type:
               personal_return: Personal return
@@ -97,6 +98,11 @@ en:
               If you have any questions, you can contact the tax tribunal on 0300 123 1024 (find out about
               <a href="https://www.gov.uk/call-charges">call charges</a>).
             </p>
+      documents_upload_problems:
+        show:
+          heading: Having problems uploading documents?
+          lead_text: You need to do the following - COPY NEEDED
+          save_or_print_pdf: Save or print your case details
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend
@@ -122,7 +128,7 @@ en:
       steps_closure_additional_info_form:
         closure_additional_info: Additional information
       steps_closure_support_documents_form:
-        closure_problems_uploading_details: Reasons you can't upload
+        having_problems_uploading_details: Reasons you can't upload
   activemodel:
     errors:
       models:
@@ -134,5 +140,5 @@ en:
               blank: Enter the years under enquiry
         steps/closure/support_documents_form:
           attributes:
-            closure_problems_uploading_details:
+            having_problems_uploading_details:
               too_short: You must give a reason why you can't upload your documents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
       edit_step :enquiry_details
       edit_step :additional_info
       edit_step :support_documents
+      show_step :documents_upload_problems
       show_step :check_answers
       show_step :confirmation
     end

--- a/db/migrate/20170227164610_remove_closure_problems_uploading_from_tribunal_case.rb
+++ b/db/migrate/20170227164610_remove_closure_problems_uploading_from_tribunal_case.rb
@@ -1,0 +1,6 @@
+class RemoveClosureProblemsUploadingFromTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :tribunal_cases, :closure_problems_uploading_documents
+    remove_column :tribunal_cases, :closure_problems_uploading_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170220162444) do
+ActiveRecord::Schema.define(version: 20170227164610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,8 +54,6 @@ ActiveRecord::Schema.define(version: 20170220162444) do
     t.string   "closure_hmrc_officer"
     t.string   "closure_years_under_enquiry"
     t.text     "closure_additional_info"
-    t.boolean  "closure_problems_uploading_documents",            default: false
-    t.text     "closure_problems_uploading_details"
     t.string   "taxpayer_individual_first_name"
     t.string   "taxpayer_individual_last_name"
     t.string   "has_representative"

--- a/spec/controllers/steps/closure/documents_upload_problems_controller_spec.rb
+++ b/spec/controllers/steps/closure/documents_upload_problems_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Closure::DocumentsUploadProblemsController, type: :controller do
+  it_behaves_like 'an end point step controller'
+end

--- a/spec/forms/steps/closure/support_documents_form_spec.rb
+++ b/spec/forms/steps/closure/support_documents_form_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 RSpec.describe Steps::Closure::SupportDocumentsForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
-    closure_problems_uploading_documents: closure_problems_uploading_documents,
-    closure_problems_uploading_details: closure_problems_uploading_details
+    having_problems_uploading_documents: having_problems_uploading_documents,
+    having_problems_uploading_details: having_problems_uploading_details
   } }
 
   let(:tribunal_case) { instance_double(TribunalCase, documents: documents) }
 
-  let(:closure_problems_uploading_documents) { false }
-  let(:closure_problems_uploading_details) { nil }
+  let(:having_problems_uploading_documents) { false }
+  let(:having_problems_uploading_details) { nil }
   let(:documents) { ['test.doc'] }
 
   subject { described_class.new(arguments) }
@@ -32,27 +32,27 @@ RSpec.describe Steps::Closure::SupportDocumentsForm do
       end
     end
 
-    context 'when closure_problems_uploading_documents is selected' do
-      let(:closure_problems_uploading_documents) { true }
+    context 'when having_problems_uploading_documents is selected' do
+      let(:having_problems_uploading_documents) { true }
 
       context 'no explanation provided' do
         it 'has a validation error' do
           expect(subject).to_not be_valid
-          expect(subject.errors[:closure_problems_uploading_details]).to_not be_empty
+          expect(subject.errors[:having_problems_uploading_details]).to_not be_empty
         end
       end
 
       context 'explanation provided is too short' do
-        let(:closure_problems_uploading_details) { 'x' }
+        let(:having_problems_uploading_details) { 'x' }
 
         it 'has a validation error' do
           expect(subject).to_not be_valid
-          expect(subject.errors[:closure_problems_uploading_details]).to_not be_empty
+          expect(subject.errors[:having_problems_uploading_details]).to_not be_empty
         end
       end
 
       context 'explanation provided is long enough' do
-        let(:closure_problems_uploading_details) { 'xx' }
+        let(:having_problems_uploading_details) { 'xx' }
 
         it 'has no validation errors' do
           expect(subject).to be_valid
@@ -63,8 +63,8 @@ RSpec.describe Steps::Closure::SupportDocumentsForm do
     context 'when valid' do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          closure_problems_uploading_documents: closure_problems_uploading_documents,
-          closure_problems_uploading_details: closure_problems_uploading_details
+          having_problems_uploading_documents: having_problems_uploading_documents,
+          having_problems_uploading_details: having_problems_uploading_details
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -86,8 +86,19 @@ RSpec.describe CaseDetailsPdf do
         expect(decorated_tribunal_case).to receive(:representative).at_least(:once).and_call_original
         expect(decorated_tribunal_case).to receive(:documents).at_least(:once).and_call_original
         expect(decorated_tribunal_case).to receive(:enquiry_answers).at_least(:once).and_call_original
+        expect(decorated_tribunal_case).not_to receive(:having_problems_uploading_details)
 
         expect(subject.generate).to match(/%PDF/)
+      end
+
+      context 'when user had problems uploading documents' do
+        let(:having_problems_uploading_documents) { true }
+
+        it 'should not show previously uploaded documents' do
+          expect(decorated_tribunal_case).not_to receive(:documents)
+          expect(decorated_tribunal_case).to receive(:having_problems_uploading_details)
+          expect(subject.generate).to match(/%PDF/)
+        end
       end
     end
 

--- a/spec/services/closure_decision_tree_spec.rb
+++ b/spec/services/closure_decision_tree_spec.rb
@@ -29,7 +29,17 @@ RSpec.describe ClosureDecisionTree do
     context 'when the step is `support_documents`' do
       let(:step_params) { { support_documents: 'anything' } }
 
-      it { is_expected.to have_destination(:check_answers, :show) }
+      context 'and user had no problems uploading' do
+        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: false) }
+
+        it { is_expected.to have_destination(:check_answers, :show) }
+      end
+
+      context 'and user had problems uploading' do
+        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: true) }
+
+        it { is_expected.to have_destination(:documents_upload_problems, :show) }
+      end
     end
 
     context 'when the step is `check_answers`' do


### PR DESCRIPTION
This page will allow to download/print the case PDF but will hide previously uploaded
documents, if any. Copy TBC.

It works in the same way as in the Appeal flow, and some of the code can be seen as
duplication, but IMO trying to avoid this small duplication will result in a more
confusing code.

Also as part of this PR, two DB fields were removed as were redundant.