### PR TITLE
Stop storing filenames of uploaded documents in model

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -29,9 +29,6 @@ class DocumentsController < ApplicationController
       filename: filename
     )
 
-    document_key_field_name = :"#{document_key_param}_file_name"
-    current_tribunal_case.update(document_key_field_name => nil) if current_tribunal_case.has_attribute?(document_key_field_name)
-
     respond_to do |format|
       format.html { redirect_to current_step_path }
       format.json { head :no_content }

--- a/app/forms/steps/details/grounds_for_appeal_form.rb
+++ b/app/forms/steps/details/grounds_for_appeal_form.rb
@@ -12,8 +12,7 @@ module Steps::Details
       raise 'No TribunalCase given' unless tribunal_case
 
       upload_document_if_present && tribunal_case.update(
-        grounds_for_appeal: grounds_for_appeal,
-        grounds_for_appeal_file_name: file_name
+        grounds_for_appeal: grounds_for_appeal
       )
     end
 
@@ -23,7 +22,7 @@ module Steps::Details
     end
 
     def document_provided?
-      (tribunal_case&.grounds_for_appeal_file_name || grounds_for_appeal_document).present?
+      tribunal_case&.documents(:grounds_for_appeal)&.any? || grounds_for_appeal_document.present?
     end
 
     def upload_document_if_present
@@ -39,12 +38,6 @@ module Steps::Details
       grounds_for_appeal_document.errors.each do |error|
         errors.add(:grounds_for_appeal_document, error)
       end
-    end
-
-    # If there is a file upload, store the name of the file, otherwise, retrieve any previously
-    # uploaded file name from the tribunal_case object (or none if nil).
-    def file_name
-      grounds_for_appeal_document&.file_name || tribunal_case&.grounds_for_appeal_file_name
     end
   end
 end

--- a/app/forms/steps/details/representative_approval_form.rb
+++ b/app/forms/steps/details/representative_approval_form.rb
@@ -7,9 +7,7 @@ module Steps::Details
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      upload_document_if_present && tribunal_case.update(
-        representative_approval_file_name: file_name
-      )
+      upload_document_if_present
     end
 
     def valid_uploaded_file
@@ -30,12 +28,6 @@ module Steps::Details
       representative_approval_document.errors.each do |error|
         errors.add(:representative_approval_document, error)
       end
-    end
-
-    # If there is a file upload, store the name of the file, otherwise, retrieve any previously
-    # uploaded file name from the tribunal_case object (or none if nil).
-    def file_name
-      representative_approval_document&.file_name || tribunal_case&.representative_approval_file_name
     end
   end
 end

--- a/app/forms/steps/hardship/hardship_reason_form.rb
+++ b/app/forms/steps/hardship/hardship_reason_form.rb
@@ -11,8 +11,7 @@ module Steps::Hardship
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
       upload_document_if_present && tribunal_case.update(
-        hardship_reason: hardship_reason,
-        hardship_reason_file_name: file_name
+        hardship_reason: hardship_reason
       )
     end
 
@@ -22,7 +21,7 @@ module Steps::Hardship
     end
 
     def document_provided?
-      (tribunal_case&.hardship_reason_file_name || hardship_reason_document).present?
+      tribunal_case&.documents(:hardship_reason)&.any? || hardship_reason_document.present?
     end
 
     def upload_document_if_present
@@ -38,12 +37,6 @@ module Steps::Hardship
       hardship_reason_document.errors.each do |error|
         errors.add(:hardship_reason_document, error)
       end
-    end
-
-    # If there is a file upload, store the name of the file, otherwise, retrieve any previously
-    # uploaded file name from the tribunal_case object (or none if nil).
-    def file_name
-      hardship_reason_document&.file_name || tribunal_case&.hardship_reason_file_name
     end
   end
 end

--- a/app/helpers/document_upload_helper.rb
+++ b/app/helpers/document_upload_helper.rb
@@ -1,21 +1,15 @@
 # Provides helpers for uploading a file in steps where the user can provide one
 # (as opposed to more than one) document.
-#
-# Convention: A `document_key` is the prefix for a field on the `TribunalCase` model,
-# ending in `_file_name` (e.g. `grounds_for_appeal_file_name`, as well as the prefix
-# for a virtual attribute on the respective form object, ending in `_document` (e.g.
-# `grounds_for_appeal_document`.
 module DocumentUploadHelper
   # Display an upload field if no document has been uploaded for this `document_key` yet
   def document_upload_field(form, document_key, label_text:)
     return if uploaded_document?(document_key)
 
