### PR TITLE
Debounce case submit button with JS

### DIFF
--- a/app/assets/javascripts/modules/debounce-button.js
+++ b/app/assets/javascripts/modules/debounce-button.js
@@ -1,0 +1,28 @@
+'use strict';
+
+moj.Modules.debounceButton = {
+  button_class: '.js-debounce',
+
+  init: function() {
+    var self = this;
+
+    if($(self.button_class).length) {
+      self.bindEvents();
+    }
+  },
+
+  bindEvents: function() {
+    var self = this,
+        disableClass = 'disabled';
+
+    $(self.button_class).on('click', function(e) {
+      var $button = $(e.target);
+
+      if($button.hasClass(disableClass)) {
+        e.preventDefault();
+      } else {
+        $button.addClass(disableClass);
+      }
+    });
+  }
+};

--- a/app/views/steps/shared/check_answers/_footer.html.erb
+++ b/app/views/steps/shared/check_answers/_footer.html.erb
@@ -12,5 +12,5 @@
 </p>
 
 <p>
-  <%= button_to t('.submit_and_continue'), submit_link, class: 'button' %>
+  <%= button_to t('.submit_and_continue'), submit_link, class: 'button js-debounce' %>
 </p>


### PR DESCRIPTION
Duplicate case submission has been prevented on the back end, but to improve user experience, we disabled the submit button on first press. 

In discussion with @mrbootle-moj we decided that there is no need to change the wording of the button or replace it with a spinner. It just changes to a "disabled" faded state on first click and subsequent clicks are blocked.

[Pivotal](https://www.pivotaltracker.com/story/show/141937843)