### PR TITLE
FTT recipient and mail personalisation when GLiMR submission fails.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ MOJ_FILE_UPLOADER_ENDPOINT=http://localhost:9292
 TAX_TRIBUNALS_DOWNLOADER_URL=http://localhost:9393
 GLIMR_API_URL=https://[hostname]/Live_API/api/tdsapi
 GOVUK_NOTIFY_API_KEY=notify-api-key
+
+# Used for `GLiMR is down` emails
+TAX_TRIBUNAL_EMAIL=your_email@example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 ENV SENTRY_DSN                   replace_this_at_build_time
 ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
 ENV GA_TRACKING_ID               replace_this_at_build_time
+ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 
 RUN touch /etc/inittab
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -7,8 +7,10 @@ ENV GLIMR_API_URL                replace_this_at_build_time
 ENV PAYMENT_ENDPOINT             replace_this_at_build_time
 ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
+ENV SENTRY_DSN                   replace_this_at_build_time
 ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
 ENV GA_TRACKING_ID               replace_this_at_build_time
+ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 
 RUN touch /etc/inittab
 

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -20,14 +20,18 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: mail_presenter.recipient_email)
   end
 
-  def ftt_new_case_notification(_tribunal_case)
+  def ftt_new_case_notification(tribunal_case)
+    mail_presenter = CaseMailPresenter.new(tribunal_case)
+
     set_template(FTT_CASE_NOTIFICATION_TEMPLATE_ID)
 
-    # TODO: waiting for template to be completed
-    # set_personalisation(
-    # )
+    set_personalisation(
+      recipient_name: mail_presenter.recipient_name,
+      company_name: mail_presenter.company_name,
+      show_company_name: mail_presenter.show_company_name?,
+      documents_url: mail_presenter.documents_url
+    )
 
-    # TODO: once we open the beta, change to: Rails.configuration.tax_tribunal_email
-    mail(to: 'jesus.laiz+ftt@digital.justice.gov.uk')
+    mail(to: mail_presenter.ftt_recipient_email)
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -35,6 +35,10 @@ class TribunalCase < ApplicationRecord
     Document.for_collection(files_collection_ref, document_key: document_key)
   end
 
+  def documents_url
+    [ENV.fetch('TAX_TRIBUNALS_DOWNLOADER_URL'), files_collection_ref].join('/')
+  end
+
   def taxpayer_is_organisation?
     taxpayer_type.organisation?
   end

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -2,9 +2,8 @@ class CaseMailPresenter < SimpleDelegator
   # Initialise with a TribunalCase instance and any method not
   # defined in this class will be forwarded automatically to that instance.
 
-  # GOV.UK Notify expects this to be literals
   def show_case_reference?
-    case_reference.present? ? 'yes' : 'no'
+    notify_presence_for(case_reference)
   end
 
   # GOV.UK Notify does not accept `nil` values, instead use empty strings
@@ -22,6 +21,20 @@ class CaseMailPresenter < SimpleDelegator
     started_by_representative? ? representative_contact_name : taxpayer_contact_name
   end
 
+  def show_company_name?
+    notify_presence_for(company_name)
+  end
+
+  # GOV.UK Notify does not accept `nil` values, instead use empty strings
+  def company_name
+    (started_by_representative? ? representative_organisation_name : taxpayer_organisation_name).to_s
+  end
+
+  # Email address to use for `GLiMR is down` notifications
+  def ftt_recipient_email
+    ENV.fetch('TAX_TRIBUNAL_EMAIL')
+  end
+
   private
 
   def representative_contact_name
@@ -32,6 +45,11 @@ class CaseMailPresenter < SimpleDelegator
   def taxpayer_contact_name
     return taxpayer_organisation_fao if taxpayer_is_organisation?
     [taxpayer_individual_first_name, taxpayer_individual_last_name].join(' ')
+  end
+
+  # GOV.UK Notify expects this to be literals
+  def notify_presence_for(field)
+    field.present? ? 'yes' : 'no'
   end
 
   def tribunal_case

--- a/app/services/glimr_new_case.rb
+++ b/app/services/glimr_new_case.rb
@@ -27,7 +27,7 @@ class GlimrNewCase
       contactPhone: tc.taxpayer_contact_phone,
       contactEmail: tc.taxpayer_contact_email,
       contactPostalCode: tc.taxpayer_contact_postcode,
