### PR TITLE
Big re-organization of the `check your answers` html and pdf views.

### DIFF
--- a/app/presenters/appeal_lateness_answers_presenter.rb
+++ b/app/presenters/appeal_lateness_answers_presenter.rb
@@ -6,8 +6,6 @@ class AppealLatenessAnswersPresenter < BaseAnswersPresenter
     ].compact
   end
 
-  private
-
   def in_time_question
     row(
       tribunal_case.in_time,

--- a/app/presenters/appeal_presenter.rb
+++ b/app/presenters/appeal_presenter.rb
@@ -29,6 +29,10 @@ class AppealPresenter < SimpleDelegator
     @appeal_lateness_answers ||= AppealLatenessAnswersPresenter.new(tribunal_case)
   end
 
+  def hardship_answers
+    @hardship_answers ||= HardshipAnswersPresenter.new(tribunal_case)
+  end
+
   private
 
   def tribunal_case

--- a/app/presenters/appeal_type_answers_presenter.rb
+++ b/app/presenters/appeal_type_answers_presenter.rb
@@ -7,10 +7,7 @@ class AppealTypeAnswersPresenter < BaseAnswersPresenter
       dispute_type_question,
       penalty_level_question,
       penalty_amount_question,
-      tax_amount_question,
-      disputed_tax_paid_question,
-      hardship_review_requested_question,
-      hardship_review_status_question
+      tax_amount_question
     ].compact
   end
 
@@ -84,27 +81,6 @@ class AppealTypeAnswersPresenter < BaseAnswersPresenter
       tribunal_case.tax_amount,
       as: :tax_amount,
       i18n_value: false
-    )
-  end
-
-  def disputed_tax_paid_question
-    row(
-      tribunal_case.disputed_tax_paid,
-      as: :disputed_tax_paid
-    )
-  end
-
-  def hardship_review_requested_question
-    row(
-      tribunal_case.hardship_review_requested,
-      as: :hardship_review_requested
-    )
-  end
-
-  def hardship_review_status_question
-    row(
-      tribunal_case.hardship_review_status,
-      as: :hardship_review_status
     )
   end
 end

--- a/app/presenters/documents_submitted_presenter.rb
+++ b/app/presenters/documents_submitted_presenter.rb
@@ -9,8 +9,4 @@ class DocumentsSubmittedPresenter < BaseAnswersPresenter
     return [] if tribunal_case.having_problems_uploading_documents?
     tribunal_case.documents(document_key)
   end
-
-  def show_hardship_reason?
-    tribunal_case.hardship_review_status == HardshipReviewStatus::REFUSED
-  end
 end

--- a/app/presenters/hardship_answers_presenter.rb
+++ b/app/presenters/hardship_answers_presenter.rb
@@ -1,0 +1,36 @@
+class HardshipAnswersPresenter < BaseAnswersPresenter
+  def rows
+    [
+      disputed_tax_paid_question,
+      hardship_review_requested_question,
+      hardship_review_status_question
+    ].compact
+  end
+
+  def show_reason?
+    tribunal_case.hardship_review_status == HardshipReviewStatus::REFUSED
+  end
+
+  private
+
+  def disputed_tax_paid_question
+    row(
+      tribunal_case.disputed_tax_paid,
+      as: :disputed_tax_paid
+    )
+  end
+
+  def hardship_review_requested_question
+    row(
+      tribunal_case.hardship_review_requested,
+      as: :hardship_review_requested
+    )
+  end
+
+  def hardship_review_status_question
+    row(
+      tribunal_case.hardship_review_status,
+      as: :hardship_review_status
+    )
+  end
+end

--- a/app/presenters/representative_details_presenter.rb
+++ b/app/presenters/representative_details_presenter.rb
@@ -23,4 +23,8 @@ class RepresentativeDetailsPresenter < BaseAnswersPresenter
   def email
     tribunal_case.representative_contact_email
   end
+
+  def proforma_present?
+    tribunal_case.representative_approval_file_name.present?
+  end
 end

--- a/app/views/steps/closure/check_answers/pdf/_header.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/_header.pdf.erb
@@ -1,6 +1,6 @@
-<% if tribunal_case.case_reference.present? %>
-  <p>
-    <span class="case-reference"><%= tribunal_case.case_reference %></span>
-  </p>
+<p>
+  <%= t('.tax_chamber') %>
   <br/>
-<% end %>
+  <strong><%= [t('.notice'), tribunal_case.case_reference].compact.join(' – ') %></strong>
+</p>
+<br/>

--- a/app/views/steps/closure/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/show.pdf.erb
@@ -8,7 +8,7 @@
 <body id="case-details-pdf">
 <%= render partial: 'steps/closure/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
 
-<h3><%= pdf_t '.application_details_heading' %></h3>
+<h3><%= t '.taxpayer_details_heading' %></h3>
 
 <hr/>
 <table>
