### PR TITLE
Cleaning up uploader error translations.

### DIFF
--- a/config/locales/default.yml
+++ b/config/locales/default.yml
@@ -15,6 +15,10 @@ en:
     format: "%{message}"
     messages:
       blank: Please enter an answer
+      file_size: File too big
+      content_type: Unsupported file type
+      response_error: Response error
+      virus_detected: Virus detected
     error_summary:
       heading: There's a problem. You need to fix this error.
       text: ""

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -338,22 +338,10 @@ en:
           attributes:
             representative_type:
               inclusion: Select whether you're entering details for an individual, company or organisation
-        steps/details/representative_approval_form:
-          attributes:
-            representative_approval_document:
-              file_size: Your file exceeds the maximum file size of 20 megabytes
-              content_type: Your file is not in a format we can accept
-              response_error: There was an error uploading your file. Please try again
-              virus_detected: Virus detected
         steps/details/grounds_for_appeal_form:
           attributes:
             grounds_for_appeal:
               blank: You must enter reasons or attach a document
-            grounds_for_appeal_document:
-              file_size: Your file exceeds the maximum file size of 20 megabytes
-              content_type: Your file is not in a format we can accept
-              response_error: There was an error uploading your file. Please try again
-              virus_detected: Virus detected
         steps/details/documents_checklist_form:
           attributes:
             original_notice_provided:

--- a/config/locales/hardship.yml
+++ b/config/locales/hardship.yml
@@ -37,11 +37,6 @@ en:
           attributes:
             hardship_reason:
               blank: You must enter reasons or attach a document
-            hardship_reason_document:
-              file_size: Your file exceeds the maximum file size of 20 megabytes
-              content_type: Your file is not in a format we can accept
-              response_error: There was an error uploading your file. Please try again
-              virus_detected: Virus detected
   helpers:
     fieldset:
       # Use an empty string in _html keys to not show the fieldset legend


### PR DESCRIPTION
It turns out we can simplify this by adding the errors to the default.yml so Rails will take care
automatically of this.

The long version of the error (the one with interpolation) continue to be in `document_upload.yml`
as this one will not be handled automagically by Rails and we need to do the interpolation ourselves.