### PR TITLE
Add explanatory copy when TC number is not present.

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -20,7 +20,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
     set_personalisation(
       recipient_name: mail_presenter.recipient_name,
       case_reference: mail_presenter.case_reference,
-      show_case_reference: mail_presenter.show_case_reference?,
+      case_reference_present: mail_presenter.case_reference_present?,
+      case_reference_absent: mail_presenter.case_reference_absent?,
       appeal_or_application: mail_presenter.appeal_or_application
     )
 

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -2,8 +2,12 @@ class CaseMailPresenter < SimpleDelegator
   # Initialise with a TribunalCase instance and any method not
   # defined in this class will be forwarded automatically to that instance.
 
-  def show_case_reference?
+  def case_reference_present?
     notify_presence_for(case_reference)
+  end
+
+  def case_reference_absent?
+    notify_absence_for(case_reference)
   end
 
   # GOV.UK Notify does not accept `nil` values, instead use empty strings
@@ -50,6 +54,11 @@ class CaseMailPresenter < SimpleDelegator
   # GOV.UK Notify expects this to be literals
   def notify_presence_for(field)
     field.present? ? 'yes' : 'no'
+  end
+
+  # GOV.UK Notify expects this to be literals
+  def notify_absence_for(field)
+    field.blank? ? 'yes' : 'no'
   end
 
   def tribunal_case

--- a/app/views/errors/case_submitted.html.erb
+++ b/app/views/errors/case_submitted.html.erb
@@ -4,9 +4,7 @@
 
     <p class="heading-medium"><%= t '.lead_text_html', tax_tribunal_phone: Rails.application.config.tax_tribunal_phone %></p>
 
-    <% if @tribunal_case.case_reference.present? %>
-      <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
-    <% end %>
+    <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
 
     <h2 class="heading-medium">
       <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>

--- a/app/views/shared/_confirmation_case_reference.html.erb
+++ b/app/views/shared/_confirmation_case_reference.html.erb
@@ -1,6 +1,18 @@
-<h1 class="heading-large">
-  <span class="heading-secondary"><%= t '.case_reference' %></span>
-  <span><%= tribunal_case.case_reference %></span>
-</h1>
+<% if tribunal_case.case_reference.present? %>
 
-<p><%= t '.note_number' %></p>
+  <h1 class="heading-large">
+    <span class="heading-secondary"><%= t '.case_reference' %></span>
+    <span><%= tribunal_case.case_reference %></span>
+  </h1>
+
+  <p><%= t '.note_number' %></p>
+
+<% else %>
+
+  <h1 class="heading-large">
+    <span class="heading-secondary"><%= t '.case_submitted_successfully' %></span>
+  </h1>
+
+  <p><%= t '.case_reference_pending' %></p>
+
+<% end %>

--- a/app/views/steps/closure/confirmation/show.html.erb
+++ b/app/views/steps/closure/confirmation/show.html.erb
@@ -3,9 +3,7 @@
   <p><%= t '.confirmation_email' %></p>
 </div>
 
-<% if @tribunal_case.case_reference.present? %>
-  <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
-<% end %>
+<%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
 
 <h2 class="heading-medium">
   <%= link_to t('.save_or_print_pdf'), steps_closure_check_answers_path(format: :pdf), target: '_blank' %>

--- a/app/views/steps/details/confirmation/show.html.erb
+++ b/app/views/steps/details/confirmation/show.html.erb
@@ -3,9 +3,7 @@
   <p><%= t '.confirmation_email' %></p>
 </div>
 
-<% if @tribunal_case.case_reference.present? %>
-  <%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
-<% end %>
+<%= render partial: 'shared/confirmation_case_reference', locals: {tribunal_case: @tribunal_case} %>
 
 <h2 class="heading-medium">
   <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>

--- a/config/locales/shared.yml
+++ b/config/locales/shared.yml
@@ -2,6 +2,8 @@ en:
   shared:
     confirmation_case_reference:
       case_reference: 'Your case reference number is:'
+      case_submitted_successfully: Your case was submitted successfully.
+      case_reference_pending: You will be sent a case reference number shortly.
       note_number: Please make a note of this number in case you need to contact us.
   steps:
     shared:

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       it 'sets the personalisation' do
         expect(
           mail.govuk_notify_personalisation.keys
-        ).to eq([:recipient_name, :case_reference, :show_case_reference, :appeal_or_application])
+        ).to eq([:recipient_name, :case_reference, :case_reference_present, :case_reference_absent, :appeal_or_application])
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       let(:case_reference) { nil }
 
       it 'sets the personalisation' do
-        expect(mail.govuk_notify_personalisation).to include(case_reference: '', show_case_reference: 'no')
+        expect(mail.govuk_notify_personalisation).to include(case_reference: '', case_reference_present: 'no', case_reference_absent: 'yes')
       end
     end
 
@@ -60,7 +60,8 @@ RSpec.describe NotifyMailer, type: :mailer do
             personalisation: {
               recipient_name: '[FILTERED]',
               case_reference: 'TC/2017/00001',
-              show_case_reference: 'yes',
+              case_reference_present: 'yes',
+              case_reference_absent: 'no',
               appeal_or_application: :appeal
             }
           }

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -35,14 +35,25 @@ RSpec.describe CaseMailPresenter do
     end
   end
 
-  describe '#show_case_reference?' do
+  describe '#case_reference_present?' do
     context 'for a case with reference number' do
-      it { expect(subject.show_case_reference?).to eq('yes') }
+      it { expect(subject.case_reference_present?).to eq('yes') }
     end
 
     context 'for a case without reference number' do
       let(:case_reference) { nil }
-      it { expect(subject.show_case_reference?).to eq('no') }
+      it { expect(subject.case_reference_present?).to eq('no') }
+    end
+  end
+
+  describe '#case_reference_absent?' do
+    context 'for a case with reference number' do
+      it { expect(subject.case_reference_absent?).to eq('no') }
+    end
+
+    context 'for a case without reference number' do
+      let(:case_reference) { nil }
+      it { expect(subject.case_reference_absent?).to eq('yes') }
     end
   end
 


### PR DESCRIPTION
Add a explanatory copy in the confirmation page and the email sent to the taxpayer in case
the TC number is not present, to tell them it will be sent at a later stage.

Only the 'dev/test' Notify environment has been updated with the new template variables, so
production is not affected, but once we deploy to PROD, we need to ensure to update the
corresponding template too, otherwise as we are sending different personalisation, it will fail.

https://www.pivotaltracker.com/story/show/141877681