### PR TITLE
Add upload field to representative approval step

### DIFF
--- a/app/forms/steps/details/representative_approval_form.rb
+++ b/app/forms/steps/details/representative_approval_form.rb
@@ -1,12 +1,41 @@
 module Steps::Details
   class RepresentativeApprovalForm < BaseForm
     attribute :representative_approval_document, DocumentUpload
+    validate :valid_uploaded_file
 
     private
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      true
+      upload_document_if_present && tribunal_case.update(
+        representative_approval_file_name: file_name
+      )
+    end
+
+    def valid_uploaded_file
+      return true if representative_approval_document.nil? || representative_approval_document.valid?
+      retrieve_document_errors
+    end
+
+    def upload_document_if_present
+      return true if representative_approval_document.nil?
+
+      representative_approval_document.upload!(document_key: :representative_approval, collection_ref: tribunal_case.files_collection_ref)
+      retrieve_document_errors
+
+      errors.empty?
+    end
+
+    def retrieve_document_errors
+      representative_approval_document.errors.each do |error|
+        errors.add(:representative_approval_document, error)
+      end
+    end
+
+    # If there is a file upload, store the name of the file, otherwise, retrieve any previously
+    # uploaded file name from the tribunal_case object (or none if nil).
+    def file_name
+      representative_approval_document&.file_name || tribunal_case&.representative_approval_file_name
     end
   end
 end

--- a/app/views/steps/details/representative_approval/edit.html.erb
+++ b/app/views/steps/details/representative_approval/edit.html.erb
@@ -17,9 +17,14 @@
       </div>
     </details>
 
-    <%= step_form @form_object do |f| %>
-      <!-- TODO: Add form fields here -->
-      <%= f.submit class: 'button' %>
-    <% end %>
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(:representative_approval) %>">
+      <%= step_form @form_object do |f| %>
+        <%= document_upload_field(f, :representative_approval, label_text: t('.attach_document_html')) %>
+
+        <%= f.submit class: 'button document_upload_continue' %>
+      <% end %>
+
+      <%= display_current_document(:representative_approval) %>
+    </div>
   </div>
 </div>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -104,6 +104,7 @@ en:
               </div>
             </div>
           download_button_text: Download PDF
+          attach_document_html: <strong>Attach approval as a document</strong>
       representative_type:
         edit:
           heading:

--- a/db/migrate/20170228170205_add_rep_approval_document_to_tribunal_case.rb
+++ b/db/migrate/20170228170205_add_rep_approval_document_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddRepApprovalDocumentToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :representative_approval_file_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228104207) do
+ActiveRecord::Schema.define(version: 20170228170205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20170228104207) do
     t.string   "case_status"
     t.string   "hardship_reason"
     t.string   "hardship_reason_file_name"
+    t.string   "representative_approval_file_name"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 


### PR DESCRIPTION
If a non-legal rep uses the service, they should be able to upload a
signed approval form from the taxpayer ("proforma").