@@ -33,46 +33,7 @@
   </tbody>
 </table>
 
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.representative_details' %></td>
-    <td class="content">
-      <% if tribunal_case.representative.present? %>
-        <div><%= tribunal_case.representative.name %></div>
-        <div>
-          <%= simple_format(tribunal_case.representative.address, class: 'simple-format') %>
-        </div>
-        <div>
-          <%= pdf_t '.questions.representative_phone' %>
-          <span><%= tribunal_case.representative.phone %></span>
-        </div>
-        <div>
-          <%= pdf_t '.questions.representative_email' %>
-          <span><%= tribunal_case.representative.email %></span>
-        </div>
-      <% else %>
-        <div>
-          <%= pdf_t '.answers.no_representative' %>
-        </div>
-      <% end %>
-    </td>
-  </tr>
-  </tbody>
-</table>
-
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.legal_representative' %></td>
-    <td class="content">
-      Not yet implemented in data capture.
-    </td>
-  </tr>
-  </tbody>
-</table>
+<%= render partial: 'steps/shared/representative_details', locals: { tribunal_case: tribunal_case } %>
 
 <hr/>
 <table>

--- a/app/views/steps/closure/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/pdf/show.pdf.erb
@@ -8,7 +8,7 @@
 <body id="case-details-pdf">
 <%= render partial: 'steps/closure/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
 
-<h3><%= t '.taxpayer_details_heading' %></h3>
+<h3><%= pdf_t '.taxpayer_details_heading' %></h3>
 
 <hr/>
 <table>

--- a/app/views/steps/closure/check_answers/show.html.erb
+++ b/app/views/steps/closure/check_answers/show.html.erb
@@ -50,28 +50,8 @@
       <%= link_to t('.change'), edit_steps_details_taxpayer_type_path %>
     </td>
   </tr>
-    <tr>
-      <th><%= t '.questions.representative_details' %></th>
-      <td>
-        <% if @tribunal_case.representative.present? %>
-          <div><%= @tribunal_case.representative.name %></div>
-          <div class="js_breaklines">
-            <%= simple_format(@tribunal_case.representative.address, class: 'simple-format') %>
-          </div>
-          <div>
-            <%= t '.questions.representative_phone' %> <span><%= @tribunal_case.representative.phone %></span>
-          </div>
-          <div>
-            <%= t '.questions.representative_email' %> <span><%= @tribunal_case.representative.email %></span>
-          </div>
-        <% else %>
-          <%= t '.answers.no_representative' %>
-        <% end %>
-      </td>
-      <td class="change-answer">
-        <%= link_to t('.change'), edit_steps_details_has_representative_path %>
-      </td>
-    </tr>
+
+  <%= render partial: 'steps/shared/representative_details', locals: { tribunal_case: @tribunal_case } %>
 
     <tr>
       <th><%= t '.questions.documents_submitted' %></th>

--- a/app/views/steps/details/check_answers/pdf/_header.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/_header.pdf.erb
@@ -1,8 +1,6 @@
 <p>
-  <% if tribunal_case.case_reference.present? %>
-    <span class="case-reference"><%= tribunal_case.case_reference %></span>
-    <br/>
-  <% end %>
-  <strong><%= [tribunal_case.taxpayer.name, 'HMRC'].to_sentence(two_words_connector: t('.appellant_connector')) %></strong>
+  <%= t('.tax_chamber') %>
+  <br/>
+  <strong><%= [t('.notice'), tribunal_case.case_reference].compact.join(' – ') %></strong>
 </p>
 <br/>

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -8,7 +8,7 @@
 <body id="case-details-pdf">
 <%= render partial: 'steps/details/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
 
-<h3><%= pdf_t '.appeal_details_heading' %></h3>
+<h4><%= t '.taxpayer_details_heading' %></h4>
 
 <hr/>
 <table>
@@ -21,42 +21,115 @@
         <%= simple_format(tribunal_case.taxpayer.address, class: 'simple-format') %>
       </div>
       <div>
-        <%= pdf_t '.questions.appellant_phone' %>
-        <span><%= tribunal_case.taxpayer.phone %></span>
-      </div>
-      <div>
         <%= pdf_t '.questions.appellant_email' %>
         <span><%= tribunal_case.taxpayer.email %></span>
       </div>
+      <div>
+        <%= pdf_t '.questions.appellant_phone' %>
+        <span><%= tribunal_case.taxpayer.phone %></span>
+      </div>
     </td>
   </tr>
   </tbody>
 </table>
 
+<%= render partial: 'steps/shared/representative_details', locals: { tribunal_case: tribunal_case } %>
+
+<hr/>
+<h4><%= pdf_t '.appeal_type_heading' %></h4>
+
 <hr/>
 <table>
   <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.representative_details' %></td>
