### PR TITLE
Don't intercept events if GA hasn't loaded

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -9,17 +9,20 @@ moj.Modules.gaEvents = {
   init: function() {
     var self = this;
 
-    if($(self.radioFormClass).length) {
-      self.trackRadioForms();
-    }
-    if($(self.checkboxClass).length) {
-      self.trackCheckboxes();
-    }
-    if($(self.linkClass).length) {
-      self.trackLinks();
-    }
-    if($(self.fileUploadFormClass).length) {
-      self.trackFileUploads();
+    // don't bind anything if the GA object isn't defined
+    if(typeof window.ga !== 'undefined') {
+      if($(self.radioFormClass).length) {
+        self.trackRadioForms();
+      }
+      if($(self.checkboxClass).length) {
+        self.trackCheckboxes();
+      }
+      if($(self.linkClass).length) {
+        self.trackLinks();
+      }
+      if($(self.fileUploadFormClass).length) {
+        self.trackFileUploads();
+      }
     }
   },
 


### PR DESCRIPTION
Prevent event interception for tracking purposes if the GA script (`window.ga`) hasn't been defined