-    field_name = document_field(document_key)
     render(
       partial: 'steps/shared/document_upload/document_upload_field',
       locals: {
         form:       form,
-        field_name: field_name,
+        field_name: document_field(document_key),
         label_text: label_text
       }
     )
@@ -36,22 +30,11 @@ module DocumentUploadHelper
   end
 
   def uploaded_document?(document_key)
-    field_name = document_file_name_field(document_key)
-    current_tribunal_case[field_name].present?
+    uploaded_document(document_key).present?
   end
 
   def uploaded_document(document_key)
-    return unless uploaded_document?(document_key)
-
-    field_name = document_file_name_field(document_key)
-    @uploaded_document ||= Document.new(
-      collection_ref: current_tribunal_case.files_collection_ref,
-      name: current_tribunal_case[field_name]
-    )
-  end
-
-  def document_file_name_field(document_key)
-    :"#{document_key}_file_name"
+    current_tribunal_case.documents(document_key).first
   end
 
   def document_field(document_key)

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -27,12 +27,17 @@ class TribunalCase < ApplicationRecord
   # Closure task
   has_value_object :closure_case_type
 
+  after_initialize do
+    # Stores results of documents fetched from uploader so they don't get fetched twice
+    @_documents_cache = {}
+  end
+
   def mapping_code
     MappingCodeDeterminer.new(self).mapping_code
   end
 
   def documents(document_key)
-    Document.for_collection(files_collection_ref, document_key: document_key)
+    @_documents_cache[document_key] ||= Document.for_collection(files_collection_ref, document_key: document_key)
   end
 
   def documents_url

--- a/app/presenters/documents_submitted_presenter.rb
+++ b/app/presenters/documents_submitted_presenter.rb
@@ -5,8 +5,20 @@ class DocumentsSubmittedPresenter < BaseAnswersPresenter
   # in the generated case PDF (the `check your answers` page will not be shown in
   # this scenario, as the user will be diverted to a kickout page before).
   #
-  def list(document_key)
+  def supporting_documents
     return [] if tribunal_case.having_problems_uploading_documents?
-    tribunal_case.documents(document_key)
+    tribunal_case.documents(:supporting_documents)
+  end
+
+  def grounds_for_appeal_file_name
+    tribunal_case.documents(:grounds_for_appeal).first&.name
+  end
+
+  def hardship_reason_file_name
+    tribunal_case.documents(:hardship_reason).first&.name
+  end
+
+  def representative_approval_file_name
+    tribunal_case.documents(:representative_approval).first&.name
   end
 end

--- a/app/presenters/representative_details_presenter.rb
+++ b/app/presenters/representative_details_presenter.rb
@@ -25,6 +25,6 @@ class RepresentativeDetailsPresenter < BaseAnswersPresenter
   end
 
   def proforma_present?
-    tribunal_case.representative_approval_file_name.present?
+    tribunal_case.documents(:representative_approval).any?
   end
 end

--- a/app/views/steps/details/check_answers/pdf/show.pdf.erb
+++ b/app/views/steps/details/check_answers/pdf/show.pdf.erb
@@ -53,7 +53,7 @@
       <tr>
         <td colspan="2" class="content with-padding">
           <%= simple_format(tribunal_case.hardship_reason, class: 'simple-format') %>
-          <p><%= pdf_t '.answers.document_attached_html', filename: tribunal_case.hardship_reason_file_name %></p>
+          <p><%= pdf_t '.answers.document_attached_html', filename: tribunal_case.documents.hardship_reason_file_name %></p>
         </td>
       </tr>
     <% end %>
@@ -100,7 +100,7 @@
   <tr>
     <td colspan="2" class="content with-padding">
       <%= simple_format(tribunal_case.grounds_for_appeal, class: 'simple-format') %>
-      <p><%= pdf_t '.answers.document_attached_html', filename: tribunal_case.grounds_for_appeal_file_name %></p>
+      <p><%= pdf_t '.answers.document_attached_html', filename: tribunal_case.documents.grounds_for_appeal_file_name %></p>
     </td>
   </tr>
   </tbody>

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -31,7 +31,7 @@
       <td colspan="2" class="with-padding">
         <p><%= t '.questions.hardship_reason' %></p>
         <%= simple_format(@tribunal_case.hardship_reason, class: 'simple-format') %>