-    <td class="content">
-      <% if tribunal_case.representative.present? %>
-        <div><%= tribunal_case.representative.name %></div>
-        <div>
-          <%= simple_format(tribunal_case.representative.address, class: 'simple-format') %>
-        </div>
-        <div>
-          <%= pdf_t '.questions.representative_phone' %>
-          <span><%= tribunal_case.representative.phone %></span>
-        </div>
-        <div>
-          <%= pdf_t '.questions.representative_email' %>
-          <span><%= tribunal_case.representative.email %></span>
-        </div>
-      <% else %>
-        <div>
-          <%= pdf_t '.answers.no_representative' %>
-        </div>
+  <% tribunal_case.appeal_type_answers.rows.each do |row| %>
+    <tr>
+      <td class="section"><%= pdf_t row.question %></td>
+      <td class="content"><%= row.i18n_value ? pdf_t(row.answer) : row.answer %></td>
+    </tr>
+    <tr>
+      <td colspan="2"></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<% if tribunal_case.hardship_answers.rows.any? %>
+  <hr/>
+  <h4><%= pdf_t '.hardship_heading' %></h4>
+  <hr/>
+  <table>
+    <tbody>
+    <% tribunal_case.hardship_answers.rows.each do |row| %>
+      <tr>
+        <td class="section"><%= pdf_t row.question %></td>
+        <td class="content"><%= pdf_t row.answer %></td>
+      </tr>
+      <tr>
+        <td colspan="2"></td>
+      </tr>
+    <% end %>
+
+    <% if tribunal_case.hardship_answers.show_reason? %>
+      <tr>
+        <td colspan="2"><%= pdf_t '.questions.hardship_reason' %></td>
+      </tr>
+      <tr>
+        <td colspan="2"><hr/></td>
+      </tr>
+      <tr>
+        <td colspan="2" class="content">
+          <%= simple_format(tribunal_case.hardship_reason, class: 'simple-format') %>
+          <p><%= pdf_t '.answers.document_attached_html', filename: tribunal_case.hardship_reason_file_name %></p>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<div class="newpage"></div>
+<%= render partial: 'steps/details/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
+
+<% if (in_time_row = tribunal_case.appeal_lateness_answers.in_time_question) %>
+  <h4><%= pdf_t '.appeal_timeliness_heading' %></h4>
+  <hr/>
+  <table>
+    <tbody>
+      <tr>
+        <td class="section"><%= pdf_t in_time_row.question %></td>
+        <td class="content">
+          <%= pdf_t in_time_row.answer %>
+        </td>
+      </tr>
+      <% if (lateness_reason = tribunal_case.appeal_lateness_answers.lateness_reason_question) %>
+        <tr>
+          <td colspan="2"><hr/></td>
+        </tr>
+        <tr>
+          <td colspan="2"><%= pdf_t lateness_reason.question %></td>
+        </tr>
+        <tr>
+          <td colspan="2" class="content with-padding">
+            <%= simple_format(tribunal_case.lateness_reason, class: 'simple-format') %>
+          </td>
+        </tr>
       <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<h4><%= pdf_t '.grounds_for_appeal_heading' %></h4>
+
+<hr/>
+<table>
+  <tbody>
+  <tr>
+    <td colspan="2"><%= pdf_t '.questions.grounds_for_appeal' %></td>
+  </tr>
+  <tr>
+    <td colspan="2" class="content with-padding">
+      <%= simple_format(tribunal_case.grounds_for_appeal, class: 'simple-format') %>
+      <p><%= pdf_t '.answers.document_attached_html', filename: tribunal_case.grounds_for_appeal_file_name %></p>
     </td>
   </tr>
   </tbody>
@@ -66,40 +139,11 @@
 <table>
   <tbody>
   <tr>
-    <td class="section"><%= pdf_t '.questions.legal_representative' %></td>
-    <td class="content">
-      Not yet implemented in data capture.
-    </td>
-  </tr>
-  </tbody>
-</table>
-
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.desired_outcome' %></td>
+    <td colspan="2"><%= pdf_t '.questions.desired_outcome' %></td>
   </tr>
   <tr>
-    <td class="content with-padding">
+    <td colspan="2" class="content with-padding">
       <%= simple_format(tribunal_case.outcome, class: 'simple-format') %>
-    </td>
-  </tr>
-  </tbody>
-</table>
-
-<hr/>
-<table>
-  <tbody>
-  <tr>
-    <td class="section"><%= pdf_t '.questions.grounds_for_appeal' %></td>
-    <td class="content">
-      <span><%= tribunal_case.grounds_for_appeal %></span>
-      <ul class="documents">
-        <% tribunal_case.documents.list(:grounds_for_appeal).each do |document| %>
-          <li><%= document.title %></li>
-        <% end %>
-      </ul>
     </td>
   </tr>
   </tbody>
@@ -122,58 +166,6 @@
       <% end %>
     </td>
   </tr>
