### PR TITLE
fix doc upload show/hide logic for IE versions

### DIFF
--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -18,7 +18,14 @@ moj.Modules.docUpload = {
     self.$form = $('#' + self.form_id);
     self.$fileList = $(self.uploaded_files);
 
-    if (!self.$form.length || isLowIE) { return; }
+    if (!self.$form.length) {
+      return;
+    }
+    if(isLowIE) {
+      $('.js-only').remove();
+      $('.no-js-only').removeClass('no-js-only');
+      return;
+    }
 
     previewTemplate = $(self.preview_template).remove()[0].outerHTML;
 

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -8,7 +8,7 @@
 
     <p><%=t 'shared.file_upload.technical_info' %></p>
 
-    <%= form_tag documents_url(document_key: :supporting_documents), multipart: true, class: 'js-hidden' do %>
+    <%= form_tag documents_url(document_key: :supporting_documents), multipart: true, class: 'no-js-only' do %>
       <%= file_field_tag :document %>
       <%= submit_tag 'Upload', class: 'button' %>
     <% end %>

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -10,7 +10,7 @@
 
     <div id="supplied_letters_placeholder"></div>
 
-    <%= form_tag documents_url(document_key: :supporting_documents), multipart: true, class: 'js-hidden' do %>
+    <%= form_tag documents_url(document_key: :supporting_documents), multipart: true, class: 'no-js-only' do %>
         <%= file_field_tag :document %>
         <%= submit_tag 'Upload', class: 'button' %>
     <% end %>


### PR DESCRIPTION
The logic got in a mess regarding what to show and how for low (<10) versions of IE on the document upload page. IE9 was showing the (non-functional) dropzone.

IE9 before
---
![image](https://cloud.githubusercontent.com/assets/988436/23755534/983ac6c8-04d8-11e7-8ca6-9570aedede01.png)

IE9 after
---
![image](https://cloud.githubusercontent.com/assets/988436/23755557/ab0d6896-04d8-11e7-9575-62e30e112316.png)
