### PR TITLE
Email if GLiMR is down or there is a failure.

### DIFF
--- a/app/controllers/appeal_cases_controller.rb
+++ b/app/controllers/appeal_cases_controller.rb
@@ -5,10 +5,6 @@ class AppealCasesController < CasesController
     AppealPresenter
   end
 
-  def check_answers_path
-    steps_details_check_answers_path
-  end
-
   def confirmation_path
     steps_details_confirmation_path
   end

--- a/app/controllers/closure_cases_controller.rb
+++ b/app/controllers/closure_cases_controller.rb
@@ -5,10 +5,6 @@ class ClosureCasesController < CasesController
     ClosurePresenter
   end
 
-  def check_answers_path
-    steps_closure_check_answers_path
-  end
-
   def confirmation_path
     steps_closure_confirmation_path
   end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,11 +1,12 @@
 class NotifyMailer < GovukNotifyRails::Mailer
-  CASE_SUBMITTED_TEMPLATE_ID = 'e64e9db9-d344-4041-a7df-135fbd39fa56'.freeze
+  CASE_CONFIRMATION_TEMPLATE_ID = 'e64e9db9-d344-4041-a7df-135fbd39fa56'.freeze
+  FTT_CASE_NOTIFICATION_TEMPLATE_ID = '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f'.freeze
 
   # Define methods as usual, and set the template and personalisation, if needed,
   # then just use mail() as with any other ActionMailer, with the recipient email
   #
-  def case_submitted(tribunal_case)
-    set_template(CASE_SUBMITTED_TEMPLATE_ID)
+  def taxpayer_case_confirmation(tribunal_case)
+    set_template(CASE_CONFIRMATION_TEMPLATE_ID)
 
     set_personalisation(
       first_name: tribunal_case.taxpayer_individual_first_name,
@@ -13,5 +14,16 @@ class NotifyMailer < GovukNotifyRails::Mailer
     )
 
     mail(to: tribunal_case.taxpayer_contact_email)
+  end
+
+  def ftt_new_case_notification(_tribunal_case)
+    set_template(FTT_CASE_NOTIFICATION_TEMPLATE_ID)
+
+    # TODO: waiting for template to be completed
+    # set_personalisation(
+    # )
+
+    # TODO: once we open the beta, change to: Rails.configuration.tax_tribunal_email
+    mail(to: 'jesus.laiz+ftt@digital.justice.gov.uk')
   end
 end

--- a/app/services/case_creator.rb
+++ b/app/services/case_creator.rb
@@ -1,32 +1,19 @@
 class CaseCreator
-  attr_reader :tribunal_case, :errors
+  attr_reader :tribunal_case
 
   def initialize(tribunal_case)
     @tribunal_case = tribunal_case
-    @errors = []
   end
 
   def call
-    begin
-      glimr_case = GlimrNewCase.new(tribunal_case).call!
-      case_reference = glimr_case.case_reference
+    glimr_case = GlimrNewCase.new(tribunal_case).call
+    case_reference = glimr_case.case_reference
 
-      tribunal_case.update(
-        case_reference: case_reference,
-        case_status: CaseStatus::SUBMITTED
-      )
-    rescue => ex
-      errors << ex.message
-    end
-
-    self
-  end
-
-  def success?
-    !errors?
-  end
-
-  def errors?
-    errors.any?
+    # case_reference could be nil, if GLiMR call failed, but despite this,
+    # we want to mark the tribunal case as `submitted`
+    tribunal_case.update(
+      case_reference: case_reference,
+      case_status: CaseStatus::SUBMITTED
+    )
   end
 end

--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -17,6 +17,12 @@ class GlimrNewCase
   rescue => e
     Rails.logger.info({ caller: self.class.name, method: __callee__, error: e }.to_json)
 
+    case e
+    when GlimrApiClient::Unavailable
+      tribunal_case.update(case_status: CaseStatus::SUBMITTED)
+    else
+      raise e
+    end
   end
 
   def params

--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -9,10 +9,14 @@ class GlimrNewCase
   end
 
   def call!
-    response = GlimrApiClient::RegisterNewCase.call(params)
-    @case_reference = response.response_body[:tribunalCaseNumber]
-    @confirmation_code = response.response_body[:confirmationCode]
+    GlimrApiClient::RegisterNewCase.call(params).tap { |api|
+      @case_reference = api.response_body[:tribunalCaseNumber]
+      @confirmation_code = api.response_body[:confirmationCode]
+    }
     self