-  </tbody>
-</table>
-
-<div class="newpage"></div>
-
-<%= render partial: 'steps/details/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
-
-<h3><%= pdf_t '.appeal_type_heading' %></h3>
-
-<hr/>
-<table>
-  <tbody>
-  <% tribunal_case.appeal_type_answers.rows.each do |row| %>
-    <tr>
-      <td class="section"><%= pdf_t row.question %></td>
-      <td class="content"><%= row.i18n_value ? pdf_t(row.answer) : row.answer %></td>
-    </tr>
-    <tr>
-      <td colspan="2"></td>
-    </tr>
-  <% end %>
-
-  <% if tribunal_case.documents.show_hardship_reason? %>
-    <tr>
-      <td><%= pdf_t '.questions.hardship_reason' %></td>
-      <td>
-        <span><%= tribunal_case.hardship_reason %></span>
-        <ul class="documents">
-          <% tribunal_case.documents.list(:hardship_reason).each do |document| %>
-            <li><%= document.title %></li>
-          <% end %>
-        </ul>
-      </td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>
-
-<h3><%= pdf_t '.appeal_timeliness_heading' %></h3>
-
-<hr/>
-<table>
-  <tbody>
-  <% tribunal_case.appeal_lateness_answers.rows.each do |row| %>
-    <tr>
-      <td class="section"><%= pdf_t row.question %></td>
-      <td class="content"><%= row.i18n_value ? pdf_t(row.answer) : row.answer %></td>
-    </tr>
-    <tr>
-      <td colspan="2"></td>
-    </tr>
-  <% end %>
   </tbody>
 </table>
 

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -8,7 +8,7 @@
 <body id="case-details-pdf">
 <%= render partial: 'steps/details/check_answers/pdf/header', locals: { tribunal_case: tribunal_case } %>
 
-<h4><%= t '.taxpayer_details_heading' %></h4>
+<h4><%= pdf_t '.taxpayer_details_heading' %></h4>
 
 <hr/>
 <table>

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -18,31 +18,43 @@
       </tr>
   <% end %>
 
-  <% if @tribunal_case.documents.show_hardship_reason? %>
+  <% @tribunal_case.hardship_answers.rows.each do |row| %>
     <tr>
-      <td><%= t '.questions.hardship_reason' %></td>
-      <td>
-        <span><%= @tribunal_case.hardship_reason %></span>
-        <ul class="list-bullet uploaded-docs">
-          <% @tribunal_case.documents.list(:hardship_reason).each do |document| %>
-            <li><%= document.title %></li>
-          <% end %>
-        </ul>
+      <td class="section"><%= pdf_t row.question %></td>
+      <td class="content"><%= pdf_t row.answer %></td>
+      <td class="change-answer"></td>
+    </tr>
+  <% end %>
+
+  <% if @tribunal_case.hardship_answers.show_reason? %>
+    <tr>
+      <td colspan="2" class="with-padding">
+        <p><%= t '.questions.hardship_reason' %></p>
+        <%= simple_format(@tribunal_case.hardship_reason, class: 'simple-format') %>
+        <p><%= t('.answers.document_attached_html', filename: @tribunal_case.hardship_reason_file_name) %></p>
       </td>
     </tr>
   <% end %>
 
-  <tr>
-    <th colspan="3"><h2 class="heading-medium"><%= t '.appeal_timeliness_heading' %></h2></th>
-  </tr>
-  <% @tribunal_case.appeal_lateness_answers.rows.each do |row| %>
+  <% if (in_time_row = @tribunal_case.appeal_lateness_answers.in_time_question) %>
+    <tr>
+      <th colspan="3"><h2 class="heading-medium"><%= t '.appeal_timeliness_heading' %></h2></th>
+    </tr>
+    <tr>
+      <td><%= translate_with_appeal_or_application in_time_row.question %></td>
+      <td><%= t(in_time_row.answer) %></td>
+      <td class="change-answer">
+        <%= in_time_row.change_link t('.change') %>
+      </td>
+    </tr>
+    <% if (lateness_reason = @tribunal_case.appeal_lateness_answers.lateness_reason_question) %>
       <tr>
-        <td><%= translate_with_appeal_or_application row.question %></td>
-        <td><%= row.i18n_value ? t(row.answer) : row.answer %></td>
-        <td class="change-answer">
-          <%= row.change_link t('.change') %>
+        <td colspan="2" class="with-padding">
+          <p><%= translate_with_appeal_or_application lateness_reason.question %></p>
+          <%= simple_format(@tribunal_case.lateness_reason, class: 'simple-format') %>
         </td>
       </tr>
+    <% end %>
   <% end %>
 
   <tr>
@@ -56,48 +68,24 @@
         <%= simple_format(@tribunal_case.taxpayer.address, class: 'simple-format') %>
       </div>
       <div>
-        <%= t '.questions.appellant_phone' %> <span><%= @tribunal_case.taxpayer.phone %></span>
+        <%= t '.questions.appellant_email' %> <span><%= @tribunal_case.taxpayer.email %></span>
       </div>
       <div>
-        <%= t '.questions.appellant_email' %> <span><%= @tribunal_case.taxpayer.email %></span>
+        <%= t '.questions.appellant_phone' %> <span><%= @tribunal_case.taxpayer.phone %></span>
       </div>
     </td>
     <td class="change-answer">
       <%= link_to t('.change'), edit_steps_details_taxpayer_type_path %>
     </td>
   </tr>
