### PR TITLE
Dynamic personalisation for case confirmation email.

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -6,14 +6,19 @@ class NotifyMailer < GovukNotifyRails::Mailer
   # then just use mail() as with any other ActionMailer, with the recipient email
   #
   def taxpayer_case_confirmation(tribunal_case)
+    mail_presenter = CaseMailPresenter.new(tribunal_case)
+
     set_template(CASE_CONFIRMATION_TEMPLATE_ID)
 
     set_personalisation(
-      first_name: tribunal_case.taxpayer_individual_first_name,
-      last_name: tribunal_case.taxpayer_individual_last_name
+      first_name: mail_presenter.recipient_first_name,
+      last_name: mail_presenter.recipient_last_name,
+      case_reference: mail_presenter.case_reference,
+      show_case_reference: mail_presenter.show_case_reference?,
+      appeal_or_application: mail_presenter.appeal_or_application
     )
 
-    mail(to: tribunal_case.taxpayer_contact_email)
+    mail(to: mail_presenter.recipient_email)
   end
 
   def ftt_new_case_notification(_tribunal_case)

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -51,10 +51,10 @@ class TribunalCase < ApplicationRecord
   end
 
   def started_by_taxpayer?
-    user_type.equal?(UserType::TAXPAYER)
+    user_type.eql?(UserType::TAXPAYER)
   end
 
   def started_by_representative?
-    user_type.equal?(UserType::REPRESENTATIVE)
+    user_type.eql?(UserType::REPRESENTATIVE)
   end
 end

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -1,0 +1,36 @@
+class CaseMailPresenter < SimpleDelegator
+  # Initialise with a TribunalCase instance and any method not
+  # defined in this class will be forwarded automatically to that instance.
+
+  # GOV.UK Notify expects this to be literals
+  def show_case_reference?
+    case_reference.present? ? 'yes' : 'no'
+  end
+
+  # GOV.UK Notify does not accept `nil` values, instead use empty strings
+  def case_reference
+    tribunal_case.case_reference.to_s
+  end
+
+  # Email address of whoever filled the form out first. If it's the representative,
+  # they would get it, otherwise the taxpayer would
+  def recipient_email
+    started_by_representative? ? representative_contact_email : taxpayer_contact_email
+  end
+
+  # Same logic as recipient email
+  def recipient_first_name
+    started_by_representative? ? representative_individual_first_name : taxpayer_individual_first_name
+  end
+
+  # Same logic as recipient email
+  def recipient_last_name
+    started_by_representative? ? representative_individual_last_name : taxpayer_individual_last_name
+  end
+
+  private
+
+  def tribunal_case
+    __getobj__
+  end
+end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -2,21 +2,60 @@ require 'spec_helper'
 
 RSpec.describe NotifyMailer, type: :mailer do
   describe 'taxpayer_case_confirmation' do
