### PR TITLE
the main content area was not centred in IE8

### DIFF
--- a/app/assets/stylesheets/ie8.css
+++ b/app/assets/stylesheets/ie8.css
@@ -1,0 +1,3 @@
+main#content {
+  margin: auto;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,9 @@
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
+  <!--[if lt IE 9]>
+  <%= stylesheet_link_tag 'ie8', media: 'all' %>
+  <![endif]-->
 <% end %>
 
 <% content_for(:header_class) do %>with-proposition<% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,2 +1,4 @@
 
 Rails.application.config.assets.version = '1.0'
+
+Rails.application.config.assets.precompile += %w( ie8.css )


### PR DESCRIPTION
Seems odd for Elements to not cater for this, but meh. It's a tiny fix.

Before
---
![image](https://cloud.githubusercontent.com/assets/988436/23851838/d73e3d12-07dc-11e7-89b4-c364d7258d09.png)

After
---
![image](https://cloud.githubusercontent.com/assets/988436/23851858/ee597a16-07dc-11e7-88cc-1ce769b58b05.png)
