### PR TITLE
Fix issues with JS timeout defaulting to 0ms

### DIFF
--- a/app/assets/javascripts/modules/session-timeout-variables.js.erb
+++ b/app/assets/javascripts/modules/session-timeout-variables.js.erb
@@ -1,0 +1,2 @@
+moj.Modules.sessionLength = <%= Rails.configuration.x.session.expires_in_minutes %>;
+moj.Modules.sessionWarnWhenRemaining = <%= Rails.configuration.x.session.warning_when_remaining %>;

--- a/app/assets/javascripts/modules/session-timeout.js
+++ b/app/assets/javascripts/modules/session-timeout.js
@@ -39,6 +39,9 @@ moj.Modules.sessionTimeout = {
     // Return if there is no container (the container is only shown if there is an active session)
     if(!$(self.config.$modalContainer).length) return;
 
+    // Do not initialise if the timeout variables haven't been set properly
+    if(isNaN(moj.Modules.sessionLength) || isNaN(moj.Modules.sessionWarnWhenRemaining)) return;
+
     // Bind buttons in modal
     $(self.config.$modalContainer + " .extend").click(function() {
       self.extend();

--- a/app/views/layouts/_timeout_modal.html.erb
+++ b/app/views/layouts/_timeout_modal.html.erb
@@ -1,8 +1,3 @@
-<script type="text/javascript">
-  moj.Modules.sessionLength = <%= Rails.configuration.x.session.expires_in_minutes %>;
-  moj.Modules.sessionWarnWhenRemaining = <%= Rails.configuration.x.session.warning_when_remaining %>;
-</script>
-
 <div id="timeout-dialog" class="modal-dialog">
   <div class="modal-dialog_container">
     <div class="modal-dialog_box" role="dialog" aria-labelledby="aria-timeout-label">


### PR DESCRIPTION
This was due to a commit that shouldn't have made it into the previous
timeout PR.

- Move timeout variables into the correct place (assets, not inline)
- Add code to check whether timeout variables are set properly before
  initializing the timeout