### PR TITLE
no JS for IE8

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,13 @@
 <% end %>
 
 <% content_for(:body_end) do %>
-  <%= javascript_include_tag 'application' %>
+  <!--[if lte IE 9]>
+  <script>
+    document.body.className = document.body.className.replace("js-enabled","")
+  </script>
+  <![endif]-->
+
+  <!--[if gt IE 8]><!--><%= javascript_include_tag 'application' %><!--<![endif]-->
 <% end %>
 
 <% content_for(:footer_support_links) do %>


### PR DESCRIPTION
IE8 just needs to be functional, and it wasn't. The radio buttons weren't working, dropzone was showing a state halfway between the functional JS version and the non-JS version, and it was non operable.

For sanity's sake, no JS for IE8.