-        <p><%= t('.answers.document_attached_html', filename: @tribunal_case.hardship_reason_file_name) %></p>
+        <p><%= t('.answers.document_attached_html', filename: @tribunal_case.documents.hardship_reason_file_name) %></p>
       </td>
     </tr>
   <% end %>
@@ -65,7 +65,7 @@
     <td colspan="2" class="with-padding">
       <p><%= translate_with_appeal_or_application '.questions.grounds_for_appeal' %></p>
       <%= simple_format(@tribunal_case.grounds_for_appeal, class: 'simple-format') %>
-      <p><%= t('.answers.document_attached_html', filename: @tribunal_case.grounds_for_appeal_file_name) %></p>
+      <p><%= t('.answers.document_attached_html', filename: @tribunal_case.documents.grounds_for_appeal_file_name) %></p>
     </td>
     <td class="change-answer">
       <%= link_to t('.change'), edit_steps_details_grounds_for_appeal_path %>

--- a/app/views/steps/shared/check_answers/_documents_submitted.html.erb
+++ b/app/views/steps/shared/check_answers/_documents_submitted.html.erb
@@ -5,7 +5,7 @@
       <%= simple_format(tribunal_case.having_problems_uploading_details, class: 'simple-format') %>
     <% else %>
       <ul class="list-bullet uploaded-docs">
-        <% tribunal_case.documents.list(:supporting_documents).each do |document| %>
+        <% tribunal_case.documents.supporting_documents.each do |document| %>
           <li><%= document.title %></li>
         <% end %>
       </ul>

--- a/app/views/steps/shared/check_answers/_documents_submitted.pdf.erb
+++ b/app/views/steps/shared/check_answers/_documents_submitted.pdf.erb
@@ -8,7 +8,7 @@
         <%= simple_format(tribunal_case.having_problems_uploading_details, class: 'simple-format') %>
       <% else %>
         <ul class="documents">
-          <% tribunal_case.documents.list(:supporting_documents).each do |document| %>
+          <% tribunal_case.documents.supporting_documents.each do |document| %>
             <li><%= document.title %></li>
           <% end %>
         </ul>

--- a/app/views/steps/shared/check_answers/_representative_details.html.erb
+++ b/app/views/steps/shared/check_answers/_representative_details.html.erb
@@ -37,7 +37,7 @@
       <th><%= t '.questions.representative_approval' %></th>
       <td>
         <ul class="list-bullet uploaded-docs">
-          <li><%= tribunal_case.representative_approval_file_name %></li>
+          <li><%= tribunal_case.documents.representative_approval_file_name %></li>
         </ul>
       </td>
       <td class="change-answer">

--- a/app/views/steps/shared/check_answers/_representative_details.pdf.erb
+++ b/app/views/steps/shared/check_answers/_representative_details.pdf.erb
@@ -50,7 +50,7 @@
         <td class="section"><%= pdf_t '.questions.representative_approval' %></td>
         <td class="content">
           <ul class="documents">
-            <li><%= tribunal_case.representative_approval_file_name %></li>
+            <li><%= tribunal_case.documents.representative_approval_file_name %></li>
           </ul>
         </td>
       </tr>

--- a/db/migrate/20170320133224_remove_filenames_from_tribunal_case.rb
+++ b/db/migrate/20170320133224_remove_filenames_from_tribunal_case.rb
@@ -1,0 +1,7 @@
+class RemoveFilenamesFromTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :tribunal_cases, :grounds_for_appeal_file_name
+    remove_column :tribunal_cases, :hardship_reason_file_name
+    remove_column :tribunal_cases, :representative_approval_file_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170317113728) do
+ActiveRecord::Schema.define(version: 20170320133224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 20170317113728) do
     t.string   "taxpayer_organisation_fao"
     t.string   "taxpayer_organisation_registration_number"
     t.text     "grounds_for_appeal"
-    t.string   "grounds_for_appeal_file_name"
     t.uuid     "files_collection_ref",                            default: -> { "uuid_generate_v4()" }
     t.boolean  "original_notice_provided",                        default: false
     t.boolean  "review_conclusion_provided",                      default: false
@@ -74,8 +73,6 @@ ActiveRecord::Schema.define(version: 20170317113728) do
     t.string   "dispute_type_other_value"
     t.string   "case_status"
     t.string   "hardship_reason"
