### PR TITLE
Implement correct counter-terrorism appeal flow

### DIFF
--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -43,7 +43,7 @@ class AppealDecisionTree < DecisionTree
     if tribunal_case_is_challenged?
       edit(:challenged_decision_status)
     elsif tribunal_case_is_unchallenged_indirect_tax?
-      edit(:dispute_type)
+      dispute_or_penalties_decision
     else
       show(:must_challenge_hmrc)
     end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -31,7 +31,7 @@ class CaseType < ValueObject
 
   # This list is sorted alphabetically by what we actually call the case types in the UI
   VALUES = [
-    APN_PENALTY                  = new(:apn_penalty,                  direct_tax: false, ask_dispute_type: false, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
+    APN_PENALTY                  = new(:apn_penalty,                  ask_penalty: true, appeal_or_application: :appeal),
     AGGREGATES_LEVY              = new(:aggregates_levy,              indirect_tax_properties),
     AIR_PASSENGER_DUTY           = new(:air_passenger_duty,           indirect_tax_properties),
     ALCOHOLIC_LIQUOR_DUTIES      = new(:alcoholic_liquor_duties,      indirect_tax_properties),
@@ -41,33 +41,33 @@ class CaseType < ValueObject
     CLIMATE_CHANGE_LEVY          = new(:climate_change_levy,          indirect_tax_properties),
     CONSTRUCTION_INDUSTRY_SCHEME = new(:construction_industry_scheme, direct_tax_properties),
     CORPORATION_TAX              = new(:corporation_tax,              direct_tax_properties),
-    COUNTER_TERRORISM            = new(:counter_terrorism,            direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :appeal),
+    COUNTER_TERRORISM            = new(:counter_terrorism,            indirect_tax: true, ask_challenged: true, appeal_or_application: :appeal),
     CUSTOMS_DUTY                 = new(:customs_duty,                 indirect_tax_properties),
     DOTAS_PENALTY                = new(:dotas_penalty,                direct_tax_properties),
     EXPORT_REGULATIONS_PENALTY   = new(:export_regulations_penalty,   indirect_tax_properties),
     GAMING_DUTY                  = new(:gaming_duty,                  indirect_tax_properties),
     GENERAL_BETTING_DUTY         = new(:general_betting_duty,         indirect_tax_properties),
     HYDROCARBON_OIL_DUTIES       = new(:hydrocarbon_oil_duties,       indirect_tax_properties),
-    INACCURATE_RETURN_PENALTY    = new(:inaccurate_return_penalty,    direct_tax: false, ask_dispute_type: false, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
+    INACCURATE_RETURN_PENALTY    = new(:inaccurate_return_penalty,    ask_penalty: true, appeal_or_application: :appeal),
     INCOME_TAX                   = new(:income_tax,                   direct_tax_properties),
-    INFORMATION_NOTICE           = new(:information_notice,           direct_tax: false, ask_dispute_type: true, ask_penalty: true, ask_hardship: false, appeal_or_application: :appeal),
+    INFORMATION_NOTICE           = new(:information_notice,           ask_dispute_type: true, ask_penalty: true, appeal_or_application: :appeal),
     INHERITANCE_TAX              = new(:inheritance_tax,              direct_tax_properties),
     INSURANCE_PREMIUM_TAX        = new(:insurance_premium_tax,        indirect_tax_properties),
     LANDFILL_TAX                 = new(:landfill_tax,                 indirect_tax_properties),
     LOTTERY_DUTY                 = new(:lottery_duty,                 indirect_tax_properties),
-    MONEY_LAUNDERING_DECISIONS   = new(:money_laundering_decisions,   direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true, appeal_or_application: :appeal),
+    MONEY_LAUNDERING_DECISIONS   = new(:money_laundering_decisions,   direct_tax: true, ask_hardship: true, appeal_or_application: :appeal),
     NI_CONTRIBUTIONS             = new(:ni_contributions,             direct_tax_properties),
     PETROLEUM_REVENUE_TAX        = new(:petroleum_revenue_tax,        direct_tax_properties),
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),
     REMOTE_GAMING_DUTY           = new(:remote_gaming_duty,           indirect_tax_properties),
-    REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, appeal_or_application: :application),
-    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: false, ask_challenged: true, appeal_or_application: :application),
+    REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, appeal_or_application: :application),
+    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_challenged: true, appeal_or_application: :application),
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),
     TOBACCO_PRODUCTS_DUTY        = new(:tobacco_products_duty,        indirect_tax_properties),
     VAT                          = new(:vat,                          indirect_tax_properties),
-    OTHER                        = new(:other,                        direct_tax: true, ask_dispute_type: false, ask_penalty: false, ask_hardship: true, ask_challenged: false, appeal_or_application: :appeal)
+    OTHER                        = new(:other,                        direct_tax: true, ask_hardship: true, appeal_or_application: :appeal)
   ].freeze
 
   def self.values

--- a/spec/services/appeal_decision_tree/challenged_decision_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_spec.rb
@@ -27,15 +27,30 @@ RSpec.describe AppealDecisionTree, '#destination' do
   end
 
   context 'for an indirect tax' do
-    let(:case_type) { CaseType.new(:dummy, direct_tax: false) }
-
     context 'and the case has not been challenged' do
       let(:challenged_decision) { ChallengedDecision::NO }
 
-      it { is_expected.to have_destination(:dispute_type, :edit) }
+      context 'and the case type asks dispute type' do
+        let(:case_type) { CaseType.new(:dummy, direct_tax: false, ask_dispute_type: true) }
+
+        it { is_expected.to have_destination(:dispute_type, :edit) }
+      end
+
+      context 'and the case type asks penalty' do
+        let(:case_type) { CaseType.new(:dummy, direct_tax: false, ask_penalty: true) }
+
+        it { is_expected.to have_destination(:penalty_amount, :edit) }
+      end
+
+      context 'and the case type does not ask dispute type or penalty' do
+        let(:case_type) { CaseType.new(:dummy, direct_tax: false) }
+
+        it { is_expected.to have_destination('/steps/lateness/in_time', :edit) }
+      end
     end
 
     context 'and the case has been challenged' do
+      let(:case_type) { CaseType.new(:dummy, direct_tax: false) }
       let(:challenged_decision) { ChallengedDecision::YES }
 
       it { is_expected.to have_destination(:challenged_decision_status, :edit) }


### PR DESCRIPTION
- Change post-challenge flow to take `ask_dispute` and `ask_penalty`
  into account
- Ask "Did you challenge" on Counter Terrorism appeals
- Simplify case type listings by removing all arguments that are just
  default values