### PR TITLE
JS-dependant solution for dropzone duplicate file names.

### DIFF
--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -46,6 +46,10 @@ moj.Modules.docUpload = {
       success: function (file, response) {
         self.removeDropzonePreview(file);
         self.addFileToList(response);
+      },
+
+      renameFilename: function (filename) {
+        return self.uniqueFilename(filename);
       }
     };
 
@@ -92,7 +96,9 @@ moj.Modules.docUpload = {
     var self = this;
 
     self.$fileList.find('.no-files').hide();
-    self.$fileList.append('<li class="file">' + file.name + ' <a href="#" data-delete-name="'+file.encoded_name+'">Remove</a></li>');
+    self.$fileList.append('<li class="file js-only">'
+      + file.name + ' <a href="#" data-name="'+file.name+'" data-delete-name="'+file.encoded_name+'">Remove</a></li>'
+    );
   },
 
   removeDropzonePreview: function(file) {
@@ -104,5 +110,29 @@ moj.Modules.docUpload = {
         self.$form.removeClass('dz-started dz-drag-hover');
       }
     });
+  },
+
+  uniqueFilename: function(filename) {
+    var self = this;
+    var fileList = self.$fileList.find('li.js-only a').map(function() {
+      return $(this).data('name');
+    });
+
+    while ($.inArray(filename, fileList) !== -1) {
+      // A duplicate uploaded filename (case-sensitive) was found
+      filename = self.appendToFilename(filename, '(1)');
+    }
+
+    return filename;
+  },
+
+  appendToFilename: function(filename, string) {
+    var dotIndex = filename.lastIndexOf('.');
+
+    if (dotIndex !== -1) {
+      return filename.substring(0, dotIndex) + string + filename.substring(dotIndex);
+    }
+
+    return filename + string;
   }
 };

--- a/app/views/steps/shared/_dropzone.html.erb
+++ b/app/views/steps/shared/_dropzone.html.erb
@@ -35,7 +35,7 @@
 
             <li class="file js-only">
               <%= doc.name %>
-              <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name %>
+              <%= link_to 'Remove', '#', 'data-name': doc.name, 'data-delete-name': doc.encoded_name %>
             </li>
         <% end %>
     <% else %>


### PR DESCRIPTION
This is a spike JS solution, working with Dropzone events, to detect duplicate already
uploaded documents, and if any found, rename on the fly the filename appendind (1) until
a unique filename is obtained. This new filename gets uploaded and added to the list of
uploaded files, transparent to the user.

This solution is simple and works making use of the hook provided by Dropzone `renameFilename`
but will not have any effect on the non-JS uploader version.

Another backend solution will be spiked now. Do not merge.