-    let(:tribunal_case) {
-      instance_double(
-        TribunalCase,
-        taxpayer_contact_email: 'test@example.com',
+    let(:tribunal_case) { TribunalCase.new(tribunal_case_attributes) }
+    let(:tribunal_case_attributes) {
+      {
+        intent: intent,
+        user_type: user_type,
+        case_reference: case_reference,
+        taxpayer_contact_email: 'taxpayer@example.com',
         taxpayer_individual_first_name: 'John',
-        taxpayer_individual_last_name: 'Test'
-      )
+        taxpayer_individual_last_name: 'Harrison',
+        representative_contact_email: 'representative@example.com',
+        representative_individual_first_name: 'Stewart',
+        representative_individual_last_name: 'Quinten',
+      }
     }
+    let(:intent) { Intent::TAX_APPEAL }
+    let(:user_type) { UserType::TAXPAYER }
+    let(:case_reference) { 'TC/2017/00001' }
+
     let(:mail) { described_class.taxpayer_case_confirmation(tribunal_case) }
 
-    it_behaves_like 'a Notify mail', template_id: 'e64e9db9-d344-4041-a7df-135fbd39fa56',
-                                     recipient: 'test@example.com'
+    it_behaves_like 'a Notify mail', template_id: 'e64e9db9-d344-4041-a7df-135fbd39fa56'
 
-    it 'sets the personalisation' do
-      expect(mail.govuk_notify_personalisation.keys.sort).to eq([:first_name, :last_name])
+    context 'for a taxpayer' do
+      it 'sets the right recipient' do
+        expect(mail.to).to eq(['taxpayer@example.com'])
+      end
+
+      it 'sets the personalisation' do
+        expect(mail.govuk_notify_personalisation).to match({
+          first_name: 'John', last_name: 'Harrison', case_reference: 'TC/2017/00001', show_case_reference: 'yes', appeal_or_application: :appeal
+        })
+      end
+    end
+
+    context 'for a representative' do
+      let(:user_type) { UserType::REPRESENTATIVE }
+
+      it 'sets the right recipient' do
+        expect(mail.to).to eq(['representative@example.com'])
+      end
+
+      it 'sets the personalisation' do
+        expect(mail.govuk_notify_personalisation).to match({
+          first_name: 'Stewart', last_name: 'Quinten', case_reference: 'TC/2017/00001', show_case_reference: 'yes', appeal_or_application: :appeal
+        })
+      end
+    end
+
+    context 'without case reference' do
+      let(:case_reference) { nil }
+
+      it 'sets the personalisation' do
+        expect(mail.govuk_notify_personalisation).to include(case_reference: '', show_case_reference: 'no')
+      end
     end
   end
 
@@ -24,7 +63,10 @@ RSpec.describe NotifyMailer, type: :mailer do
     let(:tribunal_case) { instance_double(TribunalCase) }
     let(:mail) { described_class.ftt_new_case_notification(tribunal_case) }
 
-    it_behaves_like 'a Notify mail', template_id: '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f',
-                                     recipient: 'jesus.laiz+ftt@digital.justice.gov.uk'
+    it_behaves_like 'a Notify mail', template_id: '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f'
+
+    it 'sets the right recipient' do
+      expect(mail.to).to eq(['jesus.laiz+ftt@digital.justice.gov.uk'])
+    end
   end
 end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TribunalCase, type: :model do
   end
 
   context 'when the user is the taxpayer' do
-    let(:attributes) { { user_type: UserType::TAXPAYER } }
+    let(:attributes) { { user_type: UserType.new(:taxpayer) } }
     describe '#started_by_taxpayer?' do
       specify { expect(subject.started_by_taxpayer?).to be(true) }
     end
@@ -54,7 +54,7 @@ RSpec.describe TribunalCase, type: :model do
   end
 
   context 'when the user is a representative' do
-    let(:attributes) { { user_type: UserType::REPRESENTATIVE} }
+    let(:attributes) { { user_type: UserType.new(:representative)} }
     describe '#started_by_taxpayer?' do
       specify { expect(subject.started_by_taxpayer?).to be(false) }
     end

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe CaseMailPresenter do
+  subject { described_class.new(tribunal_case) }
+
+  let(:tribunal_case) { TribunalCase.new(tribunal_case_attributes) }
+  let(:tribunal_case_attributes) {
+    {
+      user_type: user_type,
+      case_reference: case_reference,
+      taxpayer_contact_email: 'taxpayer@example.com',
+      taxpayer_individual_first_name: 'John',
+      taxpayer_individual_last_name: 'Harrison',
+      representative_contact_email: 'representative@example.com',
+      representative_individual_first_name: 'Stewart',
+      representative_individual_last_name: 'Quinten',
+    }
+  }
+  let(:user_type) { UserType::TAXPAYER }
+  let(:case_reference) { 'TC/2017/00001' }
+
+  describe '#case_reference' do
+    context 'for a case with reference number' do
+      it { expect(subject.case_reference).to eq('TC/2017/00001') }
+    end
+
+    context 'for a case without reference number' do
+      let(:case_reference) { nil }
+      it { expect(subject.case_reference).to eq('') }
+    end
+  end
+
+  describe '#show_case_reference?' do
+    context 'for a case with reference number' do
+      it { expect(subject.show_case_reference?).to eq('yes') }
+    end
+
+    context 'for a case without reference number' do
+      let(:case_reference) { nil }
+      it { expect(subject.show_case_reference?).to eq('no') }
+    end
+  end
+
+  describe '#recipient_email' do
+    context 'for a taxpayer filling the form' do
+      it { expect(subject.recipient_email).to eq('taxpayer@example.com') }
+    end
+
+    context 'for a representative filling the form' do
+      let(:user_type) { UserType::REPRESENTATIVE }
+      it { expect(subject.recipient_email).to eq('representative@example.com') }
+    end
+  end
+
+  describe '#recipient_first_name' do
+    context 'for a taxpayer filling the form' do
+      it { expect(subject.recipient_first_name).to eq('John') }
+    end
+
+    context 'for a representative filling the form' do
+      let(:user_type) { UserType::REPRESENTATIVE }
+      it { expect(subject.recipient_first_name).to eq('Stewart') }
+    end
+  end
+
+  describe '#recipient_last_name' do
+    context 'for a taxpayer filling the form' do
+      it { expect(subject.recipient_last_name).to eq('Harrison') }
+    end
+
+    context 'for a representative filling the form' do
+      let(:user_type) { UserType::REPRESENTATIVE }
+      it { expect(subject.recipient_last_name).to eq('Quinten') }
+    end
+  end
+end

--- a/spec/support/notify_mailer_shared_examples.rb
+++ b/spec/support/notify_mailer_shared_examples.rb
@@ -2,14 +2,9 @@ require 'rails_helper'
 
 RSpec.shared_examples 'a Notify mail' do |options|
   let(:template_id) { options.fetch(:template_id) }
-  let(:recipient)   { options.fetch(:recipient) }
 
   it 'is a govuk_notify delivery' do
     expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
-  end
-
-  it 'sets the recipient' do
-    expect(mail.to).to eq([recipient])
   end
 
   it 'sets the template' do


### PR DESCRIPTION
Depending on who is the recipient (taxpayer/representative), the type of case
(application or appeal) and if we have or not case reference, some of the
personalisation that we send to Notify will change.

As potentially we will need this in other emails, a little presenter to encapsulate
this logic has been created.

Also as part of this ticket a bug was found with `equal?` not returning the expected
result for `UserType`. This has now been changed to `eql?` and tests adapted.