### PR TITLE
Enable smoketesting from Jenkins

### DIFF
--- a/Dockerfile.smoketests
+++ b/Dockerfile.smoketests
@@ -1,0 +1,8 @@
+FROM ruby:2.3.1-onbuild
+
+RUN touch /etc/inittab
+
+ENV DATACAPTURE_URI https://tax-tribunals-datacapture-dev.dsd.io
+RUN apt-get update && apt-get install -y
+
+CMD bundle exec cucumber

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :test do
   gem 'capybara'
   gem 'cucumber'
   gem 'poltergeist'
+  gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'rails-controller-testing'
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
@@ -58,3 +59,4 @@ group :test do
   gem 'simplecov-rcov'
   gem 'webmock'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,7 @@ GEM
     parser (2.3.2.0)
       ast (~> 2.2)
     pg (0.19.0)
+    phantomjs (2.1.1.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -395,6 +396,7 @@ DEPENDENCIES
   mojfile-uploader-api-client (~> 0.1)
   mutant-rspec
   pg (~> 0.18)
+  phantomjs
   poltergeist
   pry-byebug
   pry-rails

--- a/smoke_tests/README.md
+++ b/smoke_tests/README.md
@@ -14,7 +14,7 @@ bundle exec cucumber
 
 ### Running on CI
 
-The script for running the Docker contain on MoJ's CI is as follows:
+The script for running the Docker container on MoJ's CI is as follows:
 
 ```bash
 #!/bin/bash

--- a/smoke_tests/README.md
+++ b/smoke_tests/README.md
@@ -12,6 +12,21 @@ export DATACAPTURE_URI=https://tax-tribunals-datacapture-dev.dsd.io
 bundle exec cucumber
 ```
 
+### Running on CI
+
+The script for running the Docker contain on MoJ's CI is as follows:
+
+```bash
+#!/bin/bash
+
+set -euo pipefail
+
+docker build -f Dockerfile.smoketests -t smoketests .;
+docker run smoketests
+```
+
+
+
 ## Caution
 
 The smoke tests create new cases on GLiMR. Do not run them against the

--- a/smoke_tests/README.md
+++ b/smoke_tests/README.md
@@ -21,7 +21,7 @@ The script for running the Docker container on MoJ's CI is as follows:
 
 set -euo pipefail
 
-docker build -f Dockerfile.smoketests -t smoketests .;
+docker build -f Dockerfile.smoketests -t smoketests .
 docker run smoketests
 ```
 

--- a/smoke_tests/support/env.rb
+++ b/smoke_tests/support/env.rb
@@ -1,3 +1,4 @@
+require 'phantomjs'
 require 'capybara'
 require 'capybara/dsl'
 require 'capybara/cucumber'
@@ -8,7 +9,11 @@ Capybara.run_server = false
 Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
 
-options = {js_errors: false}
+options = {
+  js_errors: false,
+  phantomjs: Phantomjs.path
+}
+
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, options)
 end


### PR DESCRIPTION
At the time of writing, Jenkins uses an outdated version of ruby. This
makes it difficult to install some of the gems required for the smoke
tests.  It also lacks PhantomJS, as well as the dependencies needed to
build it from scratch (bzip).

However, building a docker container is something it already does in a
well-understood way.  This push builds a container, which then runs all
the smoke tests.

Note: I experimented with skipping the development dependencies, but
decided against as this required a more complex `Dockerfile`, but did
not significantly reduce the container build time.