### PR TITLE
Rescue and send to Sentry unexpected exceptions on mailers.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,6 +16,7 @@ Rails.application.configure do
 
   config.log_tags = [ :request_id ]
   config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = true
   config.i18n.fallbacks = true
 
   config.active_support.deprecation = :notify


### PR DESCRIPTION
This will ensure we are notified about any possible exceptions happening on the
`NotifyMailer`, i.e. missing personalisation, template not found, etc.

We will append extra context to the Raven event to know which template triggered the
exception and if any, the personalisation sent (some details filtered out for privacy).

https://www.pivotaltracker.com/story/show/141211793