### PR TITLE
Fix broken js

### DIFF
--- a/app/assets/javascripts/modules/custom-radio-toggles.js
+++ b/app/assets/javascripts/modules/custom-radio-toggles.js
@@ -2,16 +2,23 @@
 
 moj.Modules.customRadioToggles = {
   config: {
+    toggleableClass: 'toggleable',
     $targetElement: null, // the element to be shown or to hide
     $showElements: [],    // collection of elements that triggers the showing of the target element
     $hideElements: []     // collection of elements that triggers the hiding of the target element
   },
 
   init: function () {
-    if (!this.config.$targetElement) { return }
+    var self = this;
 
-    this.hideElementUnlessRelevant();
-    this.bindEvents();
+    if($('.' + self.config.toggleableClass).length) {
+      self.config.$targetElement = $('.' + self.config.toggleableClass).eq(0);
+      self.config.$showElements = $(self.config.$targetElement.data('show-elements'));
+      self.config.$hideElements = $(self.config.$targetElement.data('hide-elements'));
+
+      this.hideElementUnlessRelevant();
+      this.bindEvents();
+    }
   },
 
   bindEvents: function () {

--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -7,11 +7,6 @@ moj.Modules.docUpload = {
   $form: null,
   $fileList: null,
 
-  config: {
-    maxFilesize: null,
-    acceptedFiles: null
-  },
-
   init: function() {
     var self = this,
         previewTemplate,
@@ -29,8 +24,8 @@ moj.Modules.docUpload = {
     dzOptions = {
       url: '/documents',
       paramName: 'document',
-      maxFilesize: parseInt(self.config.maxFilesize),
-      acceptedFiles: self.config.acceptedFiles,
+      maxFilesize: parseInt(self.$form.data('max-filesize')),
+      acceptedFiles: self.$form.data('accepted-files'),
       autoProcessQueue: true,
       addRemoveLinks: true,
       createImageThumbnails: false,

--- a/app/views/steps/appeal/case_type_show_more/edit.html.erb
+++ b/app/views/steps/appeal/case_type_show_more/edit.html.erb
@@ -10,21 +10,12 @@
       <%= f.radio_button_fieldset :case_type,
         choices: Steps::Appeal::CaseTypeShowMoreForm.choices %>
 
-      <div class="panel toggleable" id="case_type_other_value" aria-hidden="true">
+      <div class="panel toggleable" id="case_type_other_value" aria-hidden="true" data-show-elements="form input:radio:last" data-hide-elements="form input:radio:not(:last)">
         <%= f.text_field :case_type_other_value, class: 'form-control' %>
       </div>
 
       <%= f.submit class: 'button' %>
     <% end %>
 
-    <%= javascript_tag do %>
-      //
-      // This is a hack because we want just the last of the radio buttons to show a text field,
-      // and that is not possible to do with the current gov.uk elements form builder version.
-      //
-      moj.Modules.customRadioToggles.config.$targetElement = $('#case_type_other_value');
-      moj.Modules.customRadioToggles.config.$showElements  = $('form input:radio:last');
-      moj.Modules.customRadioToggles.config.$hideElements  = $('form input:radio:not(:last)');
-    <% end %>
   </div>
 </div>

--- a/app/views/steps/appeal/dispute_type/edit.html.erb
+++ b/app/views/steps/appeal/dispute_type/edit.html.erb
@@ -10,21 +10,12 @@
       <%= f.radio_button_fieldset :dispute_type,
         choices: @form_object.choices %>
 
-      <div class="panel toggleable" id="dispute_type_other_value" aria-hidden="true">
+      <div class="panel toggleable" id="dispute_type_other_value" aria-hidden="true" data-show-elements="form input:radio:last" data-hide-elements="form input:radio:not(:last)">
         <%= f.text_field :dispute_type_other_value, class: 'form-control' %>
       </div>
 
       <%= f.submit class: 'button' %>
     <% end %>
 
-    <%= javascript_tag do %>
-      //
-      // This is a hack because we want just the last of the radio buttons to show a text field,
-      // and that is not possible to do with the current gov.uk elements form builder version.
-      //
-      moj.Modules.customRadioToggles.config.$targetElement = $('#dispute_type_other_value');
-      moj.Modules.customRadioToggles.config.$showElements  = $('form input:radio:last');
-      moj.Modules.customRadioToggles.config.$hideElements  = $('form input:radio:not(:last)');
-    <% end %>
   </div>
 </div>

--- a/app/views/steps/appeal/penalty_amount/edit.html.erb
+++ b/app/views/steps/appeal/penalty_amount/edit.html.erb
@@ -10,21 +10,12 @@
       <%= f.radio_button_fieldset :penalty_level,
         choices: Steps::Appeal::PenaltyAmountForm.choices %>
 
-      <div class="panel toggleable" id="penalty_amount_detail" aria-hidden="true">
+      <div class="panel toggleable" id="penalty_amount_detail" aria-hidden="true" data-show-elements="form input:radio:not(:first)" data-hide-elements="form input:radio:first">
         <%= f.text_field :penalty_amount, class: 'form-control' %>
       </div>
 
       <%= f.submit class: 'button' %>
     <% end %>
 
-    <%= javascript_tag do %>
-      //
-      // This is a hack because we want two out of three radio buttons to show the amount field,
-      // and that is not possible to do with the current gov.uk elements form builder version.
-      //
-      moj.Modules.customRadioToggles.config.$targetElement = $('#penalty_amount_detail');
-      moj.Modules.customRadioToggles.config.$showElements  = $('form input:radio:not(:first)');
-      moj.Modules.customRadioToggles.config.$hideElements  = $('form input:radio:first');
-    <% end %>
   </div>
 </div>

--- a/app/views/steps/shared/_dropzone.html.erb
+++ b/app/views/steps/shared/_dropzone.html.erb
@@ -1,9 +1,3 @@
-<!-- Some configuration -->
-<%= javascript_tag do %>
-  moj.Modules.docUpload.config.acceptedFiles = '<%= DocumentUpload::ALLOWED_CONTENT_TYPES.join(',') %>';
-  moj.Modules.docUpload.config.maxFilesize = '<%= DocumentUpload::MAX_FILE_SIZE %>';
-<% end %>
-
 <!-- This is used as the file preview template -->
 <div class="dz-preview dz-file-preview">
   <div class="dz-details">
@@ -15,7 +9,7 @@
   <div class="dz-error-mark js-hidden show-when-js-is-loaded"><span>✘</span></div>
 </div>
 
-<div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0">
+<div class="dropzone dz-clickable js-hidden show-when-js-is-loaded" id="dz_doc_upload" tabindex="0" data-accepted-files="<%= DocumentUpload::ALLOWED_CONTENT_TYPES.join(',') %>" data-max-filesize="<%= DocumentUpload::MAX_FILE_SIZE %>">
   <div class="dz-default dz-message grid-row">
     <div class="column-one-third arrow-icon">
       <p></p>


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/140666983)

Moving the JS include out of the `<head>` and down to the end of the `<body>` made inline JS configurations break.

This fixes them by moving configuration variables to data attributes that modules can pick up at initialisation.