-    t.string   "hardship_reason_file_name"
-    t.string   "representative_approval_file_name"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe DocumentsController, type: :controller do
   let(:current_tribunal_case) {
     instance_double(
       TribunalCase,
-      grounds_for_appeal_file_name: 'test file.txt',
       files_collection_ref: collection_ref,
       case_status: nil
     )
@@ -100,59 +99,27 @@ RSpec.describe DocumentsController, type: :controller do
   include_examples 'checks the validity of the current tribunal case on destroy', { document_key: :foo_bar }
 
   describe '#destroy' do
-    context 'deleting a document that has no _file_name field' do
-      let(:params) { {
-        document_key: 'supporting_documents',
-        id: another_filename
-      } }
+    let(:params) { {
+      document_key: 'supporting_documents',
+      id: another_filename
+    } }
 
-      before do
-        expect(Uploader).to receive(:delete_file).with(collection_ref: collection_ref, document_key: 'supporting_documents', filename: 'another').and_return({})
-        expect(current_tribunal_case).to receive(:has_attribute?).with(:supporting_documents_file_name).and_return(false)
-        expect(current_tribunal_case).not_to receive(:update).with(grounds_for_appeal_file_name: nil)
-      end
+    before do
+      expect(Uploader).to receive(:delete_file).with(collection_ref: collection_ref, document_key: 'supporting_documents', filename: 'another').and_return({})
+    end
 
-      context 'HTML format' do
-        it 'should delete the file and redirect to the documents_checklist step' do
-          delete :destroy, params: params
-          expect(subject).to redirect_to('step/to/redirect')
-        end
-      end
-
-      context 'JSON format' do
-        it 'should respond with an empty body and success status code' do
-          delete :destroy, params: params, format: :json
-          expect(response.status).to eq(204)
-          expect(response.body).to eq('')
-        end
+    context 'HTML format' do
+      it 'should delete the file and redirect to the documents_checklist step' do
+        delete :destroy, params: params
+        expect(subject).to redirect_to('step/to/redirect')
       end
     end
 
-    context 'deleting a document that has a _file_name attribute on the TribunalCase' do
-      let(:params) { {
-        document_key: 'grounds_for_appeal',
-        id: another_filename
-      } }
-
-      before do
-        expect(Uploader).to receive(:delete_file).with(collection_ref: collection_ref, document_key: 'grounds_for_appeal', filename: 'another').and_return({})
-        expect(current_tribunal_case).to receive(:has_attribute?).with(:grounds_for_appeal_file_name).and_return(true)
-        expect(current_tribunal_case).to receive(:update).with(grounds_for_appeal_file_name: nil)
-      end
-
-      context 'HTML format' do
-        it 'should nil the document name and redirect to the same step' do
-          delete :destroy, params: params
-          expect(subject).to redirect_to('step/to/redirect')
-        end
-      end
-
-      context 'JSON format' do
-        it 'should respond with an empty body and success status code' do
-          delete :destroy, params: params, format: :json
-          expect(response.status).to eq(204)
-          expect(response.body).to eq('')
-        end
+    context 'JSON format' do
+      it 'should respond with an empty body and success status code' do
+        delete :destroy, params: params, format: :json
+        expect(response.status).to eq(204)
+        expect(response.body).to eq('')
       end
     end
   end

--- a/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
+++ b/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
     grounds_for_appeal: grounds_for_appeal,
     grounds_for_appeal_document: grounds_for_appeal_document,
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', grounds_for_appeal: nil, grounds_for_appeal_file_name: nil) }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', grounds_for_appeal: nil) }
   let(:grounds_for_appeal) { nil }
   let(:grounds_for_appeal_document) { nil }
+  let(:documents) { [] }
 
   subject { described_class.new(arguments) }
 
@@ -30,6 +31,10 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
     end
 
     context 'when validations fail' do
+      before do
+        allow(tribunal_case).to receive(:documents).with(:grounds_for_appeal).and_return(documents)
+      end
+
       context 'when grounds_for_appeal nor grounds_for_appeal_document are present' do
         let(:grounds_for_appeal) { nil }
 
@@ -54,14 +59,17 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
     end
 
     context 'when grounds_for_appeal is valid' do
