### PR TITLE
'Check your answers' has Grounds for Appeal text and document (if any attached).

### DIFF
--- a/app/presenters/documents_submitted_presenter.rb
+++ b/app/presenters/documents_submitted_presenter.rb
@@ -1,9 +1,9 @@
 class DocumentsSubmittedPresenter < BaseAnswersPresenter
-  def list
-    tribunal_case.documents(:supporting_documents)
+  def list(document_key)
+    tribunal_case.documents(document_key)
   end
 
-  def grounds_for_appeal_text(default: '')
+  def grounds_for_appeal_text(default: nil)
     tribunal_case.grounds_for_appeal.present? ? tribunal_case.grounds_for_appeal : default
   end
 end

--- a/app/views/steps/closure/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/show.pdf.erb
@@ -96,7 +96,7 @@
       <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
       <td class="content">
         <ul class="documents">
-          <% tribunal_case.documents.list.each do |document| %>
+          <% tribunal_case.documents.list(:supporting_documents).each do |document| %>
               <li><%= document.title %></li>
           <% end %>
         </ul>

--- a/app/views/steps/closure/check_answers/show.html.erb
+++ b/app/views/steps/closure/check_answers/show.html.erb
@@ -77,7 +77,7 @@
       <th><%= t '.questions.documents_submitted' %></th>
       <td>
         <ul class="list-bullet uploaded-docs">
-          <% @tribunal_case.documents.list.each do |document| %>
+          <% @tribunal_case.documents.list(:supporting_documents).each do |document| %>
             <li><%= document.title %></li>
           <% end %>
         </ul>

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -109,7 +109,12 @@
     <tr>
       <td class="section"><%= pdf_t '.questions.grounds_for_appeal' %></td>
       <td class="content">
-        <%= tribunal_case.documents.grounds_for_appeal_text(default: pdf_t('.answers.no_grounds_for_appeal_text')) %>
+        <span><%= tribunal_case.documents.grounds_for_appeal_text %></span>
+        <ul class="documents">
+          <% tribunal_case.documents.list(:grounds_for_appeal).each do |document| %>
+            <li><%= document.title %></li>
+          <% end %>
+        </ul>
       </td>
     </tr>
     </tbody>
@@ -122,7 +127,7 @@
       <td class="section"><%= pdf_t '.questions.documents_submitted' %></td>
       <td class="content">
         <ul class="documents">
-          <% tribunal_case.documents.list.each do |document| %>
+          <% tribunal_case.documents.list(:supporting_documents).each do |document| %>
               <li><%= document.title %></li>
           <% end %>
         </ul>

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -78,9 +78,12 @@
   <tr>
     <th><%= translate_with_appeal_or_application '.questions.grounds_for_appeal' %></th>
     <td>
-      <span>
-        <%= @tribunal_case.documents.grounds_for_appeal_text(default: t('.answers.no_grounds_for_appeal_text')) %>
-      </span>
+      <span><%= @tribunal_case.documents.grounds_for_appeal_text %></span>
+      <ul class="list-bullet uploaded-docs">
+        <% @tribunal_case.documents.list(:grounds_for_appeal).each do |document| %>
+          <li><%= document.title %></li>
+        <% end %>
+      </ul>
     </td>
     <td class="change-answer">
       <%= link_to t('.change'), edit_steps_details_grounds_for_appeal_path %>
@@ -103,7 +106,7 @@
     <th><%= t '.questions.documents_submitted' %></th>
     <td>
       <ul class="list-bullet uploaded-docs">
-        <% @tribunal_case.documents.list.each do |document| %>
+        <% @tribunal_case.documents.list(:supporting_documents).each do |document| %>
           <li><%= document.title %></li>
         <% end %>
       </ul>

--- a/spec/presenters/documents_submitted_presenter_spec.rb
+++ b/spec/presenters/documents_submitted_presenter_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe DocumentsSubmittedPresenter do
   let(:grounds_for_appeal) { 'foo' }
 
   describe '#list' do
-    it 'should retrieve any uploaded file' do
-      expect(tribunal_case).to receive(:documents).with(:supporting_documents)
-      subject.list
+    it 'should retrieve any uploaded file for the given documents prefix' do
+      expect(tribunal_case).to receive(:documents).with(:prefix)
+      subject.list(:prefix)
     end
   end
 
@@ -20,21 +20,17 @@ RSpec.describe DocumentsSubmittedPresenter do
       end
     end
 
-    context 'when grounds_for_appeal text is nil' do
+    context 'when grounds_for_appeal text is not present' do
       let(:grounds_for_appeal) { nil }
 
-      it 'should return a default text' do
+      it 'should return a default text if provided' do
         text = subject.grounds_for_appeal_text(default: 'default text')
         expect(text).to eq('default text')
       end
-    end
 
-    context 'when grounds_for_appeal text is blank' do
-      let(:grounds_for_appeal) { '' }
-
-      it 'should return a default text' do
-        text = subject.grounds_for_appeal_text(default: 'default text')
-        expect(text).to eq('default text')
+      it 'should return nil if no default text is provided' do
+        text = subject.grounds_for_appeal_text
+        expect(text).to be_nil
       end
     end
   end


### PR DESCRIPTION
Ensure we show all the relevant information for Grounds for Appeal. If the user enters both
(free text and attach a document) we show both. If only one of these is filled, we will only
show the entered information.

The same approach will be follow for the `hardship reasons` and other steps that contain
text and/or document attachment, in follow-up PR's.

https://www.pivotaltracker.com/story/show/141143223