### PR TITLE
Do not show `NO_REF` in the case PDF.

### DIFF
--- a/app/views/steps/closure/check_answers/pdf/_header.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/_header.pdf.erb
@@ -1,4 +1,6 @@
-<p>
-  <span class="case-reference"><%= tribunal_case.case_reference || 'NO REF' %></span>
-</p>
-<br/>
+<% if tribunal_case.case_reference.present? %>
+  <p>
+    <span class="case-reference"><%= tribunal_case.case_reference %></span>
+  </p>
+  <br/>
+<% end %>

--- a/app/views/steps/details/check_answers/pdf/_header.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/_header.pdf.erb
@@ -1,6 +1,8 @@
 <p>
-  <span class="case-reference"><%= tribunal_case.case_reference || 'NO REF' %></span>
-  <br/>
+  <% if tribunal_case.case_reference.present? %>
+    <span class="case-reference"><%= tribunal_case.case_reference %></span>
+    <br/>
+  <% end %>
   <strong><%= [tribunal_case.taxpayer.name, 'HMRC'].to_sentence(two_words_connector: t('.appellant_connector')) %></strong>
 </p>
 <br/>


### PR DESCRIPTION
When no case reference is available, show nothing, instead of `NO_REF`.