### PR TITLE
Stop smoketest/local docker compose from breaking

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM ministryofjustice/ruby:2.4.0-webapp-onbuild
+FROM ministryofjustice/ruby:2.3.3-webapp-onbuild
 
 ENV PUMA_PORT 3000
 

--- a/Dockerfile.smoketests
+++ b/Dockerfile.smoketests
@@ -1,4 +1,4 @@
-FROM ruby:2.4.0-onbuild
+FROM ruby:2.3.3-onbuild
 
 RUN touch /etc/inittab
 


### PR DESCRIPTION
We’ve standardised on 2.3.3, but these got missed as they either aren’t
tested at all (docker compose–does not require testing) or are only
excercised late in the Jenkins build pipeline (smoketests).