-      documentsURL: documents_url
+      documentsURL: tc.documents_url
     }
 
     params.merge!(taxpayer_street_params)
@@ -49,10 +49,6 @@ class GlimrNewCase
 
   def jurisdiction_id
     GlimrApiClient::Case::TRIBUNAL_JURISDICTION_ID
-  end
-
-  def documents_url
-    [ENV.fetch('TAX_TRIBUNALS_DOWNLOADER_URL'), tc.files_collection_ref].join('/')
   end
 
   # contactStreetX are indexed 1 to 4, so if there are more lines than available

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -1,26 +1,26 @@
 require 'spec_helper'
 
 RSpec.describe NotifyMailer, type: :mailer do
-  describe 'taxpayer_case_confirmation' do
-    let(:tribunal_case) { TribunalCase.new(tribunal_case_attributes) }
-    let(:tribunal_case_attributes) {
-      {
-        intent: intent,
-        user_type: user_type,
-        taxpayer_type: taxpayer_type,
-        representative_type: representative_type,
-        case_reference: case_reference,
-        taxpayer_contact_email: 'taxpayer@example.com',
-        taxpayer_individual_first_name: 'John',
-        taxpayer_individual_last_name: 'Harrison'
-      }
+  let(:tribunal_case) { TribunalCase.new(tribunal_case_attributes) }
+  let(:tribunal_case_attributes) {
+    {
+      intent: intent,
+      user_type: user_type,
+      taxpayer_type: taxpayer_type,
+      representative_type: representative_type,
+      case_reference: case_reference,
+      taxpayer_contact_email: 'taxpayer@example.com',
+      taxpayer_individual_first_name: 'John',
+      taxpayer_individual_last_name: 'Harrison'
     }
-    let(:intent) { Intent::TAX_APPEAL }
-    let(:user_type) { UserType::TAXPAYER }
-    let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
-    let(:representative_type) { ContactableEntityType::INDIVIDUAL }
-    let(:case_reference) { 'TC/2017/00001' }
+  }
+  let(:intent) { Intent::TAX_APPEAL }
+  let(:user_type) { UserType::TAXPAYER }
+  let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
+  let(:representative_type) { ContactableEntityType::INDIVIDUAL }
+  let(:case_reference) { 'TC/2017/00001' }
 
+  describe 'taxpayer_case_confirmation' do
     let(:mail) { described_class.taxpayer_case_confirmation(tribunal_case) }
 
     it_behaves_like 'a Notify mail', template_id: 'e64e9db9-d344-4041-a7df-135fbd39fa56'
@@ -43,13 +43,25 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe 'ftt_new_case_notification' do
-    let(:tribunal_case) { instance_double(TribunalCase) }
     let(:mail) { described_class.ftt_new_case_notification(tribunal_case) }
+
+    before do
+      expect(tribunal_case).to receive(:documents_url)
+      allow(ENV).to receive(:fetch).with('TAX_TRIBUNAL_EMAIL').and_return('ftt@email.com')
+    end
 
     it_behaves_like 'a Notify mail', template_id: '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f'
 
-    it 'sets the right recipient' do
-      expect(mail.to).to eq(['jesus.laiz+ftt@digital.justice.gov.uk'])
+    context 'recipient' do
+      it { expect(mail.to).to eq(['ftt@email.com']) }
+    end
+
+    context 'personalisation' do
+      it 'sets the personalisation' do
+        expect(
+          mail.govuk_notify_personalisation.keys
+        ).to eq([:recipient_name, :company_name, :show_company_name, :documents_url])
+      end
     end
   end
 end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe TribunalCase, type: :model do
     end
   end
 
+  describe '#documents_url' do
+    let(:collection_ref) { SecureRandom.uuid }
+    let(:attributes) { { files_collection_ref: collection_ref } }
+
+    it 'should retrieve the base url from the ENV and append the files collection ref' do
+      expect(ENV).to receive(:fetch).with('TAX_TRIBUNALS_DOWNLOADER_URL').and_return('http://downloader.com')
+      expect(subject.documents_url).to eq("http://downloader.com/#{collection_ref}")
+    end
+  end
+
   describe '#taxpayer_is_organisation?' do
     let(:taxpayer_type) { OpenStruct.new(organisation?: true, value: :anything) }
     let(:attributes) { { taxpayer_type: taxpayer_type } }

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -13,16 +13,15 @@ RSpec.describe CaseMailPresenter do
       taxpayer_contact_email: 'taxpayer@example.com',
       taxpayer_individual_first_name: 'John',
       taxpayer_individual_last_name: 'Harrison',
-      taxpayer_organisation_fao: 'TP Org Fao',
       representative_contact_email: 'representative@example.com',
       representative_individual_first_name: 'Stewart',
-      representative_individual_last_name: 'Quinten',
-      representative_organisation_fao: 'Rep Org Fao'
-    }
+      representative_individual_last_name: 'Quinten'
+    }.merge(additional_attributes)
   }
   let(:user_type) { nil }
   let(:taxpayer_type) { nil }
   let(:representative_type) { nil }