-    <tr>
-      <th><%= t '.questions.representative_details' %></th>
-      <td>
-        <% if @tribunal_case.representative.present? %>
-          <div><%= @tribunal_case.representative.name %></div>
-          <div class="js_breaklines">
-            <%= simple_format(@tribunal_case.representative.address, class: 'simple-format') %>
-          </div>
-          <div>
-            <%= t '.questions.representative_phone' %> <span><%= @tribunal_case.representative.phone %></span>
-          </div>
-          <div>
-            <%= t '.questions.representative_email' %> <span><%= @tribunal_case.representative.email %></span>
-          </div>
-        <% else %>
-          <%= t '.answers.no_representative' %>
-        <% end %>
-      </td>
-      <td class="change-answer">
-        <%= link_to t('.change'), edit_steps_details_has_representative_path %>
-      </td>
-    </tr>
+
+  <%= render partial: 'steps/shared/representative_details', locals: { tribunal_case: @tribunal_case } %>
 
   <tr>
-    <th><%= translate_with_appeal_or_application '.questions.grounds_for_appeal' %></th>
-    <td>
-      <span><%= @tribunal_case.grounds_for_appeal %></span>
-      <ul class="list-bullet uploaded-docs">
-        <% @tribunal_case.documents.list(:grounds_for_appeal).each do |document| %>
-          <li><%= document.title %></li>
-        <% end %>
-      </ul>
+    <td colspan="2" class="with-padding">
+      <p><%= translate_with_appeal_or_application '.questions.grounds_for_appeal' %></p>
+      <%= simple_format(@tribunal_case.grounds_for_appeal, class: 'simple-format') %>
+      <p><%= t('.answers.document_attached_html', filename: @tribunal_case.grounds_for_appeal_file_name) %></p>
     </td>
     <td class="change-answer">
       <%= link_to t('.change'), edit_steps_details_grounds_for_appeal_path %>
@@ -105,11 +93,9 @@
   </tr>
 
   <tr>
-    <th><%= t '.questions.desired_outcome' %></th>
-    <td>
-      <span>
-        <%= simple_format(@tribunal_case.outcome, class: 'simple-format') %>
-      </span>
+    <td colspan="2" class="with-padding">
+      <p><%= t '.questions.desired_outcome' %></p>
+      <%= simple_format(@tribunal_case.outcome, class: 'simple-format') %>
     </td>
     <td class="change-answer">
       <%= link_to t('.change'), edit_steps_details_outcome_path %>

--- a/app/views/steps/shared/_representative_details.html.erb
+++ b/app/views/steps/shared/_representative_details.html.erb
@@ -1,0 +1,49 @@
+<tr>
+  <th><%= t '.questions.representative_details' %></th>
+  <td>
+    <% if @tribunal_case.representative.present? %>
+      <div><%= @tribunal_case.representative.name %></div>
+      <div class="js_breaklines">
+        <%= simple_format(@tribunal_case.representative.address, class: 'simple-format') %>
+      </div>
+      <div>
+        <%= t '.questions.representative_email' %> <span><%= @tribunal_case.representative.email %></span>
+      </div>
+      <div>
+        <%= t '.questions.representative_phone' %> <span><%= @tribunal_case.representative.phone %></span>
+      </div>
+    <% else %>
+      <%= t '.answers.no_representative' %>
+    <% end %>
+  </td>
+  <td class="change-answer">
+    <%= link_to t('.change'), edit_steps_details_has_representative_path %>
+  </td>
+</tr>
+
+<% if tribunal_case.representative.present? %>
+  <tr>
+    <th><%= t '.questions.legal_representative' %></th>
+    <td>
+      <!-- TODO: We only have a Yes/No value at the moment, there is a ticket to change that, this is temporal -->
+      Tax Agent
+    </td>
+    <td class="change-answer">
+      <%= link_to t('.change'), edit_steps_details_representative_is_legal_professional_path %>
+    </td>
+  </tr>
+
+  <% if tribunal_case.representative.proforma_present? %>
+    <tr>
+      <th><%= t '.questions.representative_approval' %></th>
+      <td>
+        <ul class="list-bullet uploaded-docs">
+          <li><%= tribunal_case.representative_approval_file_name %></li>
+        </ul>
+      </td>
+      <td class="change-answer">
+        <%= link_to t('.change'), edit_steps_details_representative_approval_path %>
+      </td>
+    </tr>
+  <% end %>
+<% end %>

