### PR TITLE
Moving Notify template IDs from constants to ENV variables.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,8 @@ TAX_TRIBUNALS_DOWNLOADER_URL=http://localhost:9393
 GLIMR_API_URL=https://[hostname]/Live_API/api/tdsapi
 GOVUK_NOTIFY_API_KEY=notify-api-key
 
+NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID=fa138a1a-5bea-4b01-993f-f25927363d02
+NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID=c2362d14-f99e-4420-b102-8d297dd3a62f
+
 # Used for `GLiMR is down` emails
 TAX_TRIBUNAL_EMAIL=your_email@example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
 ENV GA_TRACKING_ID               replace_this_at_build_time
 ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 
+ENV NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID        replace_this_at_build_time
+ENV NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID    replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN apt-get update && apt-get install -y

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -12,6 +12,9 @@ ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
 ENV GA_TRACKING_ID               replace_this_at_build_time
 ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 
+ENV NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID        replace_this_at_build_time
+ENV NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID    replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN apt-get update && apt-get install -y

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,14 +1,11 @@
 class NotifyMailer < GovukNotifyRails::Mailer
-  CASE_CONFIRMATION_TEMPLATE_ID = 'e64e9db9-d344-4041-a7df-135fbd39fa56'.freeze
-  FTT_CASE_NOTIFICATION_TEMPLATE_ID = '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f'.freeze
-
   # Define methods as usual, and set the template and personalisation, if needed,
   # then just use mail() as with any other ActionMailer, with the recipient email
   #
   def taxpayer_case_confirmation(tribunal_case)
     mail_presenter = CaseMailPresenter.new(tribunal_case)
 
-    set_template(CASE_CONFIRMATION_TEMPLATE_ID)
+    set_template(ENV.fetch('NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID'))
 
     set_personalisation(
       recipient_name: mail_presenter.recipient_name,
@@ -23,7 +20,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
   def ftt_new_case_notification(tribunal_case)
     mail_presenter = CaseMailPresenter.new(tribunal_case)
 
-    set_template(FTT_CASE_NOTIFICATION_TEMPLATE_ID)
+    set_template(ENV.fetch('NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID'))
 
     set_personalisation(
       recipient_name: mail_presenter.recipient_name,

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -20,10 +20,15 @@ RSpec.describe NotifyMailer, type: :mailer do
   let(:representative_type) { ContactableEntityType::INDIVIDUAL }
   let(:case_reference) { 'TC/2017/00001' }
 
+  before do
+    allow(ENV).to receive(:fetch).with('NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID').and_return('confirmation-template')
+    allow(ENV).to receive(:fetch).with('NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID').and_return('ftt-notification-template')
+  end
+
   describe 'taxpayer_case_confirmation' do
     let(:mail) { described_class.taxpayer_case_confirmation(tribunal_case) }
 
-    it_behaves_like 'a Notify mail', template_id: 'e64e9db9-d344-4041-a7df-135fbd39fa56'
+    it_behaves_like 'a Notify mail', template_id: 'confirmation-template'
 
     context 'personalisation' do
       it 'sets the personalisation' do
@@ -50,7 +55,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       allow(ENV).to receive(:fetch).with('TAX_TRIBUNAL_EMAIL').and_return('ftt@email.com')
     end
 
-    it_behaves_like 'a Notify mail', template_id: '50d09d1e-4e61-4ad3-9697-836b8cbb9f1f'
+    it_behaves_like 'a Notify mail', template_id: 'ftt-notification-template'
 
     context 'recipient' do
       it { expect(mail.to).to eq(['ftt@email.com']) }


### PR DESCRIPTION
They need to be specified per-environment and we can't really use the same UUID for
all the environments.