### PR TITLE
Use ActiveModel::Errors for document upload errors

### DIFF
--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -1,6 +1,7 @@
 class DocumentUpload
   include Virtus.model
   extend ActiveModel::Naming
+  extend ActiveModel::Translation
 
   attribute :tempfile, Object
   attribute :content_type, String
@@ -75,22 +76,6 @@ class DocumentUpload
     validate
     errors.empty?
   end
-
-  # Required for ActiveModel::Errors
-
-  def read_attribute_for_validation(attr)
-    send(attr)
-  end
-
-  def self.human_attribute_name(attr, options = {})
-    attr
-  end
-
-  def self.lookup_ancestors
-    [self]
-  end
-
-  # Required for ActiveModel::Errors
 
   def errors?
     errors.any?

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -1,5 +1,6 @@
 class DocumentUpload
   include Virtus.model
+  extend ActiveModel::Naming
 
   attribute :tempfile, Object
   attribute :content_type, String
@@ -39,7 +40,7 @@ class DocumentUpload
     self.original_filename = filename || obj.original_filename
     self.collection_ref = collection_ref
     self.document_key = document_key
-    self.errors = []
+    self.errors = ActiveModel::Errors.new(self)
   end
 
   def upload!(collection_ref: nil, document_key: nil)
@@ -74,6 +75,22 @@ class DocumentUpload
     validate
     errors.empty?
   end
+
+  # Required for ActiveModel::Errors
+
+  def read_attribute_for_validation(attr)
+    send(attr)
+  end
+
+  def self.human_attribute_name(attr, options = {})
+    attr
+  end
+
+  def self.lookup_ancestors
+    [self]
+  end
+
+  # Required for ActiveModel::Errors
 
   def errors?
     errors.any?
@@ -132,7 +149,7 @@ class DocumentUpload
   end
 
   def add_error(code)
-    errors << translate(code) unless errors.include?(code)
+    errors.add(code, translate(code)) unless errors.has_key?(code)
   end
 
   def translate(key)

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -365,6 +365,7 @@ en:
               file_size: Your file exceeds the maximum file size of 20 megabytes
               content_type: Your file is not in a format we can accept
               response_error: There was an error uploading your file. Please try again
+              virus_detected: Virus detected
         steps/details/documents_checklist_form:
           attributes:
             original_notice_provided:

--- a/config/locales/hardship.yml
+++ b/config/locales/hardship.yml
@@ -41,6 +41,7 @@ en:
               file_size: Your file exceeds the maximum file size of 20 megabytes
               content_type: Your file is not in a format we can accept
               response_error: There was an error uploading your file. Please try again
+              virus_detected: Virus detected
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend

--- a/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
+++ b/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
         let(:grounds_for_appeal_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
 
         it 'should retrieve the errors from the uploader' do
-          expect(subject.errors).to receive(:add).with(:grounds_for_appeal_document, String).and_call_original
+          expect(subject.errors).to receive(:add).with(:grounds_for_appeal_document, :content_type).and_call_original
           expect(subject).to_not be_valid
         end
       end

--- a/spec/forms/steps/details/representative_approval_form_spec.rb
+++ b/spec/forms/steps/details/representative_approval_form_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Steps::Details::RepresentativeApprovalForm do
         let(:representative_approval_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
 
         it 'should retrieve the errors from the uploader' do
-          expect(subject.errors).to receive(:add).with(:representative_approval_document, String).and_call_original
+          expect(subject.errors).to receive(:add).with(:representative_approval_document, :content_type).and_call_original
           expect(subject).to_not be_valid
         end
       end

--- a/spec/forms/steps/hardship/hardship_reason_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_reason_form_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
         let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
 
         it 'should retrieve the errors from the uploader' do
-          expect(subject.errors).to receive(:add).with(:hardship_reason_document, String).and_call_original
+          expect(subject.errors).to receive(:add).with(:hardship_reason_document, :content_type).and_call_original
           expect(subject).to_not be_valid
         end
       end

--- a/spec/models/document_upload_spec.rb
+++ b/spec/models/document_upload_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe DocumentUpload do
 
   context '#errors' do
     it 'should be empty upon initialization' do
-      expect(subject.errors).to eq([])
+      expect(subject.errors).to be_empty
     end
   end
 


### PR DESCRIPTION
Now that we're using GovukElementsErrorsHelper for the top-of-page error
message, we need to ensure that errors are always presented via an
ActiveModel::Errors object (because the helper ends up calling "keys" on
the errors, which breaks if errors are in an array). This was breaking the
page when we had file upload errors on the grounds for appeal page
(presumably on other pages, too)
Also, add virus_detected to our translations, where missing