### PR TITLE
Fixing the logic behind who receive the email and contact names.

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -11,8 +11,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_template(CASE_CONFIRMATION_TEMPLATE_ID)
 
     set_personalisation(
-      first_name: mail_presenter.recipient_first_name,
-      last_name: mail_presenter.recipient_last_name,
+      recipient_name: mail_presenter.recipient_name,
       case_reference: mail_presenter.case_reference,
       show_case_reference: mail_presenter.show_case_reference?,
       appeal_or_application: mail_presenter.appeal_or_application

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -18,17 +18,21 @@ class CaseMailPresenter < SimpleDelegator
     started_by_representative? ? representative_contact_email : taxpayer_contact_email
   end
 
-  # Same logic as recipient email
-  def recipient_first_name
-    started_by_representative? ? representative_individual_first_name : taxpayer_individual_first_name
-  end
-
-  # Same logic as recipient email
-  def recipient_last_name
-    started_by_representative? ? representative_individual_last_name : taxpayer_individual_last_name
+  def recipient_name
+    started_by_representative? ? representative_contact_name : taxpayer_contact_name
   end
 
   private
+
+  def representative_contact_name
+    return representative_organisation_fao if representative_is_organisation?
+    [representative_individual_first_name, representative_individual_last_name].join(' ')
+  end
+
+  def taxpayer_contact_name
+    return taxpayer_organisation_fao if taxpayer_is_organisation?
+    [taxpayer_individual_first_name, taxpayer_individual_last_name].join(' ')
+  end
 
   def tribunal_case
     __getobj__

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -7,46 +7,29 @@ RSpec.describe NotifyMailer, type: :mailer do
       {
         intent: intent,
         user_type: user_type,
+        taxpayer_type: taxpayer_type,
+        representative_type: representative_type,
         case_reference: case_reference,
         taxpayer_contact_email: 'taxpayer@example.com',
         taxpayer_individual_first_name: 'John',
-        taxpayer_individual_last_name: 'Harrison',
-        representative_contact_email: 'representative@example.com',
-        representative_individual_first_name: 'Stewart',
-        representative_individual_last_name: 'Quinten',
+        taxpayer_individual_last_name: 'Harrison'
       }
     }
     let(:intent) { Intent::TAX_APPEAL }
     let(:user_type) { UserType::TAXPAYER }
+    let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
+    let(:representative_type) { ContactableEntityType::INDIVIDUAL }
     let(:case_reference) { 'TC/2017/00001' }
 
     let(:mail) { described_class.taxpayer_case_confirmation(tribunal_case) }
 
     it_behaves_like 'a Notify mail', template_id: 'e64e9db9-d344-4041-a7df-135fbd39fa56'
 
-    context 'for a taxpayer' do
-      it 'sets the right recipient' do
-        expect(mail.to).to eq(['taxpayer@example.com'])
-      end
-
+    context 'personalisation' do
       it 'sets the personalisation' do
-        expect(mail.govuk_notify_personalisation).to match({
-          first_name: 'John', last_name: 'Harrison', case_reference: 'TC/2017/00001', show_case_reference: 'yes', appeal_or_application: :appeal
-        })
-      end
-    end
-
-    context 'for a representative' do
-      let(:user_type) { UserType::REPRESENTATIVE }
-
-      it 'sets the right recipient' do
-        expect(mail.to).to eq(['representative@example.com'])
-      end
-
-      it 'sets the personalisation' do
-        expect(mail.govuk_notify_personalisation).to match({
-          first_name: 'Stewart', last_name: 'Quinten', case_reference: 'TC/2017/00001', show_case_reference: 'yes', appeal_or_application: :appeal
-        })
+        expect(
+          mail.govuk_notify_personalisation.keys
+        ).to eq([:recipient_name, :case_reference, :show_case_reference, :appeal_or_application])
       end
     end
 

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -7,16 +7,22 @@ RSpec.describe CaseMailPresenter do
   let(:tribunal_case_attributes) {
     {
       user_type: user_type,
+      taxpayer_type: taxpayer_type,
+      representative_type: representative_type,
       case_reference: case_reference,
       taxpayer_contact_email: 'taxpayer@example.com',
       taxpayer_individual_first_name: 'John',
       taxpayer_individual_last_name: 'Harrison',
+      taxpayer_organisation_fao: 'TP Org Fao',
       representative_contact_email: 'representative@example.com',
       representative_individual_first_name: 'Stewart',
       representative_individual_last_name: 'Quinten',
+      representative_organisation_fao: 'Rep Org Fao'
     }
   }
-  let(:user_type) { UserType::TAXPAYER }
+  let(:user_type) { nil }
+  let(:taxpayer_type) { nil }
+  let(:representative_type) { nil }
   let(:case_reference) { 'TC/2017/00001' }
 
   describe '#case_reference' do
@@ -42,35 +48,44 @@ RSpec.describe CaseMailPresenter do
   end
 
   describe '#recipient_email' do
-    context 'for a taxpayer filling the form' do
+    context 'when case was started by the taxpayer' do
+      let(:user_type) { UserType::TAXPAYER }
       it { expect(subject.recipient_email).to eq('taxpayer@example.com') }
     end
 
-    context 'for a representative filling the form' do
+    context 'when case was started by a representative' do
       let(:user_type) { UserType::REPRESENTATIVE }
       it { expect(subject.recipient_email).to eq('representative@example.com') }
     end
   end
 
-  describe '#recipient_first_name' do
-    context 'for a taxpayer filling the form' do
-      it { expect(subject.recipient_first_name).to eq('John') }
+  describe '#recipient_name' do
+    context 'when case was started by the taxpayer' do
+      let(:user_type) { UserType::TAXPAYER }
+
+      context 'for an individual filling the form' do
+        let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
+        it { expect(subject.recipient_name).to eq('John Harrison') }
+      end
+
+      context 'for an organisation filling the form' do
+        let(:taxpayer_type) { ContactableEntityType::COMPANY }
+        it { expect(subject.recipient_name).to eq('TP Org Fao') }
+      end
     end
 
-    context 'for a representative filling the form' do
+    context 'when case was started by a representative' do
       let(:user_type) { UserType::REPRESENTATIVE }
-      it { expect(subject.recipient_first_name).to eq('Stewart') }
-    end
-  end
 
-  describe '#recipient_last_name' do
-    context 'for a taxpayer filling the form' do
-      it { expect(subject.recipient_last_name).to eq('Harrison') }
-    end
+      context 'for an individual filling the form' do
+        let(:representative_type) { ContactableEntityType::INDIVIDUAL }
+        it { expect(subject.recipient_name).to eq('Stewart Quinten') }
+      end
 
-    context 'for a representative filling the form' do
-      let(:user_type) { UserType::REPRESENTATIVE }
-      it { expect(subject.recipient_last_name).to eq('Quinten') }
+      context 'for an organisation filling the form' do
+        let(:representative_type) { ContactableEntityType::COMPANY }
+        it { expect(subject.recipient_name).to eq('Rep Org Fao') }
+      end
     end
   end
 end


### PR DESCRIPTION
This PR will ensure we send the email to the correct recipient and also we send
the correct contact name to Notify.

As part of this PR, where previously we were using `((first_name))` and `((last_name))`
Notify variables, now we will only use `((recipient_name))`.

https://www.pivotaltracker.com/story/show/141210885