### PR TITLE
tell dropzone to not even in IE9 or less

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -160,10 +160,6 @@ $(document).ready(function() {
   // trigger stickAtTopWhenScrolling
   GOVUK.stickAtTopWhenScrolling.init();
 
-  // Hide the non-js uploader and show the dropzone one
-  $('.show-when-js-is-loaded').removeClass('js-hidden');
-  $('.hide-when-js-is-loaded').addClass('js-hidden');
-
   // Initialize JS in /modules (this includes the Dropzone custom setup)
   window.moj.init();
 });

--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -10,14 +10,19 @@ moj.Modules.docUpload = {
   init: function() {
     var self = this,
         previewTemplate,
-        dzOptions;
+        dzOptions,
+        isLowIE = $('html').hasClass('lte-ie9');
 
     Dropzone.autoDiscover = false;
 
     self.$form = $('#' + self.form_id);
     self.$fileList = $(self.uploaded_files);
 
-    if (!self.$form.length) { return; }
+    if (!self.$form.length || isLowIE) { return; }
+
+    // Hide the non-js uploader and show the dropzone one
+    $('.show-when-js-is-loaded').removeClass('js-hidden');
+    $('.hide-when-js-is-loaded').addClass('js-hidden');
 
     previewTemplate = $(self.preview_template).remove()[0].outerHTML;
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,15 @@
 
 <% content_for(:body_start) do %>
   <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
+
+  <!--
+    it's easier to trigger the non-js dropzone solution than to style and tweak
+    the dropzone fallback to work properly in IE9 and below and the upshot is
+    the same, so add a class to the html element to enable IE9 detection
+  -->
+  <!--[if lte IE 9]>
+  <script>document.documentElement.className = [document.documentElement.className, 'lte-ie9'].join(' ');</script>
+  <![endif]-->
 <% end %>
 
 <% content_for(:content) do %>


### PR DESCRIPTION
Dropzone only works in IE10+, but its fallback is a bit screwed up, and it's less work to just make IE9 and lower use our non-JS solution than fix the Dropzone fallback.

IE9 Before
---
![image](https://cloud.githubusercontent.com/assets/988436/23703517/3ab56b60-03f8-11e7-8d8a-20c613f9ccdd.png)

IE9 After
---
![image](https://cloud.githubusercontent.com/assets/988436/23703538/541e27c2-03f8-11e7-824b-5a10201b2fe3.png)