+  rescue => e
+    Rails.logger.info({ caller: self.class.name, method: __callee__, error: e }.to_json)
+
   end
 
   def params

--- a/spec/controllers/appeal_cases_controller_spec.rb
+++ b/spec/controllers/appeal_cases_controller_spec.rb
@@ -1,53 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe AppealCasesController, type: :controller do
-
-  let(:current_tribunal_case) { instance_double(TribunalCase, case_status: nil) }
-  let(:case_creator_double) { instance_double(CaseCreator, call: case_creator_result) }
-  let(:case_submitted_mail_double) { double(deliver_later: true) }
-
   include_examples 'checks the validity of the current tribunal case on create'
-
-  describe 'POST #create' do
-    before do
-      allow(subject).to receive(:current_tribunal_case).and_return(current_tribunal_case)
-      allow(CaseCreator).to receive(:new).with(current_tribunal_case).and_return(case_creator_double)
-      allow(NotifyMailer).to receive(:case_submitted).with(current_tribunal_case).and_return(case_submitted_mail_double)
-    end
-
-    context 'for a successful result' do
-      let(:case_creator_result) { instance_double(CaseCreator, success?: true, errors: []) }
-
-      it 'should generate and upload the case details PDF' do
-        expect_any_instance_of(CaseDetailsPdf).to receive(:generate_and_upload).and_return(true)
-        post :create
-      end
-
-      it 'should redirect to the confirmation page' do
-        allow(controller).to receive(:generate_and_upload_pdf)
-        post :create
-        expect(response).to redirect_to(steps_details_confirmation_path)
-      end
-
-      it 'should send a case submitted email' do
-        allow(subject).to receive(:generate_and_upload_pdf)
-        expect(case_submitted_mail_double).to receive(:deliver_later)
-        post :create
-      end
-    end
-
-    context 'for an unsuccessful result' do
-      let(:case_creator_result) { instance_double(CaseCreator, success?: false, errors: ['an error']) }
-
-      it 'should redirect to the summary page with an error' do
-        post :create
-        expect(flash[:alert]).to eq(['an error'])
-        expect(response).to redirect_to(steps_details_check_answers_path)
-      end
-
-      it 'should not send a case submitted email' do
-        expect(case_submitted_mail_double).not_to receive(:deliver_later)
-      end
-    end
-  end
+  include_examples 'submits the tribunal case to GLiMR', confirmation_path: '/steps/details/confirmation'
 end

--- a/spec/controllers/closure_cases_controller_spec.rb
+++ b/spec/controllers/closure_cases_controller_spec.rb
@@ -1,53 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ClosureCasesController, type: :controller do
-
-  let(:current_tribunal_case) { instance_double(TribunalCase, case_status: nil) }
-  let(:case_creator_double) { instance_double(CaseCreator, call: case_creator_result) }
-  let(:case_submitted_mail_double) { double(deliver_later: true) }
-
   include_examples 'checks the validity of the current tribunal case on create'
-
-  describe 'POST #create' do
-    before do
-      allow(subject).to receive(:current_tribunal_case).and_return(current_tribunal_case)
-      allow(CaseCreator).to receive(:new).with(current_tribunal_case).and_return(case_creator_double)
-      allow(NotifyMailer).to receive(:case_submitted).with(current_tribunal_case).and_return(case_submitted_mail_double)
-    end
-
-    context 'for a successful result' do
-      let(:case_creator_result) { instance_double(CaseCreator, success?: true, errors: []) }
-
-      it 'should generate and upload the case details PDF' do
-        expect_any_instance_of(CaseDetailsPdf).to receive(:generate_and_upload).and_return(true)
-        post :create
-      end
-
-      it 'should redirect to the confirmation page' do
-        allow(controller).to receive(:generate_and_upload_pdf)
-        post :create
-        expect(response).to redirect_to(steps_closure_confirmation_path)
-      end
-
-      it 'should send a case submitted email' do
-        allow(subject).to receive(:generate_and_upload_pdf)
-        expect(case_submitted_mail_double).to receive(:deliver_later)
-        post :create
-      end
-    end
-
-    context 'for an unsuccessful result' do
-      let(:case_creator_result) { instance_double(CaseCreator, success?: false, errors: ['an error']) }
-
-      it 'should redirect to the summary page with an error' do
-        post :create
-        expect(flash[:alert]).to eq(['an error'])
-        expect(response).to redirect_to(steps_closure_check_answers_path)
-      end
-
-      it 'should not send a case submitted email' do
-        expect(case_submitted_mail_double).not_to receive(:deliver_later)
-      end
-    end
-  end
+  include_examples 'submits the tribunal case to GLiMR', confirmation_path: '/steps/closure/confirmation'
 end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe NotifyMailer, type: :mailer do
