### PR TITLE
Use correct errors from uploader gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.1)
-    mojfile-uploader-api-client (0.4)
+    mojfile-uploader-api-client (0.5)
       rest-client (~> 2.0.0)
     morpher (0.2.6)
       abstract_type (~> 0.0.7)

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -51,7 +51,10 @@ class DocumentUpload
     )
   rescue Uploader::InfectedFileError
     add_error(:virus_detected)
-  rescue Uploader::UploaderError
+  rescue Uploader::UploaderError => e
+    # For generic upload errors (other than infected), we want to keep track of what happened
+    Raven.capture_exception(e)
+
     add_error(:response_error)
   end
 

--- a/spec/models/document_upload_spec.rb
+++ b/spec/models/document_upload_spec.rb
@@ -142,8 +142,9 @@ RSpec.describe DocumentUpload do
 
     context 'with error' do
       context 'response error' do
+        let(:error) { double("Upstream error", code: 418, body: "Is it coffee you're looking for?") }
         it 'should upload the document' do
-          expect(Uploader).to receive(:add_file).and_raise(Uploader::UploaderError)
+          expect(Uploader).to receive(:add_file).and_raise(Uploader::UploaderError, error)
           expect(subject).to receive(:add_error).with(:response_error).and_call_original
           subject.upload!(collection_ref: '123')
           expect(subject.errors?).to eq(true)

--- a/spec/services/uploader_spec.rb
+++ b/spec/services/uploader_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Uploader do
   let(:result) { double('result') }
+  let(:error) { MojFileUploaderApiClient::RequestError.new('message', 'code', 'body') }
 
   describe '.add_file' do
     let(:params) { {
@@ -39,7 +40,7 @@ RSpec.describe Uploader do
         folder: 'doc_key',
         filename: 'file_name.doc',
         data: 'data'
-      ).and_raise(MojFileUploaderApiClient::RequestError)
+      ).and_raise(error)
 
       expect { described_class.add_file(params) }.to raise_error(Uploader::UploaderError)
     end
@@ -67,7 +68,7 @@ RSpec.describe Uploader do
         collection_ref: '123',
         folder: 'doc_key',
         filename: 'file_name.doc'
-      ).and_raise(MojFileUploaderApiClient::RequestError)
+      ).and_raise(error)
 
       expect { described_class.delete_file(params) }.to raise_error(Uploader::UploaderError)
     end
@@ -103,7 +104,7 @@ RSpec.describe Uploader do
       expect(MojFileUploaderApiClient).to receive(:list_files).with(
         collection_ref: '123',
         folder: 'doc_key',
-      ).and_raise(MojFileUploaderApiClient::RequestError)
+      ).and_raise(error)
 
       expect { described_class.list_files(params) }.to raise_error(Uploader::UploaderError)
     end


### PR DESCRIPTION
- Bump `mojfile-uploader-api-client` gem
- Retain information from upstream errors by capturing them in the
  `UploaderError`
- When adding files to supporting documents, send any errors to Raven
  rescuing them