### PR TITLE
Support for appending optional css classes in step_form.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,13 @@ module ApplicationHelper
       method: :put
     }.merge(options)
 
+    # Support for appending optional css classes, maintaining the default one
+    opts.merge!(
+      html: { class: dom_class(record, :edit) }
+    ) do |_key, old_value, new_value|
+      { class: old_value.values | new_value.values }
+    end
+
     form_for record, opts, &block
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,13 +8,16 @@ class ActionView::TestCase::TestController
 end
 
 RSpec.describe ApplicationHelper do
-  let(:record) { double('Record') }
+  let(:record) { TribunalCase.new }
 
   describe '#step_form' do
     let(:expected_defaults) { {
       url: {
         controller: "application",
         action: :update
+      },
+      html: {
+        class: 'edit_tribunal_case'
       },
       method: :put
     } }
@@ -30,6 +33,11 @@ RSpec.describe ApplicationHelper do
     it 'accepts additional options like FormHelper#form_for would' do
       expect(helper).to receive(:form_for).with(record, expected_defaults.merge(foo: 'bar'))
       helper.step_form(record, { foo: 'bar' })
+    end
+
+    it 'appends optional css classes if provided' do
+      expect(helper).to receive(:form_for).with(record, expected_defaults.merge(html: {class: %w(test edit_tribunal_case)}))
+      helper.step_form(record, html: {class: 'test'})
     end
   end
 


### PR DESCRIPTION
There is a need in some places to provide extra css classes to the form generated
by `step_form`, but passing extra `html: {css: 'xxx'}` options will overwrite the
auto-generated one. This PR will allow appending classes, maintaining any previous one.