-  describe 'case_submitted' do
+  describe 'taxpayer_case_confirmation' do
     let(:tribunal_case) {
       instance_double(
         TribunalCase,
@@ -10,29 +10,21 @@ RSpec.describe NotifyMailer, type: :mailer do
         taxpayer_individual_last_name: 'Test'
       )
     }
+    let(:mail) { described_class.taxpayer_case_confirmation(tribunal_case) }
 
-    let(:template) { 'e64e9db9-d344-4041-a7df-135fbd39fa56' }
-    let(:mail) { described_class.case_submitted(tribunal_case) }
-
-    it 'is a govuk_notify delivery' do
-      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
-    end
-
-    it 'sets the recipient' do
-      expect(mail.to).to eq(['test@example.com'])
-    end
-
-    # This is just internal, as the real subject gets set in the template at Notify website
-    it 'sets the subject' do
-      expect(mail.body).to match("This is a GOV.UK Notify email with template #{template}")
-    end
-
-    it 'sets the template' do
-      expect(mail.govuk_notify_template).to eq(template)
-    end
+    it_behaves_like 'a Notify mail', template_id: 'e64e9db9-d344-4041-a7df-135fbd39fa56',
+                                     recipient: 'test@example.com'
 
     it 'sets the personalisation' do
       expect(mail.govuk_notify_personalisation.keys.sort).to eq([:first_name, :last_name])
     end
+  end
+
+  describe 'ftt_new_case_notification' do
+    let(:tribunal_case) { instance_double(TribunalCase) }
+    let(:mail) { described_class.ftt_new_case_notification(tribunal_case) }
+
+    it_behaves_like 'a Notify mail', template_id: '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f',
+                                     recipient: 'jesus.laiz+ftt@digital.justice.gov.uk'
   end
 end

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -2,13 +2,18 @@
 #
 class NotifyMailerPreview < ActionMailer::Preview
 
-  def case_submitted
+  def taxpayer_case_confirmation
     tribunal_case = TribunalCase.new(
       taxpayer_contact_email: 'test@example.com',
       taxpayer_individual_first_name: 'John',
       taxpayer_individual_last_name: 'Test'
     )
-    NotifyMailer.case_submitted(tribunal_case)
+    NotifyMailer.taxpayer_case_confirmation(tribunal_case)
+  end
+
+  def ftt_new_case_notification
+    tribunal_case = TribunalCase.new
+    NotifyMailer.ftt_new_case_notification(tribunal_case)
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,3 +23,8 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
+
+# So we don't need to require the gem in test scenarios
+class Raven
+  def self.capture_exception(_ex); end;
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,3 +21,5 @@ RSpec.configure do |config|
   config.include(ViewSpecHelpers, type: :helper)
   config.before(:each, type: :helper) { initialize_view_helpers(helper) }
 end
+
+RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/services/case_creator_spec.rb
+++ b/spec/services/case_creator_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe CaseCreator do
-
   let!(:tribunal_case) { TribunalCase.create }
 
   subject { described_class.new(tribunal_case) }
@@ -10,65 +9,43 @@ RSpec.describe CaseCreator do
     it 'accepts a tribunal case' do
       expect(subject.tribunal_case).to eq(tribunal_case)
     end
-
-    it 'defaults to no errors' do
-      expect(subject.errors).to eq([])
-    end
   end
 
   describe '#call' do
-    let(:glimr_new_case_double) {
-      instance_double(GlimrNewCase, call!: double(case_reference: 'TC/2017/12345', confirmation_code: 'ABCDEF'))
-    }
-
     before do
       allow(GlimrNewCase).to receive(:new).with(tribunal_case).and_return(glimr_new_case_double)
     end
 
     context 'registering the case into glimr' do
-      it 'calls the glimr API' do
-        expect(glimr_new_case_double).to receive(:call!)
-        subject.call
-      end
+      context 'when glimr call was success' do
+        let(:glimr_new_case_double) {
+          instance_double(GlimrNewCase, call: double(case_reference: 'TC/2017/12345', confirmation_code: 'ABCDEF'))
+        }
 
