### PR TITLE
Prevent users submitting the same case multiple times.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,6 @@ class ApplicationController < ActionController::Base
   end
 
   def check_tribunal_case_status
-    raise Errors::CaseSubmitted if current_tribunal_case.case_status == CaseStatus::SUBMITTED
+    raise Errors::CaseSubmitted unless current_tribunal_case.case_status.nil?
   end
 end

--- a/app/services/case_creator.rb
+++ b/app/services/case_creator.rb
@@ -6,6 +6,10 @@ class CaseCreator
   end
 
   def call
+    tribunal_case.update(
+      case_status: CaseStatus::IN_PROGRESS
+    )
+
     glimr_case = GlimrNewCase.new(tribunal_case).call
     case_reference = glimr_case.case_reference
 

--- a/app/value_objects/case_status.rb
+++ b/app/value_objects/case_status.rb
@@ -1,5 +1,6 @@
 class CaseStatus < ValueObject
   VALUES = [
-    SUBMITTED = new(:submitted)
+    IN_PROGRESS = new(:in_progress),
+    SUBMITTED   = new(:submitted)
   ].freeze
 end

--- a/spec/services/case_creator_spec.rb
+++ b/spec/services/case_creator_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe CaseCreator do
     end
 
     context 'registering the case into glimr' do
+      context 'marking the tribunal case as `in_progress`' do
+        let(:glimr_new_case_double) {
+          instance_double(GlimrNewCase, call: double(case_reference: 'TC/2017/12345', confirmation_code: 'ABCDEF'))
+        }
+
+        it 'should mark the tribunal case as `in_progress` while GLiMR call is executed' do
+          expect(tribunal_case).to receive(:update).with(case_status: CaseStatus::IN_PROGRESS)
+          expect(tribunal_case).to receive(:update).with(case_reference: 'TC/2017/12345', case_status: CaseStatus::SUBMITTED)
+          subject.call
+        end
+      end
+
       context 'when glimr call was success' do
         let(:glimr_new_case_double) {
           instance_double(GlimrNewCase, call: double(case_reference: 'TC/2017/12345', confirmation_code: 'ABCDEF'))

--- a/spec/support/current_tribunal_case_shared_examples.rb
+++ b/spec/support/current_tribunal_case_shared_examples.rb
@@ -9,6 +9,14 @@ RSpec.shared_examples 'checks the validity of the current tribunal case' do
     end
   end
 
+  context 'when there is a case with submission in progress in the session' do
+    let(:current_tribunal_case) { instance_double(TribunalCase, case_status: CaseStatus::IN_PROGRESS) }
+
+    it 'redirects to the case already submitted error page' do
+      expect(response).to redirect_to(case_submitted_errors_path)
+    end
+  end
+
   context 'when there is an already submitted case in the session' do
     let(:current_tribunal_case) { instance_double(TribunalCase, case_status: CaseStatus::SUBMITTED) }
 


### PR DESCRIPTION
This PR introduces an intermediate case status `in_progress` which is set as soon as
the user clicks submits, while the submission to GLiMR is being processed, and we reset
the status back to `submitted` once we get the result from GLiMR.

This stops the user from clicking quickly the submit button, or submitting and going back
and forward, and the case will not be duplicated. The user will get the message about their
case being already submitted, and we will show the case reference if any, and the link to
download the PDF, as usual.

https://www.pivotaltracker.com/story/show/141857773

Another PR will also introduce a frontend improvement to give the user feedback once clicking
the submit button, and disable or hide it to avoid also duplications, but this will be a
JS-dependant solution so this PR is a catch-all solution for the odd edge case.