--- a/app/views/steps/shared/_representative_details.pdf.erb
+++ b/app/views/steps/shared/_representative_details.pdf.erb
@@ -1,0 +1,59 @@
+<hr/>
+<table>
+  <tbody>
+  <tr>
+    <td class="section"><%= pdf_t '.questions.representative_details' %></td>
+    <td class="content">
+      <% if tribunal_case.representative.present? %>
+        <div><%= tribunal_case.representative.name %></div>
+        <div>
+          <%= simple_format(tribunal_case.representative.address, class: 'simple-format') %>
+        </div>
+        <div>
+          <%= pdf_t '.questions.representative_email' %>
+          <span><%= tribunal_case.representative.email %></span>
+        </div>
+        <div>
+          <%= pdf_t '.questions.representative_phone' %>
+          <span><%= tribunal_case.representative.phone %></span>
+        </div>
+      <% else %>
+        <div>
+          <%= pdf_t '.answers.no_representative' %>
+        </div>
+      <% end %>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+<% if tribunal_case.representative.present? %>
+  <hr/>
+  <table>
+    <tbody>
+    <tr>
+      <td class="section"><%= pdf_t '.questions.legal_representative' %></td>
+      <!-- TODO: We only have a Yes/No value at the moment, there is a ticket to change that, this is temporal -->
+      <td class="content">
+        <span>Tax Agent</span>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+
+  <% if tribunal_case.representative.proforma_present? %>
+    <hr/>
+    <table>
+      <tbody>
+      <tr>
+        <td class="section"><%= pdf_t '.questions.representative_approval' %></td>
+        <td class="content">
+          <ul class="documents">
+            <li><%= tribunal_case.representative_approval_file_name %></li>
+          </ul>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  <% end %>
+<% end %>

--- a/config/locales/closure.pdf.yml
+++ b/config/locales/closure.pdf.yml
@@ -4,21 +4,17 @@
 #
 en:
   steps:
-    details:
+    closure:
       check_answers:
         pdf:
           header:
             tax_chamber: First-tier Tribunal (Tax Chamber)
-            notice: Notice of appeal
+            notice: Application to close enquiry
           show:
             taxpayer_details_heading: Taxpayer details
             questions:
-              challenged_decision: Decision challenged with HMRC?
-              tax_amount: Amount of tax under dispute
-              penalty_level: Penalty or surcharge amount
-              penalty_amount: Penalty or surcharge amount
-              in_time: Are you in time?
-              lateness_reason: Reason(s) for late %{appeal_or_application}
+              # Insert here custom translations for questions
+              placeholder: placeholder
             answers:
               # Insert here custom translations for answers
               placeholder: placeholder

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -57,12 +57,8 @@ en:
             appellant_details: "Taxpayer's details"
             appellant_phone: "Tel:"
             appellant_email: "Email:"
-            representative_details: "Representative's details"
-            representative_phone: "Tel:"
-            representative_email: "Email:"
             additional_info: Additional information
             documents_submitted: Documents submitted
-            legal_representative: Legal representative
           answers:
             case_type:
               personal_return: Personal return
@@ -75,7 +71,6 @@ en:
               stamp_duty_land_tax_return: 'Stamp Duty Land Tax (SDLT): land transaction return'
               stamp_duty_land_tax_claim: 'Stamp Duty Land Tax (SDLT): claim or amendment of a claim'
               transactions_in_securities: 'Transactions in securities: issue of counteraction or no-counteraction notice'
-            no_representative: I don't have a representative
       confirmation:
         show:
           case_submitted: Case submitted

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -160,6 +160,8 @@ en:
           appeal_type_heading: Appeal type
           appeal_timeliness_heading: Appeal deadline
           appeal_details_heading: Appeal details
+          grounds_for_appeal_heading: Grounds for appeal
+          hardship_heading: Hardship application
           questions:
             challenged_decision: Did you appeal the original decision with HMRC?
             challenged_decision_status: What reponse did you receive?
@@ -177,12 +179,8 @@ en:
             appellant_details: "Taxpayer's details"
             appellant_phone: "Tel:"
             appellant_email: "Email:"
-            representative_details: "Representative's details"
-            representative_phone: "Tel:"
-            representative_email: "Email:"
             grounds_for_appeal: Grounds for %{appeal_or_application}
             documents_submitted: Documents submitted
-            legal_representative: Legal representative
             desired_outcome: Desired outcome
             disputed_tax_paid: Have you paid the amount of tax under dispute?
             hardship_review_requested: Did you ask HMRC if you could appeal without paying the tax first?
@@ -271,7 +269,7 @@ en:
               'yes': 'Yes'
               'no': 'No'
               unsure: I am not sure
-            no_representative: I don't have a representative
+            document_attached_html: '<strong>Document attached:</strong> %{filename}'
       outcome:
         edit:
           heading: What outcome do you want from your %{appeal_or_application}?

--- a/config/locales/shared.yml
+++ b/config/locales/shared.yml
@@ -3,3 +3,15 @@ en:
     confirmation_case_reference:
       case_reference: 'Your case reference number is:'
       note_number: Please make a note of this number in case you need to contact us.
+  steps:
+    shared:
+      representative_details:
+        change: Change
+        questions:
+          legal_representative: Type of representative
+          representative_approval: Representative approval
+          representative_details: "Representative's details"
+          representative_phone: "Tel:"
+          representative_email: "Email:"
+        answers:
+          no_representative: "I don't have a representative"

