### PR TITLE
Implement new money-laundering flow

### DIFF
--- a/app/forms/steps/appeal/dispute_type_form.rb
+++ b/app/forms/steps/appeal/dispute_type_form.rb
@@ -9,32 +9,55 @@ module Steps::Appeal
     def choices
       case tribunal_case&.case_type
       when CaseType::INFORMATION_NOTICE
-        [
-          DisputeType::PENALTY,
-          DisputeType::INFORMATION_NOTICE,
-          DisputeType::OTHER
-        ]
+        information_notice_choices
       when CaseType::INCOME_TAX
-        [
-          DisputeType::PENALTY,
-          DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
-          DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
-          DisputeType::AMOUNT_AND_PENALTY,
-          DisputeType::PAYE_CODING_NOTICE,
-          DisputeType::OTHER
-        ]
+        income_tax_choices
+      when CaseType::MONEY_LAUNDERING_DECISIONS
+        money_laundering_choices
       else
-        [
-          DisputeType::PENALTY,
-          DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
-          DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
-          DisputeType::AMOUNT_AND_PENALTY,
-          DisputeType::OTHER
-        ]
+        default_choices
       end.map(&:to_s)
     end
 
     private
+
+    def information_notice_choices
+      [
+        DisputeType::PENALTY,
+        DisputeType::INFORMATION_NOTICE,
+        DisputeType::OTHER
+     ]
+    end
+
+    def income_tax_choices
+      [
+        DisputeType::PENALTY,
+        DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
+        DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
+        DisputeType::AMOUNT_AND_PENALTY,
+        DisputeType::PAYE_CODING_NOTICE,
+        DisputeType::OTHER
+      ]
+    end
+
+    def money_laundering_choices
+      [
+        DisputeType::PENALTY,
+        DisputeType::REFUSAL_TO_REGISTER_APPLICANT,
+        DisputeType::CANCELLATION_OF_REGISTRATION,
+        DisputeType::OTHER
+      ]
+    end
+
+    def default_choices
+      [
+        DisputeType::PENALTY,
+        DisputeType::AMOUNT_OF_TAX_OWED_BY_HMRC,
+        DisputeType::AMOUNT_OF_TAX_OWED_BY_TAXPAYER,
+        DisputeType::AMOUNT_AND_PENALTY,
+        DisputeType::OTHER
+      ]
+    end
 
     def dispute_type_value
       DisputeType.new(dispute_type)

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -55,7 +55,7 @@ class CaseType < ValueObject
     INSURANCE_PREMIUM_TAX        = new(:insurance_premium_tax,        indirect_tax_properties),
     LANDFILL_TAX                 = new(:landfill_tax,                 indirect_tax_properties),
     LOTTERY_DUTY                 = new(:lottery_duty,                 indirect_tax_properties),
-    MONEY_LAUNDERING_DECISIONS   = new(:money_laundering_decisions,   direct_tax: true, ask_hardship: true, appeal_or_application: :appeal),
+    MONEY_LAUNDERING_DECISIONS   = new(:money_laundering_decisions,   ask_dispute_type: true, ask_challenged: true, appeal_or_application: :appeal),
     NI_CONTRIBUTIONS             = new(:ni_contributions,             direct_tax_properties),
     PETROLEUM_REVENUE_TAX        = new(:petroleum_revenue_tax,        direct_tax_properties),
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),

--- a/app/value_objects/dispute_type.rb
+++ b/app/value_objects/dispute_type.rb
@@ -6,6 +6,8 @@ class DisputeType < ValueObject
     AMOUNT_AND_PENALTY             = new(:amount_and_penalty),
     PAYE_CODING_NOTICE             = new(:paye_coding_notice),
     INFORMATION_NOTICE             = new(:information_notice),
+    REFUSAL_TO_REGISTER_APPLICANT  = new(:refusal_to_register_applicant),
+    CANCELLATION_OF_REGISTRATION   = new(:cancellation_of_registration),
     OTHER                          = new(:other)
   ].freeze
 

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -186,6 +186,8 @@ en:
           amount_and_penalty_html: <strong>HMRC claim you owe tax and a penalty or surcharge</strong><br>both must be shown on the same letter
           paye_coding_notice_html: <strong>Pay As You Earn (PAYE) coding notice</strong><br>the code used to work out how much tax is taken from your pay
           information_notice_html: <strong>Appeal against an information notice</strong>
+          refusal_to_register_applicant_html: <strong>Refusal to register an applicant</strong>
+          cancellation_of_registration_html: <strong>Cancellation of registration</strong>
           other_html: <strong>None of the above</strong>
       steps_appeal_penalty_amount_form:
         penalty_amount: What is the penalty or surcharge amount? (Optional)

--- a/spec/forms/steps/appeal/dispute_type_form_spec.rb
+++ b/spec/forms/steps/appeal/dispute_type_form_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe Steps::Appeal::DisputeTypeForm do
       end
     end
 
+    context 'when the appeal is about money laundering' do
+      let(:case_type) { CaseType::MONEY_LAUNDERING_DECISIONS }
+
+      it 'shows only the relevant choices' do
+        expect(subject.choices).to eq(%w(
+          penalty
+          refusal_to_register_applicant
+          cancellation_of_registration
+          other
+        ))
+      end
+    end
+
     context 'when the appeal is about anything else' do
       let(:case_type) { CaseType.new(:anything) }
 

--- a/spec/value_objects/dispute_type_spec.rb
+++ b/spec/value_objects/dispute_type_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe DisputeType do
         amount_of_tax_owed_by_taxpayer
         amount_and_penalty
         paye_coding_notice
-        information_notice other
+        information_notice
+        refusal_to_register_applicant
+        cancellation_of_registration
+        other
       ))
     end
   end


### PR DESCRIPTION
- Money-laundering flow asks whether the user has challenged (but
  doesn't kick them out if they haven't)
- Dispute types include new "refusal to register an applicant" and
  "cancellation of registration", as well as "penalty or surchage"