### PR TITLE
Non-JS solution for dropzone duplicate file names.

### DIFF
--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -92,7 +92,7 @@ moj.Modules.docUpload = {
     var self = this;
 
     self.$fileList.find('.no-files').hide();
-    self.$fileList.append('<li class="file">' + file.name + ' <a href="#" data-delete-name="'+file.encoded_name+'">Remove</a></li>');
+    self.$fileList.append('<li class="file js-only">' + file.name + ' <a href="#" data-delete-name="'+file.encoded_name+'">Remove</a></li>');
   },
 
   removeDropzonePreview: function(file) {

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -12,7 +12,7 @@ class Document
     Uploader.list_files(
       collection_ref: collection_ref,
       document_key: document_key
-    ).map {|file| new(file.merge(collection_ref: collection_ref)) }
+    ).map {|file| new(file.merge(collection_ref: collection_ref)) }.sort
   end
 
   def encoded_name
@@ -24,5 +24,13 @@ class Document
   #
   def to_param
     encoded_name
+  end
+
+  def <=>(other)
+    last_modified <=> other.last_modified
+  end
+
+  def ==(other)
+    other.collection_ref == collection_ref && other.name == name
   end
 end

--- a/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
+++ b/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
 
   subject { described_class.new(arguments) }
 
+  before do
+    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
+    allow(Uploader).to receive(:list_files).and_return([])
+  end
+
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
       let(:tribunal_case)  { nil }

--- a/spec/forms/steps/details/representative_approval_form_spec.rb
+++ b/spec/forms/steps/details/representative_approval_form_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Steps::Details::RepresentativeApprovalForm do
 
   subject { described_class.new(arguments) }
 
+  before do
+    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
+    allow(Uploader).to receive(:list_files).and_return([])
+  end
+
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
       let(:tribunal_case)  { nil }

--- a/spec/forms/steps/hardship/hardship_reason_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_reason_form_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
 
   subject { described_class.new(arguments) }
 
+  before do
+    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
+    allow(Uploader).to receive(:list_files).and_return([])
+  end
+
   describe '#save' do
     context 'when no tribunal_case is associated with the form' do
       let(:tribunal_case)  { nil }

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Document do
     }
   end
   let(:result) { [
-      { key: '12345/test.doc', title: 'test.doc', last_modified: '2016-12-05T12:20:02.000Z' },
+      { key: '12345/test.doc', title: 'test.doc', last_modified: '2016-12-05T12:24:02.000Z' },
       { key: '12345/another.doc', title: 'another.doc', last_modified: '2016-12-05T12:20:02.000Z' }
     ] }
 
@@ -65,10 +65,10 @@ RSpec.describe Document do
       ).and_return(result)
     end
 
-    it 'returns the documents' do
+    it 'returns the sorted documents' do
       documents = described_class.for_collection('12345', document_key: :foo)
       expect(documents.size).to eq(2)
-      expect(documents.map(&:name).sort).to eq(%w(another.doc test.doc))
+      expect(documents.map(&:name)).to eq(%w(another.doc test.doc))
     end
   end
 end

--- a/spec/models/document_upload_spec.rb
+++ b/spec/models/document_upload_spec.rb
@@ -137,6 +137,18 @@ RSpec.describe DocumentUpload do
       it { expect(subject.file_name).to eq('image(2).jpg') }
     end
 
+    context 'existing `image.jpg`, `image(1).jpg` and `image(2).jpg`, uploading `image.jpg`' do
+      let(:new_filename) { 'image.jpg' }
+      let(:uploaded_files) {
+        [
+          {collection_ref: '123', name: 'image.jpg'},
+          {collection_ref: '123', name: 'image(1).jpg'},
+          {collection_ref: '123', name: 'image(2).jpg'}
+        ]
+      }
+      it { expect(subject.file_name).to eq('image(3).jpg') }
+    end
+
     # Although we are filtering out by extension and do not allow files without extension, the following tests cover a
     # theoretical situation uploading files without an extension.
     describe 'files without an extension' do


### PR DESCRIPTION
Detect duplicate already uploaded documents, and if any found, rename on the fly the
filename appendind `(n)` where `n` is an incrementing number starting in 1, until a
unique filename is obtained. This new filename gets uploaded and added to the list of
uploaded files, transparent to the user.

Possible combinations:

- Existing `image.jpg`, uploading `image.jpg`, renamed to `image(1).jpg`
- Existing `image.jpg` and `image(1).jpg`, uploading `image.jpg`, renamed to `image(2).jpg`
- Existing `image(1).jpg`, uploading `image(1).jpg`, renamed to `image(1)(1).jpg`

Also, as part of this PR, we are now returning date-sorted files from the S3 bucket.