### PR TITLE
Ensure the confirmation page makes sense without a case reference.

### DIFF
--- a/app/views/errors/case_submitted.html.erb
+++ b/app/views/errors/case_submitted.html.erb
@@ -2,12 +2,9 @@
   <div class="column-two-thirds">
     <h1 class="heading-large"><%= t '.heading' %></h1>
 
-    <h1 class="heading-large">
-      <span class="heading-secondary"><%= t '.case_reference' %></span>
-      <span><%= @tribunal_case.case_reference %></span>
-    </h1>
-
-    <p><%= t '.note_number' %></p>
+    <% if @tribunal_case.case_reference.present? %>
+      <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
+    <% end %>
 
     <h2 class="heading-medium">
       <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>

--- a/app/views/shared/_confirmation_case_reference.html.erb
+++ b/app/views/shared/_confirmation_case_reference.html.erb
@@ -1,0 +1,6 @@
+<h1 class="heading-large">
+  <span class="heading-secondary"><%= t '.case_reference' %></span>
+  <span><%= tribunal_case.case_reference %></span>
+</h1>
+
+<p><%= t '.note_number' %></p>

--- a/app/views/steps/closure/confirmation/show.html.erb
+++ b/app/views/steps/closure/confirmation/show.html.erb
@@ -3,12 +3,9 @@
   <p><%= t '.confirmation_email' %></p>
 </div>
 
-<h1 class="heading-large">
-  <span class="heading-secondary"><%= t '.case_reference' %></span>
-  <span><%= @tribunal_case.case_reference %></span>
-</h1>
-
-<p><%= t '.note_number' %></p>
+<% if @tribunal_case.case_reference.present? %>
+  <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
+<% end %>
 
 <h2 class="heading-medium">
   <%= link_to t('.save_or_print_pdf'), steps_closure_check_answers_path(format: :pdf), target: '_blank' %>

--- a/app/views/steps/details/confirmation/show.html.erb
+++ b/app/views/steps/details/confirmation/show.html.erb
@@ -3,12 +3,9 @@
   <p><%= t '.confirmation_email' %></p>
 </div>
 
-<h1 class="heading-large">
-  <span class="heading-secondary"><%= t '.case_reference' %></span>
-  <span><%= @tribunal_case.case_reference %></span>
-</h1>
-
-<p><%= t '.note_number' %></p>
+<% if @tribunal_case.case_reference.present? %>
+  <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
+<% end %>
 
 <h2 class="heading-medium">
   <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -79,13 +79,11 @@ en:
             no_representative: I don't have a representative
       confirmation:
         show:
-          case_reference: 'Your case reference number is:'
           case_submitted: Case submitted
           confirmation_email: We will send confirmation by email
-          note_number: Please make a note of this number in case you need to contact us.
           save_or_print_pdf: Save or print your case details
           what_happens_next_html: |
-            <p>We will also send your case reference number and case details by email.</p>
+            <p>We will also send your case details by email.</p>
             <h2 class="heading-medium">What happens next?</h2>
             <ul class="list list-bullet">
               <li>we will review your details</li>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -240,13 +240,11 @@ en:
           lead_text: Give a summary of the decisions you think should be made in regards to your %{appeal_or_application}. Write no more than 2-3 sentences which clearly outline the result you want.
       confirmation:
         show:
-          case_reference: 'Your case reference number is:'
           case_submitted: Case submitted
           confirmation_email: We will send confirmation by email
-          note_number: Please make a note of this number in case you need to contact us.
           save_or_print_pdf: Save or print your case details
           what_happens_next_html: |
-            <p>We will also send your case reference number and case details by email.</p>
+            <p>We will also send your case details by email.</p>
             <h2 class="heading-medium">What happens next?</h2>
             <ul class="list list-bullet">
               <li>we will review your details</li>

--- a/config/locales/shared.yml
+++ b/config/locales/shared.yml
@@ -1,0 +1,5 @@
+en:
+  shared:
+    confirmation_case_reference:
+      case_reference: 'Your case reference number is:'
+      note_number: Please make a note of this number in case you need to contact us.


### PR DESCRIPTION
If the case submission to GLiMR fails, we might not have a case reference to show
in the confirmation page, so we need to make some copy amendments.

Also, the same apply to the `case already submitted` error page.