-      it 'should respond to success? with false and have no errors' do
-        subject.call
-        expect(subject.success?).to eq(true)
-        expect(subject.errors).to eq([])
-      end
-
-      context 'when there are errors' do
-        before do
-          allow(glimr_new_case_double).to receive(:call!).and_raise('boom!')
-        end
-
-        it 'should respond to success? with false and have errors' do
-          subject.call
-          expect(subject.success?).to eq(false)
-          expect(subject.errors).to eq(['boom!'])
-        end
-      end
-    end
-
-    context 'storing the returned GLiMR case reference' do
-      context 'when glimr and payment call was success' do
         it 'should store the case reference in the DB entry' do
-          expect(tribunal_case.case_reference).to be_nil
           subject.call
           expect(tribunal_case.case_reference).to eq('TC/2017/12345')
         end
 
         it 'should mark the case as `submitted`' do
-          expect(tribunal_case.case_status).to be_nil
           subject.call
           expect(tribunal_case.case_status).to eq(CaseStatus::SUBMITTED)
         end
       end
 
       context 'when glimr call fails' do
-        it 'should not even reach this point' do
-          expect(tribunal_case).not_to receive(:update).with(:case_reference)
+        let(:glimr_new_case_double) {
+          instance_double(GlimrNewCase, call: double(case_reference: nil, confirmation_code: nil))
+        }
+
+        it 'should remain with a nil case reference in the DB entry' do
           subject.call
+          expect(tribunal_case.case_reference).to be_nil
+        end
+
+        it 'should mark the case as `submitted` regardless' do
+          subject.call
+          expect(tribunal_case.case_status).to eq(CaseStatus::SUBMITTED)
         end
       end
     end

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe GlimrNewCase do
 
   let(:case_attributes) do
     {
+      case_type: CaseType::INCOME_TAX,
       taxpayer_type: taxpayer_type,
       taxpayer_individual_first_name: taxpayer_first_name,
       taxpayer_individual_last_name: taxpayer_last_name,
@@ -30,14 +31,14 @@ RSpec.describe GlimrNewCase do
     end
   end
 
-  describe '#call!' do
+  describe '#call' do
     let(:glimr_response_double) {
       instance_double(
         GlimrApiClient::RegisterNewCase,
         response_body: {
-        tribunalCaseNumber: 'TC/12345',
-        confirmationCode: 'ABCDEF'
-      }
+          tribunalCaseNumber: 'TC/12345',
+          confirmationCode: 'ABCDEF'
+        }
       )
     }
 
@@ -45,8 +46,8 @@ RSpec.describe GlimrNewCase do
     let(:glimr_params) do
       {
         jurisdictionId: 8,
-        onlineMappingCode: 'APPEAL_PENALTY_LOW',
-        documentsURL: 'http://downloader.dsd.io/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
+        onlineMappingCode: 'APPN_OTHER',
+        documentsURL: 'http://downloader.com/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
         contactFirstName: 'Filomena',
         contactLastName: 'Keebler',
         contactStreet1: '769 Eleanore Landing',
@@ -57,123 +58,87 @@ RSpec.describe GlimrNewCase do
       }
     end
 
-    context "Glimr call happens" do
-      before do
-        expect(GlimrApiClient::RegisterNewCase).to receive(:call).
+    before do
+      allow(ENV).to receive(:fetch).with('TAX_TRIBUNALS_DOWNLOADER_URL').and_return('http://downloader.com')
+      expect(GlimrApiClient::RegisterNewCase).to receive(:call).
           with(hash_including(glimr_params)).and_return(glimr_response_double)
-        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::APPEAL_PENALTY_LOW)
+    end
+
+    context 'registering the case into glimr' do
+      it 'returns a GlimrNewCase instance' do
+        expect(subject.call).to be_an_instance_of(described_class)
       end
 
-      context 'registering the case into glimr' do
-        it 'returns a GlimrNewCase instance' do
-          expect(subject.call!).to be_an_instance_of(described_class)
-        end
-
-        it 'retrieves the tc_number and conf_code' do
-          subject.call!
-          expect(subject.case_reference).to eq('TC/12345')
-          expect(subject.confirmation_code).to eq('ABCDEF')
-        end
-
-        context 'lengthy addresses' do
-          context 'several lines but less than 4' do
-            let(:taxpayer_address) { "769 Eleanore Landing\nAnother street\nSuite 225" }
-            let(:glimr_params) do
-              {
-                contactStreet1: '769 Eleanore Landing',
-                contactStreet2: 'Another street',
-                contactStreet3: 'Suite 225',
-              }
-            end
-
-            it { subject.call! }
-          end
-
-          context 'exceeding the 4 lines limit' do
-            let(:taxpayer_address) { "769 Eleanore Landing\nAnother street\nSuite 225\nMore address\nEven more address" }
-            let(:glimr_params) do
-              {
-                contactStreet1: '769 Eleanore Landing',
-                contactStreet2: 'Another street',
-                contactStreet3: 'Suite 225',
-                contactStreet4: 'More address, Even more address'
-              }
-            end
-
-            it { subject.call! }
-          end
-        end
+      it 'retrieves the tc_number and conf_code' do
+        subject.call
+        expect(subject.case_reference).to eq('TC/12345')
+        expect(subject.confirmation_code).to eq('ABCDEF')
       end
     end
 