--- a/spec/helpers/check_answers_helper_spec.rb
+++ b/spec/helpers/check_answers_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CheckAnswersHelper do
     # These are just a few keys to perform a quick sanity check of the method.
     # If ever changed or removed, any other keys can be used instead.
     let(:found_key) { '.questions.penalty_level' }
-    let(:cascaded_key) { '.questions.lateness_reason' }
+    let(:cascaded_key) { '.questions.documents_submitted' }
     let(:interpolation_key) { '.questions.case_type' }
 
     before do
@@ -23,7 +23,7 @@ RSpec.describe CheckAnswersHelper do
 
     it 'cascades a not found key' do
       result = helper.pdf_t(cascaded_key)
-      expect(result).to eq('Reason for lateness?')
+      expect(result).to eq('Documents submitted')
     end
 
     it 'interpolates the appeal_or_application params' do

--- a/spec/presenters/appeal_presenter_spec.rb
+++ b/spec/presenters/appeal_presenter_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe AppealPresenter do
       expect(subject.appeal_lateness_answers).to be_an_instance_of(AppealLatenessAnswersPresenter)
     end
   end
+
+  context '#hardship_answers' do
+    it 'returns a hardship answers presenter instance' do
+      expect(subject.hardship_answers).to be_an_instance_of(HardshipAnswersPresenter)
+    end
+  end
 end

--- a/spec/presenters/appeal_type_answers_presenter_spec.rb
+++ b/spec/presenters/appeal_type_answers_presenter_spec.rb
@@ -14,10 +14,7 @@ RSpec.describe AppealTypeAnswersPresenter do
       dispute_type_other_value: dispute_type_other_value,
       penalty_level: penalty_level,
       penalty_amount: penalty_amount,
-      tax_amount: tax_amount,
-      disputed_tax_paid: disputed_tax_paid,
-      hardship_review_requested: hardship_review_requested,
-      hardship_review_status: hardship_review_status
+      tax_amount: tax_amount
     )
   }
 
@@ -32,9 +29,6 @@ RSpec.describe AppealTypeAnswersPresenter do
   let(:penalty_level)              { nil }
   let(:penalty_amount)             { nil }
   let(:tax_amount)                 { nil }
-  let(:disputed_tax_paid)          { nil }
-  let(:hardship_review_requested)  { nil }
-  let(:hardship_review_status)     { nil }
 
   let(:declared_rows) {
     [
@@ -44,10 +38,7 @@ RSpec.describe AppealTypeAnswersPresenter do
         :dispute_type_question,
         :penalty_level_question,
         :penalty_amount_question,
-        :tax_amount_question,
-        :disputed_tax_paid_question,
-        :hardship_review_requested_question,
-        :hardship_review_status_question
+        :tax_amount_question
     ].freeze
   }
 
@@ -240,72 +231,6 @@ RSpec.describe AppealTypeAnswersPresenter do
       it 'has the correct attributes' do
         expect(row.question).to    eq('.questions.tax_amount')
         expect(row.answer).to      eq('about 12345')
-        expect(row.change_path).to be_nil
-      end
-    end
-  end
-
-  describe '`disputed_tax_paid` question' do
-    let(:row) { subject.disputed_tax_paid_question }
-
-    context 'when `disputed_tax_paid` is nil' do
-      let(:disputed_tax_paid) { nil }
-
-      it 'is not included' do
-        expect(row).to be_nil
-      end
-    end
-
-    context 'when `disputed_tax_paid` is given' do
-      let(:disputed_tax_paid)  { 'foo' }
-
-      it 'has the correct attributes' do
-        expect(row.question).to    eq('.questions.disputed_tax_paid')
-        expect(row.answer).to      eq('.answers.disputed_tax_paid.foo')
-        expect(row.change_path).to be_nil
-      end
-    end
-  end
-
-  describe '`hardship_review_requested` question' do
-    let(:row) { subject.hardship_review_requested_question }
-
-    context 'when `hardship_review_requested` is nil' do
-      let(:hardship_review_requested) { nil }
-
-      it 'is not included' do
-        expect(row).to be_nil
-      end
-    end
-
-    context 'when `hardship_review_requested` is given' do
-      let(:hardship_review_requested)  { 'foo' }
-
-      it 'has the correct attributes' do
-        expect(row.question).to    eq('.questions.hardship_review_requested')
-        expect(row.answer).to      eq('.answers.hardship_review_requested.foo')
-        expect(row.change_path).to be_nil
-      end
-    end
-  end
-
-  describe '`hardship_review_status` row' do
-    let(:row) { subject.hardship_review_status_question }
-
-    context 'when `hardship_review_status` is nil' do
-      let(:hardship_review_status) { nil }
-
-      it 'is not included' do
-        expect(row).to be_nil
-      end
-    end
-
-    context 'when `hardship_review_status` is given' do
-      let(:hardship_review_status) { 'foo' }
-
-      it 'has the correct attributes' do
-        expect(row.question).to    eq('.questions.hardship_review_status')
-        expect(row.answer).to      eq('.answers.hardship_review_status.foo')
         expect(row.change_path).to be_nil
       end
     end

