### PR TITLE
Add document upload for "hardship reason" step

### DIFF
--- a/app/forms/steps/hardship/hardship_reason_form.rb
+++ b/app/forms/steps/hardship/hardship_reason_form.rb
@@ -1,14 +1,54 @@
 module Steps::Hardship
   class HardshipReasonForm < BaseForm
     attribute :hardship_reason, String
+    attribute :hardship_reason_document, DocumentUpload
 
-    validates_length_of :hardship_reason, minimum: 5
+    validates_length_of :hardship_reason, minimum: 5, if: :requires_hardship_reason_text?
+    validates_presence_of :hardship_reason_document, if: :requires_hardship_reason_document?
+    validate :valid_uploaded_file
 
     private
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      tribunal_case.update(hardship_reason: hardship_reason)
+      upload_document_if_present && tribunal_case.update(
+        hardship_reason: hardship_reason,
+        hardship_reason_file_name: file_name
+      )
+    end
+
+    def valid_uploaded_file
+      return true if hardship_reason_document.nil? || hardship_reason_document.valid?
+      retrieve_document_errors
+    end
+
+    def requires_hardship_reason_text?
+      tribunal_case&.hardship_reason_file_name.blank? && hardship_reason_document.blank?
+    end
+
+    def requires_hardship_reason_document?
+      hardship_reason.blank? && requires_hardship_reason_text?
+    end
+
+    def upload_document_if_present
+      return true if hardship_reason_document.nil?
+
+      hardship_reason_document.upload!(document_key: :hardship_reason, collection_ref: tribunal_case.files_collection_ref)
+      retrieve_document_errors
+
+      errors.empty?
+    end
+
+    def retrieve_document_errors
+      hardship_reason_document.errors.each do |error|
+        errors.add(:hardship_reason_document, error)
+      end
+    end
+
+    # If there is a file upload, store the name of the file, otherwise, retrieve any previously
+    # uploaded file name from the tribunal_case object (or none if nil).
+    def file_name
+      hardship_reason_document&.file_name || tribunal_case&.hardship_reason_file_name
     end
   end
 end

--- a/app/views/steps/hardship/hardship_reason/edit.html.erb
+++ b/app/views/steps/hardship/hardship_reason/edit.html.erb
@@ -6,9 +6,16 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.text_area :hardship_reason, size: '60x10', class: 'form-control-3-4' %>
-      <%= f.submit class: 'button' %>
-    <% end %>
+    <div id="gfa_main_container" class="uploaded_doc_<%= uploaded_document?(:hardship_reason) %>">
+      <%= step_form @form_object do |f| %>
+        <%= f.text_area :hardship_reason, size: '60x10', class: 'form-control form-control-3-4 form-control-large' %>
+
+        <%= document_upload_field(f, :hardship_reason, label_text: t('.attach_document_html')) %>
+
+        <%= f.submit class: 'button' %>
+      <% end %>
+
+      <%= display_current_document(:hardship_reason) %>
+    </div>
   </div>
 </div>

--- a/config/locales/hardship.yml
+++ b/config/locales/hardship.yml
@@ -18,6 +18,7 @@ en:
         edit:
           heading: Why will paying the tax under dispute cause financial hardship?
           lead_text: The judge will decide whether your appeal can continue without paying the tax first.
+          attach_document_html: <strong>Attach reasons as a document</strong>
   activemodel:
     errors:
       models:
@@ -33,6 +34,15 @@ en:
           attributes:
             hardship_review_status:
               inclusion: Select the status of your hardship application
+        steps/hardship/hardship_reason_form:
+          attributes:
+            hardship_reason:
+              too_short: You must enter the reasons (at least %{count} characters) or attach a document
+            hardship_reason_document:
+              blank: You must enter the reasons or attach a document
+              file_size: The attached file exceeds the maximum allowed size
+              content_type: The attached file is not a supported type
+              response_error: There was an error uploading the file. Please try again
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend

--- a/db/migrate/20170228104207_add_hardship_upload_fields_to_tribunal_case.rb
+++ b/db/migrate/20170228104207_add_hardship_upload_fields_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddHardshipUploadFieldsToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :hardship_reason_file_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170227164610) do
+ActiveRecord::Schema.define(version: 20170228104207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20170227164610) do
     t.string   "dispute_type_other_value"
     t.string   "case_status"
     t.string   "hardship_reason"
+    t.string   "hardship_reason_file_name"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/forms/steps/hardship/hardship_reason_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_reason_form_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+include ActionDispatch::TestProcess
+
+RSpec.describe Steps::Hardship::HardshipReasonForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    hardship_reason: hardship_reason,
+    hardship_reason_document: hardship_reason_document,
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', hardship_reason: hardship_reason, hardship_reason_file_name: hardship_reason_file_name) }
+  let(:hardship_reason) { nil }
+  let(:hardship_reason_document) { nil }
+  let(:hardship_reason_file_name) { nil }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when no tribunal_case is associated with the form' do
+      let(:tribunal_case)  { nil }
+      let(:hardship_reason) { 'Hardship Reason' }
+
+      it 'raises an error' do
+        expect { subject.save }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when validations fail' do
+      context 'when hardship_reason and hardship_reason_document are not present' do
+        let(:hardship_reason) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the hardship_reason field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:hardship_reason]).to eq(['You must enter the reasons (at least 5 characters) or attach a document'])
+        end
+
+        it 'has a validation error on the hardship_reason_document field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors[:hardship_reason_document]).to eq(['You must enter the reasons or attach a document'])
+        end
+      end
+
+      context 'when hardship_reason_document is not valid' do
+        let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
+
+        it 'should retrieve the errors from the uploader' do
+          expect(subject.errors).to receive(:add).with(:hardship_reason_document, String).and_call_original
+          expect(subject).to_not be_valid
+        end
+      end
+    end
+
+    context 'when hardship_reason is valid' do
+      context 'when providing appeal text' do
+        let(:hardship_reason) { 'I disagree with HMRC.' }
+        let(:hardship_reason_document) { nil }
+
+        it 'saves the record' do
+          expect(tribunal_case).to receive(:update).with(
+            hardship_reason: 'I disagree with HMRC.',
+            hardship_reason_file_name: nil
+          ).and_return(true)
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'when providing an attached document' do
+        let(:hardship_reason) { nil }
+        let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
+
+        context 'document upload successful' do
+          it 'saves the record' do
+            expect(tribunal_case).to receive(:update).with(
+              hardship_reason: nil,
+              hardship_reason_file_name: 'image.jpg'
+            ).and_return(true)
+
+            expect(Uploader).to receive(:add_file).with(hash_including(document_key: :hardship_reason)).and_return({})
+
+            expect(subject.save).to be(true)
+          end
+        end
+
+        context 'document upload unsuccessful' do
+          it 'doesn\'t save the record' do
+            expect(tribunal_case).not_to receive(:update)
+            expect(subject).to receive(:upload_document_if_present).and_return(false)
+            expect(subject.save).to be(false)
+          end
+        end
+      end
+
+      context 'when providing appeal text and document' do
+        let(:hardship_reason) { 'A very good reason' }
+        let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
+        let(:upload_response) { double(code: 200, body: {}, error?: false) }
+
+        it 'saves the record' do
+          expect(tribunal_case).to receive(:update).with(
+            hardship_reason: 'A very good reason',
+            hardship_reason_file_name: 'image.jpg'
+          ).and_return(true)
+
+          expect(Uploader).to receive(:add_file).and_return({})
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Add the document upload, as with other steps. Allow users to upload a
document instead of entering text for the "Why will paying the tax under
dispute cause financial hardship?" step.