### PR TITLE
fix doc upload float bug on small screens

### DIFF
--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -9,3 +9,25 @@
 .sticky-wrapper {
   clear: both;
 }
+
+
+/* clearfix */
+/* http://nicolasgallagher.com/micro-clearfix-hack/ */
+/**
+ * For modern browsers
+ * 1. The space content is one way to avoid an Opera bug when the
+ *    contenteditable attribute is included anywhere else in the document.
+ *    Otherwise it causes space to appear at the top and bottom of elements
+ *    that are clearfixed.
+ * 2. The use of `table` rather than `block` is only necessary if using
+ *    `:before` to contain the top-margins of child elements.
+ */
+.cf:before,
+.cf:after {
+    content: " "; /* 1 */
+    display: table; /* 2 */
+}
+
+.cf:after {
+    clear: both;
+}

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -17,7 +17,7 @@
 
     <%= render partial: 'steps/shared/dropzone', locals: { document_list: @document_list } %>
 
-    <%= step_form @form_object do |f| %>
+    <%= step_form @form_object, html: { class: 'cf' } do |f| %>
         <div class="form-group supplied_letters_checkboxes">
           <%= f.label :original_notice_provided, class: 'block-label selection-button-checkbox' do %>
             <%= f.check_box :original_notice_provided, form: 'new_steps_details_documents_checklist_form' %>


### PR DESCRIPTION
the sidebar on the supporting documents page had a float bug on small screens

Before
---
![screen shot 2017-03-06 at 16 35 32](https://cloud.githubusercontent.com/assets/988436/23619269/0d931858-028b-11e7-9c23-e54d5501a7f8.png)

After
---
![screen shot 2017-03-06 at 16 35 13](https://cloud.githubusercontent.com/assets/988436/23619282/12c5044e-028b-11e7-9577-7fac951b5c77.png)