+      before do
+        allow(tribunal_case).to receive(:documents).with(:grounds_for_appeal).and_return(documents)
+      end
+
       context 'when providing appeal text' do
         let(:grounds_for_appeal) { 'I disagree with HMRC.' }
         let(:grounds_for_appeal_document) { nil }
 
         it 'saves the record' do
           expect(tribunal_case).to receive(:update).with(
-            grounds_for_appeal: 'I disagree with HMRC.',
-            grounds_for_appeal_file_name: nil
+            grounds_for_appeal: 'I disagree with HMRC.'
           ).and_return(true)
           expect(subject.save).to be(true)
         end
@@ -74,8 +82,7 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
         context 'document upload successful' do
           it 'saves the record' do
             expect(tribunal_case).to receive(:update).with(
-              grounds_for_appeal: nil,
-              grounds_for_appeal_file_name: 'image.jpg'
+              grounds_for_appeal: nil
             ).and_return(true)
 
             expect(Uploader).to receive(:add_file).with(hash_including(document_key: :grounds_for_appeal)).and_return({})
@@ -100,8 +107,7 @@ RSpec.describe Steps::Details::GroundsForAppealForm do
 
         it 'saves the record' do
           expect(tribunal_case).to receive(:update).with(
-            grounds_for_appeal: 'I disagree with HMRC.',
-            grounds_for_appeal_file_name: 'image.jpg'
+            grounds_for_appeal: 'I disagree with HMRC.'
           ).and_return(true)
 
           expect(Uploader).to receive(:add_file).and_return({})

--- a/spec/forms/steps/details/representative_approval_form_spec.rb
+++ b/spec/forms/steps/details/representative_approval_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Steps::Details::RepresentativeApprovalForm do
     tribunal_case: tribunal_case,
     representative_approval_document: representative_approval_document
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, representative_approval_file_name: nil, files_collection_ref: 'ABC123') }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: 'ABC123') }
   let(:representative_approval_document) { nil }
 
   subject { described_class.new(arguments) }
@@ -28,7 +28,6 @@ RSpec.describe Steps::Details::RepresentativeApprovalForm do
       let(:representative_approval_document) { nil }
 
       it 'returns true' do
-        expect(tribunal_case).to receive(:update).with(representative_approval_file_name: nil).and_return(true)
         expect(subject.save).to eq(true)
       end
     end
@@ -47,13 +46,8 @@ RSpec.describe Steps::Details::RepresentativeApprovalForm do
         let(:representative_approval_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
 
         context 'document upload successful' do
-          it 'saves the record' do
-            expect(tribunal_case).to receive(:update).with(
-              representative_approval_file_name: 'image.jpg'
-            ).and_return(true)
-
+          it 'uploads the file' do
             expect(Uploader).to receive(:add_file).with(hash_including(document_key: :representative_approval)).and_return({})
-
             expect(subject.save).to be(true)
           end
         end

--- a/spec/forms/steps/hardship/hardship_reason_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_reason_form_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
     hardship_reason: hardship_reason,
-    hardship_reason_document: hardship_reason_document,
+    hardship_reason_document: hardship_reason_document
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', hardship_reason: hardship_reason, hardship_reason_file_name: hardship_reason_file_name) }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', hardship_reason: hardship_reason) }
   let(:hardship_reason) { nil }
   let(:hardship_reason_document) { nil }
-  let(:hardship_reason_file_name) { nil }
+  let(:documents) { [] }
 
   subject { described_class.new(arguments) }
 
@@ -31,6 +31,10 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
     end
 
     context 'when validations fail' do
+      before do
+        allow(tribunal_case).to receive(:documents).with(:hardship_reason).and_return(documents)
+      end
+
       context 'when hardship_reason nor hardship_reason_document are present' do
         let(:hardship_reason) { nil }
 
@@ -55,14 +59,17 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
     end
 
     context 'when hardship_reason is valid' do
+      before do
+        allow(tribunal_case).to receive(:documents).with(:hardship_reason).and_return(documents)
+      end
+
       context 'when providing appeal text' do
         let(:hardship_reason) { 'I disagree with HMRC.' }
         let(:hardship_reason_document) { nil }
 
         it 'saves the record' do
           expect(tribunal_case).to receive(:update).with(
-            hardship_reason: 'I disagree with HMRC.',
-            hardship_reason_file_name: nil
+            hardship_reason: 'I disagree with HMRC.'
           ).and_return(true)
           expect(subject.save).to be(true)
         end
