### PR TITLE
Requiring Raven and getting rid of the test fakes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0'
 gem 'responders'
 gem 'sass-rails', '~> 5.0'
-gem 'sentry-raven', require: false
+gem 'sentry-raven'
 gem 'uglifier', '>= 1.3.0'
 gem 'uk_postcode'
 gem 'virtus'

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,6 +1,5 @@
 # :nocov:
 if %w( production ).include?(Rails.env) && ENV['SENTRY_DSN'].present?
-  require 'raven'
   Raven.configure do |config|
     config.dsn = ENV['SENTRY_DSN']
     config.environments = %w( production )

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe ApplicationController do
     def another_exception; raise Exception; end
   end
 
-  # So we don't need to require the gem in these test scenarios
-  class Raven
-    def self.capture_exception(_ex); end;
-  end
-
   context 'Exceptions handling' do
     before do
       allow(Rails).to receive(:env).and_return('production'.inquiry)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,8 +23,3 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
-
-# So we don't need to require the gem in test scenarios
-class Raven
-  def self.capture_exception(_ex); end;
-end


### PR DESCRIPTION
After this change, running the app and tests in local will show the following DEBUG message:

> INFO -- sentry: ** [Raven] Raven 2.3.0 configured not to capture errors: DSN not set

This is expected and fine. A bit annoying maybe but fine, as we don't really want to send anything to Sentry when running the app on local.