### PR TITLE
Link to the real pro forma PDF file

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,7 +15,7 @@
         <li data-dependent="fees=yes" class="js-hidden"><strong>a way to pay your tribunal fee</strong> such as a debit or credit card, unless you are on a <a href="https://www.gov.uk/get-help-with-court-fees">low income or certain benefits</a></li>
       </ul>
 
-      <p>You'll also need to download and fill in an <a href="https://drive.google.com/open?id=0B-4PgEZDV9SBczhkbGNDanJEa28">authorisation form (PDF, 241KB)</a></strong> if you want someone to represent you.</p>
+      <p>You'll also need to download and fill in an <a href="<%= asset_path('proforma.pdf') %>">authorisation form (PDF, 241KB)</a></strong> if you want someone to represent you.</p>
 
       <p class="notice util_mt-large">
         <i class="icon icon-important">

--- a/app/views/steps/appeal/start/show.html.erb
+++ b/app/views/steps/appeal/start/show.html.erb
@@ -23,10 +23,10 @@
     </p>
 
     <%= t('.description_html',
-          approval_form_href: 'https://drive.google.com/open?id=0B-4PgEZDV9SBczhkbGNDanJEa28',
-          approval_form_format_and_size: 'PDF, 58Kb'
-         )
-      %>
+          approval_form_href: asset_path('proforma.pdf'),
+          approval_form_format_and_size: 'PDF, 241KB'
+        )
+    %>
 
     <p>
     <%= link_to t('.continue'), edit_steps_appeal_case_type_path, class: 'button button-start', role: 'button' %>

--- a/app/views/steps/closure/start/show.html.erb
+++ b/app/views/steps/closure/start/show.html.erb
@@ -4,7 +4,11 @@
 
     <p class="lede"><%= t('.lead_text') %></p>
 
-    <%= t('.description_html') %>
+    <%= t('.description_html',
+          approval_form_href: asset_path('proforma.pdf'),
+          approval_form_format_and_size: 'PDF, 241KB'
+        )
+    %>
 
     <p>
       <%= link_to t('.continue'), edit_steps_closure_case_type_path, class: 'button button-start', role: 'button' %>

--- a/app/views/steps/details/has_representative/edit.html.erb
+++ b/app/views/steps/details/has_representative/edit.html.erb
@@ -17,7 +17,11 @@
         <%=t '.details_heading' %>
       </summary>
       <div class="panel" id="details-content-0" aria-hidden="false">
-        <%= translate_with_appeal_or_application '.details_content_html' %>
+        <%= translate_with_appeal_or_application('.details_content_html',
+              approval_form_href: asset_path('proforma.pdf'),
+              approval_form_format_and_size: 'PDF, 241KB'
+            )
+        %>
       </div>
     </details>
   </div>

--- a/app/views/steps/details/user_type/edit.html.erb
+++ b/app/views/steps/details/user_type/edit.html.erb
@@ -13,7 +13,11 @@
     <details role="group">
       <summary role="button" aria-controls="details-content" aria-expanded="false"><%=t '.representative_heading' %></summary>
       <div class="panel" id="details-content" aria-hidden="true">
-        <%= translate_with_appeal_or_application '.representative_content_html' %>
+        <%= translate_with_appeal_or_application('.representative_content_html',
+              approval_form_href: asset_path('proforma.pdf'),
+              approval_form_format_and_size: 'PDF, 241KB'
+            )
+        %>
       </div>
     </details>
   </div>

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -13,7 +13,7 @@ en:
               <li><strong>a scan or photo</strong> of the original notice or review conclusion letter</li>
               <li><strong>reasons for your appeal</strong> to copy and paste or attach as a document</li>
             </ul>
-            <p>You'll also need to download and fill in an <a href="https://drive.google.com/open?id=0B-4PgEZDV9SBczhkbGNDanJEa28">authorisation form (PDF, 241KB)</a></strong> if you want someone to represent you.</p>
+            <p>You'll also need to download and fill in an <a href="%{approval_form_href}">authorisation form (%{approval_form_format_and_size})</a> if you want someone to represent you.</p>
             <p class="notice util_mt-large">
               <i class="icon icon-important"> <span class="visuallyhidden">Warning</span> </i>
               <strong class="bold-small">You can’t save details so get everything ready before you start </strong>
@@ -63,7 +63,7 @@ en:
       must_challenge_hmrc:
         show:
           heading: You must appeal the original decision with HMRC
-          lead_text: The original notice letter will explain what to do. 
+          lead_text: The original notice letter will explain what to do.
           free_to_challenge_hmrc_heading: You will only be able to appeal to the tax tribunal once you have written to HMRC.
           free_to_challenge_hmrc_guidance_html: Check the options when you <a href="https://www.gov.uk/tax-appeals">disagree with a tax decision</a>.
           contact_hmrc_button: Contact HMRC

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -12,7 +12,7 @@ en:
               <li><strong>details of the enquiry you want closed</strong> including the HMRC reference number and tax years under enquiry</li>
             </ul>
             <p>You can also provide further information and supporting documents saying why you think the enquiry should close.</p>
-            <p>You'll need to download and fill in an <a href="https://drive.google.com/open?id=0B-4PgEZDV9SBczhkbGNDanJEa28">authorisation form (PDF, 241KB)</a></strong> if you want someone to represent you.</p>
+            <p>You'll need to download and fill in an <a href="%{approval_form_href}">authorisation form (%{approval_form_format_and_size})</a> if you want someone to represent you.</p>
 
       case_type:
         edit:

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -41,7 +41,7 @@ en:
                 <li>friend or family relative</li>
               </ul>
             <p>You can use a representative if you feel you need help or advice. A representative is able to receive letters from the tax tribunal and go to any hearings for you.</p>
-            <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href="">authorisation form</a>.</p>
+            <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href="%{approval_form_href}">authorisation form (%{approval_form_format_and_size})</a>.</p>
       taxpayer_type:
         edit:
           heading:
@@ -62,7 +62,7 @@ en:
                 <li>friend or family relative</li>
               </ul>
             <p>You can use a representative if you feel you need help or advice. A representative is able to receive letters from the tax tribunal and go to any hearings for you.</p>
-            <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href=""> authorisation form</a>.</p>
+            <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href="%{approval_form_href}">authorisation form (%{approval_form_format_and_size})</a>.</p>
       representative_is_legal_professional:
         edit:
           heading:


### PR DESCRIPTION
We had some links to a google drive page, and some
empty links where the proforma href should go.
This commit fixes all of them, using the asset
path to the real PDF file (stored in the app
source tree).

https://www.pivotaltracker.com/story/show/141396449