@@ -75,8 +82,7 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
         context 'document upload successful' do
           it 'saves the record' do
             expect(tribunal_case).to receive(:update).with(
-              hardship_reason: nil,
-              hardship_reason_file_name: 'image.jpg'
+              hardship_reason: nil
             ).and_return(true)
 
             expect(Uploader).to receive(:add_file).with(hash_including(document_key: :hardship_reason)).and_return({})
@@ -101,8 +107,7 @@ RSpec.describe Steps::Hardship::HardshipReasonForm do
 
         it 'saves the record' do
           expect(tribunal_case).to receive(:update).with(
-            hardship_reason: 'A very good reason',
-            hardship_reason_file_name: 'image.jpg'
+            hardship_reason: 'A very good reason'
           ).and_return(true)
 
           expect(Uploader).to receive(:add_file).and_return({})

--- a/spec/helpers/document_upload_helper_spec.rb
+++ b/spec/helpers/document_upload_helper_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe DocumentUploadHelper do
 
   before do
     allow(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
-    allow(tribunal_case).to receive(:[]).with(:some_step_file_name).and_return(file_name)
+    allow(tribunal_case).to receive(:documents).with(:some_step).and_return(documents)
   end
 
   describe '#document_upload_field' do
     subject { helper.document_upload_field(form, :some_step, label_text: 'A file') }
 
     context 'when there is no document uploaded' do
-      let(:file_name) { nil }
+      let(:documents) { [] }
 
       it 'renders the upload field' do
         expect(helper).to receive(:render).with(
@@ -29,7 +29,7 @@ RSpec.describe DocumentUploadHelper do
     end
 
     context 'when there is an uploaded document' do
-      let(:file_name) { 'shopping_list.pdf' }
+      let(:documents) { [double(Document, name: 'shopping_list.pdf')] }
 
       it { is_expected.to be_nil }
     end
@@ -39,25 +39,19 @@ RSpec.describe DocumentUploadHelper do
     subject { helper.display_current_document(:some_step) }
 
     context 'when there is no document uploaded' do
-      let(:file_name) { nil }
+      let(:documents) { [] }
 
       it { is_expected.to be_nil }
     end
 
     context 'when there is an uploaded document' do
-      let(:file_name) { 'shopping_list.pdf' }
-      let(:document) { instance_double(Document) }
+      let(:documents) { [instance_double(Document, name: 'shopping_list.pdf')] }
 
       it 'renders the uploaded document partial' do
-        expect(Document).to receive(:new).with(
-          collection_ref: 'r3f3r3nc3',
-          name: 'shopping_list.pdf'
-        ).and_return(document)
-
         expect(helper).to receive(:render).with(
           partial: 'steps/shared/document_upload/current_document',
           locals: {
-            current_document: document,
+            current_document: documents.first,
             document_key: :some_step
           }
         )

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -18,9 +18,16 @@ RSpec.describe TribunalCase, type: :model do
     let(:collection_ref) { SecureRandom.uuid }
     let(:attributes) { { files_collection_ref: collection_ref } }
 
-    it 'should delegate to Document' do
+    it 'delegates to Document' do
       expect(Document).to receive(:for_collection).with(collection_ref, document_key: :foo)
       subject.documents(:foo)
+    end
+
+    it 'memoizes for a given key' do
+      expect(Document).to receive(:for_collection).with(collection_ref, document_key: :bar).once.and_return([])
+
+      subject.documents(:bar)
+      subject.documents(:bar)
     end
   end
 

--- a/spec/presenters/documents_submitted_presenter_spec.rb
+++ b/spec/presenters/documents_submitted_presenter_spec.rb
@@ -3,15 +3,19 @@ require 'spec_helper'
 RSpec.describe DocumentsSubmittedPresenter do
   subject { described_class.new(tribunal_case) }
 
-  describe '#list' do
+  describe '#supporting_documents' do
     let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: having_problems) }
+    let(:documents) { double('documents') }
+
+    before do
+      allow(tribunal_case).to receive(:documents).with(:supporting_documents).and_return(documents)
+    end
 
     context 'when no problems uploading documents' do
       let(:having_problems) { false }
 
       it 'should retrieve any uploaded file for the given documents prefix' do
-        expect(tribunal_case).to receive(:documents).with(:prefix)
-        subject.list(:prefix)
+        expect(subject.supporting_documents).to eq(documents)
       end
     end
 
@@ -19,8 +23,79 @@ RSpec.describe DocumentsSubmittedPresenter do
       let(:having_problems) { true }
 
       it 'should return an empty collection' do
