### PR TITLE
Fetch all documents at once in TribunalCase

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,11 +1,16 @@
 class Document
-  attr_accessor :collection_ref, :name, :last_modified
+  attr_reader :collection_ref, :full_name, :name, :last_modified
   alias_attribute :title, :name
 
   def initialize(attrs)
-    self.collection_ref = attrs.fetch(:collection_ref)
-    self.name = attrs[:name] || attrs.fetch(:title)
-    self.last_modified = attrs[:last_modified]
+    @collection_ref = attrs.fetch(:collection_ref)
+    @full_name = attrs[:name] || attrs.fetch(:title)
+    @name = @full_name.split('/').last
+    @last_modified = attrs[:last_modified]
+  end
+
+  def self.all_for_collection(collection_ref)
+    for_collection(collection_ref, document_key: nil).group_by { |f| f.full_name.split('/').first.to_sym }
   end
 
   def self.for_collection(collection_ref, document_key:)
@@ -16,7 +21,7 @@ class Document
   end
 
   def encoded_name
-    Base64.encode64(name)
+    Base64.encode64(full_name)
   end
 
   # We use the encoded file name in the route path for DELETE (or fallback POST)
@@ -31,6 +36,6 @@ class Document
   end
 
   def ==(other)
-    other.collection_ref == collection_ref && other.name == name
+    other.collection_ref == collection_ref && other.full_name == full_name
   end
 end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -27,12 +27,6 @@ class TribunalCase < ApplicationRecord
   # Closure task
   has_value_object :closure_case_type
 
-  # Stores results of documents fetched from uploader so they don't get fetched
-  # twice
-  after_initialize do
-    @_documents_cache = {}
-  end
-
   # Do not store unsanitized user input that may get sent through to
   # third-party APIs.
   before_save :sanitize
@@ -42,7 +36,8 @@ class TribunalCase < ApplicationRecord
   end
 
   def documents(document_key)
-    @_documents_cache[document_key] ||= Document.for_collection(files_collection_ref, document_key: document_key)
+    @_documents_cache ||= Document.all_for_collection(files_collection_ref)
+    @_documents_cache.fetch(document_key, [])
   end
 
   def documents_url

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -112,14 +112,20 @@ RSpec.describe TribunalCase, type: :model do
   describe '#documents' do
     let(:collection_ref) { SecureRandom.uuid }
     let(:attributes) { { files_collection_ref: collection_ref } }
+    let(:documents) { double('Documents') }
 
     it 'delegates to Document' do
-      expect(Document).to receive(:for_collection).with(collection_ref, document_key: :foo)
-      subject.documents(:foo)
+      expect(Document).to receive(:all_for_collection).with(collection_ref).and_return({foo: documents})
+      expect(subject.documents(:foo)).to eq(documents)
     end
 
-    it 'memoizes for a given key' do
-      expect(Document).to receive(:for_collection).with(collection_ref, document_key: :bar).once.and_return([])
+    it 'returns empty array if no documents found' do
+      expect(Document).to receive(:all_for_collection).with(collection_ref).and_return({foo: documents})
+      expect(subject.documents(:bar)).to eq([])
+    end
+
+    it 'memoizes' do
+      expect(Document).to receive(:all_for_collection).with(collection_ref).once.and_return({bar: documents})
 
       subject.documents(:bar)
       subject.documents(:bar)


### PR DESCRIPTION
A recent change made `TribunalCase` instances cache fetched documents
for any given document key. This improves it even further by fetching
all documents for a model instance _once_, and caching that, ensuring
that we don't have to keep fetching data from the uploader.