+  let(:additional_attributes) { {} }
   let(:case_reference) { 'TC/2017/00001' }
 
   describe '#case_reference' do
@@ -70,6 +69,8 @@ RSpec.describe CaseMailPresenter do
 
       context 'for an organisation filling the form' do
         let(:taxpayer_type) { ContactableEntityType::COMPANY }
+        let(:additional_attributes) { {taxpayer_organisation_fao: 'TP Org Fao'} }
+
         it { expect(subject.recipient_name).to eq('TP Org Fao') }
       end
     end
@@ -84,8 +85,69 @@ RSpec.describe CaseMailPresenter do
 
       context 'for an organisation filling the form' do
         let(:representative_type) { ContactableEntityType::COMPANY }
+        let(:additional_attributes) { {representative_organisation_fao: 'Rep Org Fao'} }
+
         it { expect(subject.recipient_name).to eq('Rep Org Fao') }
       end
+    end
+  end
+
+  describe '#company_name' do
+    context 'when case was started by the taxpayer' do
+      let(:user_type) { UserType::TAXPAYER }
+
+      context 'for an individual filling the form' do
+        let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
+        it { expect(subject.company_name).to eq('') }
+      end
+
+      context 'for an organisation filling the form' do
+        let(:taxpayer_type) { ContactableEntityType::COMPANY }
+        let(:additional_attributes) { {taxpayer_organisation_name: 'TP Org Name'} }
+
+        it { expect(subject.company_name).to eq('TP Org Name') }
+      end
+    end
+
+    context 'when case was started by a representative' do
+      let(:user_type) { UserType::REPRESENTATIVE }
+
+      context 'for an individual filling the form' do
+        let(:representative_type) { ContactableEntityType::INDIVIDUAL }
+        it { expect(subject.company_name).to eq('') }
+      end
+
+      context 'for an organisation filling the form' do
+        let(:representative_type) { ContactableEntityType::COMPANY }
+        let(:additional_attributes) { {representative_organisation_name: 'Rep Org Name'} }
+
+        it { expect(subject.company_name).to eq('Rep Org Name') }
+      end
+    end
+  end
+
+  describe '#show_company_name?' do
+    context 'for a case with a company name' do
+      before do
+        expect(subject).to receive(:company_name).and_return('Company Ltd.')
+      end
+
+      it { expect(subject.show_company_name?).to eq('yes') }
+    end
+
+    context 'for a case without a company name' do
+      before do
+        expect(subject).to receive(:company_name).and_return('')
+      end
+
+      it { expect(subject.show_company_name?).to eq('no') }
+    end
+  end
+
+  describe '#ftt_recipient_email' do
+    it 'should retrieve it from the ENV' do
+      expect(ENV).to receive(:fetch).with('TAX_TRIBUNAL_EMAIL')
+      subject.ftt_recipient_email
     end
   end
 end

--- a/spec/services/glimr_new_case_spec.rb
+++ b/spec/services/glimr_new_case_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe GlimrNewCase do
     end
 
     before do
-      allow(ENV).to receive(:fetch).with('TAX_TRIBUNALS_DOWNLOADER_URL').and_return('http://downloader.com')
+      allow(tribunal_case).to receive(:documents_url).and_return('http://downloader.com/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687')
       expect(GlimrApiClient::RegisterNewCase).to receive(:call).
           with(hash_including(glimr_params)).and_return(glimr_response_double)
     end


### PR DESCRIPTION
Moving the hardcoded FTT address to an ENV variable, and adding the personalisation
to the Notify email template.