### PR TITLE
Add GOV.UK Elements Form error box

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,9 +18,21 @@ module ApplicationHelper
 
   # Render a back link pointing to the user's previous step
   def step_header
-    render partial: 'step_header', locals: {
-      path: controller.previous_step_path
-    }
+    capture do
+      render partial: 'step_header', locals: {
+        path: controller.previous_step_path
+      }
+    end + error_summary(@form_object)
+  end
+
+  def error_summary(form_object)
+    return if form_object.nil?
+
+    GovukElementsErrorsHelper.error_summary(
+      form_object,
+      translate('errors.error_summary.heading'),
+      translate('errors.error_summary.text')
+    )
   end
 
   def translate_for_user_type(key, params={})

--- a/config/locales/default.yml
+++ b/config/locales/default.yml
@@ -16,8 +16,8 @@ en:
     messages:
       blank: Please enter an answer
     error_summary:
-      heading: Message to alert the user to a problem goes here
-      text: More help about errors goes here
+      heading: There's a problem. You need to fix this error.
+      text: ""
   helpers:
     submit:
       # These are defaults applicable to most steps, override them for

--- a/config/locales/default.yml
+++ b/config/locales/default.yml
@@ -15,6 +15,9 @@ en:
     format: "%{message}"
     messages:
       blank: Please enter an answer
+    error_summary:
+      heading: Message to alert the user to a problem goes here
+      text: More help about errors goes here
   helpers:
     submit:
       # These are defaults applicable to most steps, override them for

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -42,9 +42,36 @@ RSpec.describe ApplicationHelper do
   end
 
   describe '#step_header' do
+    let(:form_object) { double('Form object') }
+
     it 'renders the expected content' do
-      expect(helper).to receive(:render).with(partial: 'step_header', locals: {path: '/foo/bar'})
-      helper.step_header
+      expect(helper).to receive(:render).with(partial: 'step_header', locals: {path: '/foo/bar'}).and_return('foo')
+
+      assign(:form_object, form_object)
+      expect(helper).to receive(:error_summary).with(form_object).and_return('bar')
+
+      expect(helper.step_header).to eq('foobar')
+    end
+  end
+
+  describe '#error_summary' do
+    context 'when no form object is given' do
+      let(:form_object) { nil }
+
+      it 'returns nil' do
+        expect(helper.error_summary(form_object)).to be_nil
+      end
+    end
+
+    context 'when a form object is given' do
+      let(:form_object) { double('form object') }
+      let(:summary) { double('error summary') }
+
+      it 'delegates to GovukElementsErrorsHelper' do
+        expect(GovukElementsErrorsHelper).to receive(:error_summary).with(form_object, anything, anything).and_return(summary)
+
+        expect(helper.error_summary(form_object)).to eq(summary)
+      end
     end
   end
 


### PR DESCRIPTION
For now, show the form error box on any step that has errors. In the
future we might want to hide it for steps that only have one fieldset
because it's a bit too much.

![screen shot 2017-03-15 at 16 21 26](https://cloud.githubusercontent.com/assets/72141/23958727/ed067f6e-099a-11e7-9c3f-d14b3bffe1c8.png)
