### PR TITLE
fix for Back link spacing (missing arrow) in low IEs

### DIFF
--- a/app/assets/stylesheets/ie8.css
+++ b/app/assets/stylesheets/ie8.css
@@ -1,3 +1,7 @@
 main#content {
   margin: auto;
 }
+
+.link-back {
+  padding-left: 0;
+}


### PR DESCRIPTION
IE8 Before
---
![image](https://cloud.githubusercontent.com/assets/988436/23857389/0a7c88b0-07f5-11e7-9939-b708f224a954.png)

IE8 After
---
![image](https://cloud.githubusercontent.com/assets/988436/23857429/358557d0-07f5-11e7-8f49-4dcf45fb7003.png)