--- a/spec/presenters/documents_submitted_presenter_spec.rb
+++ b/spec/presenters/documents_submitted_presenter_spec.rb
@@ -24,18 +24,4 @@ RSpec.describe DocumentsSubmittedPresenter do
       end
     end
   end
-
-  describe '#show_hardship_reason?' do
-    let(:tribunal_case) { instance_double(TribunalCase, hardship_review_status: hardship_review_status) }
-
-    context 'when the hardship status is refused' do
-      let(:hardship_review_status) { HardshipReviewStatus::REFUSED }
-      it { expect(subject.show_hardship_reason?).to eq(true) }
-    end
-
-    context 'when the hardship status is other than refused' do
-      let(:hardship_review_status) { HardshipReviewStatus::GRANTED }
-      it { expect(subject.show_hardship_reason?).to eq(false) }
-    end
-  end
 end

--- a/spec/presenters/hardship_answers_presenter_spec.rb
+++ b/spec/presenters/hardship_answers_presenter_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+RSpec.describe HardshipAnswersPresenter do
+  subject { described_class.new(tribunal_case) }
+  let(:tribunal_case) {
+    instance_double(
+      TribunalCase,
+      disputed_tax_paid: disputed_tax_paid,
+      hardship_review_requested: hardship_review_requested,
+      hardship_review_status: hardship_review_status
+    )
+  }
+  let(:paths) { Rails.application.routes.url_helpers }
+
+  let(:disputed_tax_paid)         { nil }
+  let(:hardship_review_requested) { nil }
+  let(:hardship_review_status)    { nil }
+
+  describe '#show_reason?' do
+    let(:tribunal_case) { instance_double(TribunalCase, hardship_review_status: hardship_review_status) }
+
+    context 'when the hardship status is refused' do
+      let(:hardship_review_status) { HardshipReviewStatus::REFUSED }
+      it { expect(subject.show_reason?).to eq(true) }
+    end
+
+    context 'when the hardship status is other than refused' do
+      let(:hardship_review_status) { HardshipReviewStatus::GRANTED }
+      it { expect(subject.show_reason?).to eq(false) }
+    end
+  end
+
+  describe '#rows' do
+    describe '`disputed_tax_paid` question' do
+      let(:row) { subject.rows[0] }
+
+      context 'when `disputed_tax_paid` is nil' do
+        let(:disputed_tax_paid) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `disputed_tax_paid` is given' do
+        let(:disputed_tax_paid)  { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.disputed_tax_paid')
+          expect(row.answer).to      eq('.answers.disputed_tax_paid.foo')
+          expect(row.change_path).to be_nil
+        end
+      end
+    end
+
+    describe '`hardship_review_requested` question' do
+      let(:row) { subject.rows[1] }
+      let(:disputed_tax_paid) { 'foo' }
+
+      context 'when `hardship_review_requested` is nil' do
+        let(:hardship_review_requested) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `hardship_review_requested` is given' do
+        let(:hardship_review_requested)  { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.hardship_review_requested')
+          expect(row.answer).to      eq('.answers.hardship_review_requested.foo')
+          expect(row.change_path).to be_nil
+        end
+      end
+    end
+
+    describe '`hardship_review_status` row' do
+      let(:row) { subject.rows[2] }
+      let(:disputed_tax_paid) { 'foo' }
+      let(:hardship_review_requested)  { 'foo' }
+
+      context 'when `hardship_review_status` is nil' do
+        let(:hardship_review_status) { nil }
+
+        it 'is not included' do
+          expect(row).to be_nil
+        end
+      end
+
+      context 'when `hardship_review_status` is given' do
+        let(:hardship_review_status) { 'foo' }
+
+        it 'has the correct attributes' do
+          expect(row.question).to    eq('.questions.hardship_review_status')
+          expect(row.answer).to      eq('.answers.hardship_review_status.foo')
+          expect(row.change_path).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/representative_details_presenter_spec.rb
+++ b/spec/presenters/representative_details_presenter_spec.rb
@@ -94,4 +94,18 @@ RSpec.describe RepresentativeDetailsPresenter do
       end
     end
   end
+
+  describe '#proforma_present?' do
+    let(:tribunal_case) { instance_double(TribunalCase, representative_approval_file_name: file_name) }
+
+    context 'when a document was uploaded' do
+      let(:file_name) { 'document.txt' }
+      it { expect(subject.proforma_present?).to eq(true) }
+    end
+
+    context 'when no document was uploaded' do
+      let(:file_name) { nil }
+      it { expect(subject.proforma_present?).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces missing sections like hardship reasons, representative approval, etc.
and also moves around other sections, to match Jason design.

The same, where possible, has been done for `appeal` and `closure` but a following PR will
introduce some missing sections specific to `closure` (as this PR was growing already too much).

* https://www.pivotaltracker.com/story/show/141877591
* https://www.pivotaltracker.com/story/show/141859679