### PR TITLE
Silently send to Sentry missing translation, without user error.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
   end
 
   def appeal_or_application_params
-    {appeal_or_application: I18n.translate("generic.appeal_or_application.#{current_tribunal_case.appeal_or_application}")}
+    {appeal_or_application: translate("generic.appeal_or_application.#{current_tribunal_case.appeal_or_application}")}
   end
 
   def analytics_tracking_id

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,5 +34,5 @@ Rails.application.configure do
   # gov.uk elements formbuilder, exceptions will not be raised for
   # missing translations of model attribute names. The form will
   # get the constantized attribute name itself, in form labels.
-  config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = false
 end

--- a/config/initializers/capture_missing_translations.rb
+++ b/config/initializers/capture_missing_translations.rb
@@ -17,6 +17,8 @@ module I18n
         key: key
       )
       Raven.capture_exception(self)
+
+      self
     end
   end
 end

--- a/config/initializers/capture_missing_translations.rb
+++ b/config/initializers/capture_missing_translations.rb
@@ -1,0 +1,22 @@
+# We want to be alerted via Sentry about any missing translation happening on production, without
+# having to raise an exception, blowing up the app and showing an error message to the user.
+#
+# Overriding the `MissingTranslationData` class to capture the exception whenever initialized, we make
+# sure we are alerted each time this exception is generated, without having to enable the config flag
+# `raise_on_missing_translations` on production environment, and thus letting the `translate` or `t`
+# helpers return a sensible fallback translation to the user.
+#
+module I18n
+  class MissingTranslationData
+    def initialize(locale, key, options = nil)
+      super
+
+      Raven.extra_context(
+        locale: locale,
+        scope: options[:scope],
+        key: key
+      )
+      Raven.capture_exception(self)
+    end
+  end
+end


### PR DESCRIPTION
Capture any missing translation exceptions without showing them to the user, send them to Sentry
and let the `translate` or `t` helpers return a sensible fallback to the user, without the app
blowing app.

On dev and test environment we continue raising exceptions, but not anymore on prod.