-        expect(tribunal_case).not_to receive(:documents).with(:prefix)
-        expect(subject.list(:prefix)).to eq([])
+        expect(subject.supporting_documents).to be_empty
+      end
+    end
+  end
+
+  describe '#grounds_for_appeal_file_name' do
+    let(:tribunal_case) { instance_double(TribunalCase) }
+
+    before do
+      allow(tribunal_case).to receive(:documents).with(:grounds_for_appeal).and_return(documents)
+    end
+
+    context 'when there is a grounds for appeal file uploaded' do
+      let(:documents) { [instance_double(Document, name: 'foo.pdf')] }
+
+      it 'returns the file name' do
+        expect(subject.grounds_for_appeal_file_name).to eq('foo.pdf')
+      end
+    end
+
+    context 'when there is no grounds for appeal document uploaded' do
+      let(:documents) { [] }
+
+      it 'returns nil' do
+        expect(subject.grounds_for_appeal_file_name).to be_nil
+      end
+    end
+  end
+
+  describe '#hardship_reason_file_name' do
+    let(:tribunal_case) { instance_double(TribunalCase) }
+
+    before do
+      allow(tribunal_case).to receive(:documents).with(:hardship_reason).and_return(documents)
+    end
+
+    context 'when there is a hardship reason file uploaded' do
+      let(:documents) { [instance_double(Document, name: 'foo.pdf')] }
+
+      it 'returns the file name' do
+        expect(subject.hardship_reason_file_name).to eq('foo.pdf')
+      end
+    end
+
+    context 'when there is no hardship reason document uploaded' do
+      let(:documents) { [] }
+
+      it 'returns nil' do
+        expect(subject.hardship_reason_file_name).to be_nil
+      end
+    end
+  end
+
+  describe '#representative_approval_file_name' do
+    let(:tribunal_case) { instance_double(TribunalCase) }
+
+    before do
+      allow(tribunal_case).to receive(:documents).with(:representative_approval).and_return(documents)
+    end
+
+    context 'when there is a rep approval file uploaded' do
+      let(:documents) { [instance_double(Document, name: 'foo.pdf')] }
+
+      it 'returns the file name' do
+        expect(subject.representative_approval_file_name).to eq('foo.pdf')
+      end
+    end
+
+    context 'when there is no rep approval document uploaded' do
+      let(:documents) { [] }
+
+      it 'returns nil' do
+        expect(subject.representative_approval_file_name).to be_nil
       end
     end
   end

--- a/spec/presenters/representative_details_presenter_spec.rb
+++ b/spec/presenters/representative_details_presenter_spec.rb
@@ -96,15 +96,19 @@ RSpec.describe RepresentativeDetailsPresenter do
   end
 
   describe '#proforma_present?' do
-    let(:tribunal_case) { instance_double(TribunalCase, representative_approval_file_name: file_name) }
+    before do
+      allow(tribunal_case).to receive(:documents).with(:representative_approval).and_return(documents)
+    end
 
     context 'when a document was uploaded' do
-      let(:file_name) { 'document.txt' }
+      let(:documents) { [instance_double(Document)] }
+
       it { expect(subject.proforma_present?).to eq(true) }
     end
 
     context 'when no document was uploaded' do
-      let(:file_name) { nil }
+      let(:documents) { [] }
+
       it { expect(subject.proforma_present?).to eq(false) }
     end
   end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CaseDetailsPdf do
         let(:having_problems_uploading_documents) { true }
 
         it 'should not show previously uploaded documents' do
-          expect(tribunal_case).not_to receive(:documents)
+          expect(tribunal_case).not_to receive(:documents).with(:supporting_documents)
           expect(decorated_tribunal_case).to receive(:having_problems_uploading_details)
           expect(subject.generate).to match(/%PDF/)
         end


### PR DESCRIPTION
This removes all the `*_file_name` fields from the `TribunalCase` model
and moves to only relying on the uploader listing functionality to tell
us about the files the user has uploaded.

- Update `GroundsForAppealForm`, `HardshipReasonForm`, and
  `RepresentativeApprovalForm` to no longer store file names against the
  model
- Update `UploadHelper` to get file names from the Uploader
- Update `TribunalCase` to cache fetched documents for the length of the
  request
- Update CYA pages to get file names from the uploader
- Remove no longer needed filename fields from the schema