### PR TITLE
Document#encoded_name should not use full filename

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -21,7 +21,7 @@ class Document
   end
 
   def encoded_name
-    Base64.encode64(full_name)
+    Base64.encode64(name)
   end
 
   # We use the encoded file name in the route path for DELETE (or fallback POST)


### PR DESCRIPTION
A recent change made the `Document#encoded_name` use the full
underlying filename (including the folder) instead of just the
file name itself - this reverts that change.