-    context "Glimr call does not happen" do
-      before do
-        allow(GlimrApiClient::RegisterNewCase).to receive(:call).
-          with(hash_including(glimr_params)).and_return(glimr_response_double)
-        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::APPEAL_PENALTY_LOW)
-      end
-
-      context 'when taxpayer_type is company' do
-        let(:taxpayer_type) { ContactableEntityType::COMPANY }
-        let(:organisation_params) {
-          glimr_params.except(:contactFirstName, :contactLastName).merge(
-            contactOrganisationName: 'Company Name', contactFAO: 'Destany Fritsch')
+    context 'when taxpayer_type is company' do
+      let(:taxpayer_type) { ContactableEntityType::COMPANY }
+      let(:glimr_params) {
+        {
+          contactOrganisationName: 'Company Name',
+          contactFAO: 'Destany Fritsch'
         }
+      }
 
-        it 'sends required organisation params but not individual params' do
-          expect(GlimrApiClient::RegisterNewCase).to receive(:call).
-            with(hash_including(organisation_params)).and_return(glimr_response_double)
-          subject.call!
-        end
-      end
+      it { subject.call }
     end
 
-    describe 'Error cases' do
+    context 'lengthy addresses' do
+      context 'several lines but less than 4' do
+        let(:taxpayer_address) { "769 Eleanore Landing\nAnother street\nSuite 225" }
+        let(:glimr_params) do
+          {
+            contactStreet1: '769 Eleanore Landing',
+            contactStreet2: 'Another street',
+            contactStreet3: 'Suite 225',
+          }
+        end
+
+        it { subject.call }
+      end
+
+      context 'exceeding the 4 lines limit' do
+        let(:taxpayer_address) { "769 Eleanore Landing\nAnother street\nSuite 225\nMore address\nEven more address" }
+        let(:glimr_params) do
+          {
+            contactStreet1: '769 Eleanore Landing',
+            contactStreet2: 'Another street',
+            contactStreet3: 'Suite 225',
+            contactStreet4: 'More address, Even more address'
+          }
+        end
+
+        it { subject.call }
+      end
+    end
+  end
+
+  describe 'Error cases' do
+    # Right now we are capturing any kind of error that his call might produce, like timeouts,
+    # or GlimrApiClient::Unavailable, and not showing the user the error, just silently sending it
+    # to Raven and logging it, and also sending an email to the tribunal telling them there was a problem.
+    context 'Any kind of error StandardError' do
       before do
-        allow(tribunal_case).to receive(:mapping_code).and_return(MappingCode::APPEAL_PENALTY_LOW)
+        allow(GlimrApiClient::RegisterNewCase).to receive(:call).and_raise(StandardError)
       end
 
-      # The original spec positied a nil response body from GlimrApiClient.
-      # Although there are currently some edge cases (see
-      # https://www.pivotaltracker.com/story/show/140766861), this should not
-      # acutally happen.  Instead, it should raise a
-      # GlimrApiClient::Unavailable exception.
-      context 'GlimrApiClient::Unavailable' do
-        before do
-          allow(GlimrApiClient::RegisterNewCase).to receive(:call).and_raise(GlimrApiClient::Unavailable)
-        end
-
-        it 'is trapped' do
-          expect { subject.call! }.not_to raise_exception
-        end
-
-        it 'is logged' do
-          expect(Rails.logger).to receive(:info)
-          subject.call!
-        end
-
-        it 'marks the case as submitted' do
-          expect { subject.call! }.to change { tribunal_case.case_status }.to(CaseStatus::SUBMITTED)
-        end
+      it 'is trapped' do
+        expect { subject.call }.not_to raise_exception
       end
 
-      context 'Other Errors' do
-        before do
-          allow(GlimrApiClient::RegisterNewCase).to receive(:call).and_raise(NoMethodError)
-        end
+      it 'is logged' do
+        expect(Rails.logger).to receive(:info)
+        subject.call
+      end
 
-        it 'is not trapped' do
-          expect { subject.call! }.to raise_exception(NoMethodError)
-        end
-
-        it 'is logged' do
-          expect(Rails.logger).to receive(:info)
-          expect { subject.call! }.to raise_exception(NoMethodError)
-        end
-
-        it 'does not mark the case as submitted' do
-          expect { subject.call! }.to raise_exception(NoMethodError).and not_change(tribunal_case, :case_status)
-        end
+      it 'is captured by Raven' do
+        expect(Raven).to receive(:capture_exception)
+        subject.call
       end
     end
   end

--- a/spec/support/cases_controller_shared_examples.rb
+++ b/spec/support/cases_controller_shared_examples.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'submits the tribunal case to GLiMR' do |options|
+  let(:confirmation_path) { options.fetch(:confirmation_path) }
+
+  let(:current_tribunal_case) { instance_double(TribunalCase, case_status: nil, case_reference: case_reference) }
+  let(:case_creator_double) { instance_double(CaseCreator, call: true) }
+  let(:taxpayer_case_confirmation_mail_double) { double(deliver_later: true) }
+  let(:ftt_new_case_notification_mail_double) { double(deliver_later: true) }
+  let(:case_reference) { nil }
+
+  describe 'POST #create' do
+    before do
+      allow(subject).to receive(:current_tribunal_case).and_return(current_tribunal_case)
+      allow(subject).to receive(:generate_and_upload_pdf)
+
+      allow(CaseCreator).to receive(:new).with(current_tribunal_case).and_return(case_creator_double)
+
+      allow(NotifyMailer).to receive(:taxpayer_case_confirmation).with(current_tribunal_case).and_return(taxpayer_case_confirmation_mail_double)
+      allow(NotifyMailer).to receive(:ftt_new_case_notification).with(current_tribunal_case).and_return(ftt_new_case_notification_mail_double)
+    end
+
+    context 'for a successful result, where we have a case reference' do
+      let(:case_reference) { 'XXX' }
+
+      it 'should generate and upload the case details PDF' do
+        allow(subject).to receive(:generate_and_upload_pdf).and_call_original
+        expect_any_instance_of(CaseDetailsPdf).to receive(:generate_and_upload).and_return(true)
+        post :create
+      end
+
+      it 'should send a case submitted email' do
+        expect(taxpayer_case_confirmation_mail_double).to receive(:deliver_later)
+        post :create
+      end
+
+      it 'should redirect to the confirmation page' do
+        post :create
+        expect(response).to redirect_to(confirmation_path)
+      end
+    end
+
+    context 'for an unsuccessful result, where we do not have a case reference' do
+      let(:case_reference) { nil }
+
+      it 'should generate and upload the case details PDF' do
+        allow(subject).to receive(:generate_and_upload_pdf).and_call_original
+        expect_any_instance_of(CaseDetailsPdf).to receive(:generate_and_upload).and_return(true)
+        post :create
+      end
+
+      it 'should send a `case submitted` email' do
+        expect(taxpayer_case_confirmation_mail_double).to receive(:deliver_later)
+        post :create
+      end
+
+      it 'should send a `case with errors` email' do
+        expect(ftt_new_case_notification_mail_double).to receive(:deliver_later)
+        post :create
+      end
+
+      it 'should redirect to the confirmation page' do
+        post :create
+        expect(response).to redirect_to(confirmation_path)
+      end
+    end
+  end
+end

--- a/spec/support/notify_mailer_shared_examples.rb
+++ b/spec/support/notify_mailer_shared_examples.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'a Notify mail' do |options|
+  let(:template_id) { options.fetch(:template_id) }
+  let(:recipient)   { options.fetch(:recipient) }
+
+  it 'is a govuk_notify delivery' do
+    expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+  end
+
+  it 'sets the recipient' do
+    expect(mail.to).to eq([recipient])
+  end
+
+  it 'sets the template' do
+    expect(mail.govuk_notify_template).to eq(template_id)
+  end
+
+  # This is just internal, as the real subject gets set in the template at Notify website
+  it 'sets the subject' do
+    expect(mail.body).to match("This is a GOV.UK Notify email with template #{template_id}")
+  end
+end


### PR DESCRIPTION
This PR contains some of the work done already by @tatyree, with some refactor specially in the email tests.

It implements the email that we are going to send when there is a failure in GLiMR, but for now we are not going to send it to the _real_ email address, until we open the beta.