### PR TITLE
Rename upload fields positioning hack CSS

### DIFF
--- a/app/assets/stylesheets/local/positioning_hacks.scss
+++ b/app/assets/stylesheets/local/positioning_hacks.scss
@@ -1,4 +1,4 @@
-// Once a grounds for appeal document has been uploaded, when loading again the same step will give us
+// Once a document has been uploaded, when loading again the same step will give us
 // the option to delete said document. The fact we need to ensure the app is functional without javascript,
 // forces us to have two separated forms but the arrangement of the 'Remove document' form needs to
 // be visually rendered inside the 'Continue' form.
@@ -6,13 +6,13 @@
 // We reposition the 'Remove' button and the 'Continue' button with the following CSS in order to visually
 // match the design and original arrangement when javascript is not available.
 
-#gfa_main_container.uploaded_doc_true {
-  .gfa_uploaded_doc_container {
+#document_upload_main_container.uploaded_doc_true {
+  .uploaded_document_container {
     position: relative;
     top: -50px;
   }
 
-  input.gfa_continue {
+  input.document_upload_continue {
     position: relative;
     top: 120px;
   }

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -6,13 +6,13 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <div id="gfa_main_container" class="uploaded_doc_<%= uploaded_document?(:grounds_for_appeal) %>">
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(:grounds_for_appeal) %>">
       <%= step_form @form_object do |f| %>
         <%= f.text_area :grounds_for_appeal, size: '40x4', class: 'form-control form-control-3-4 form-control-large' %>
 
         <%= document_upload_field(f, :grounds_for_appeal, label_text: t('.attach_document_html')) %>
 
-        <%= f.submit class: 'button gfa_continue' %>
+        <%= f.submit class: 'button document_upload_continue' %>
       <% end %>
 
       <%= display_current_document(:grounds_for_appeal) %>

--- a/app/views/steps/hardship/hardship_reason/edit.html.erb
+++ b/app/views/steps/hardship/hardship_reason/edit.html.erb
@@ -6,13 +6,13 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <div id="gfa_main_container" class="uploaded_doc_<%= uploaded_document?(:hardship_reason) %>">
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(:hardship_reason) %>">
       <%= step_form @form_object do |f| %>
         <%= f.text_area :hardship_reason, size: '60x10', class: 'form-control form-control-3-4 form-control-large' %>
 
         <%= document_upload_field(f, :hardship_reason, label_text: t('.attach_document_html')) %>
 
-        <%= f.submit class: 'button' %>
+        <%= f.submit class: 'button document_upload_continue' %>
       <% end %>
 
       <%= display_current_document(:hardship_reason) %>

--- a/app/views/steps/shared/document_upload/_current_document.html.erb
+++ b/app/views/steps/shared/document_upload/_current_document.html.erb
@@ -1,4 +1,4 @@
-<div class="gfa_uploaded_doc_container">
+<div class="uploaded_document_container">
   <p><%= t('.previous_document', file_name: current_document.name) %></p>
   <%= button_to 'Remove', document_path(current_document, document_key: document_key), method: :delete, data: {confirm: 'Are you sure?'}, class: 'button' %>
 </div>


### PR DESCRIPTION
The positioning hack for the upload fields is now being used in more
places than just the "grounds for appeal" (GFA) form. This makes the
names of the IDs and CSS classes more generic so we can use them in
more places.