### PR TITLE
add details polyfill and shame.css

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require dropzone
+//= require details.polyfill
 //= require_tree .
 
 //= require govuk_toolkit

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,6 +38,8 @@
 @import 'elements/phase-banner';
 @import 'elements/components';
 
+@import 'elements/shame';
+
 @import 'local/developer_tools';
 @import 'local/tables';
 @import 'local/lists';


### PR DESCRIPTION
The `<details>` element polyfill is still needed for IE, and [`_shame.scss`](https://github.com/alphagov/govuk_elements/blob/master/public/sass/elements/_shame.scss) is also needed for the arrow to show up in Firefox.