### PR TITLE
Don't remove js-enabled class for IE9

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
 <% end %>
 
 <% content_for(:body_end) do %>
-  <!--[if lte IE 9]>
+  <!--[if lte IE 8]>
   <script>
     document.body.className = document.body.className.replace("js-enabled","")
   </script>


### PR DESCRIPTION
Got my conditional comments in a muddle and lied to IE9 by mistake.