### PR TITLE
Change button label `start again` to `finish` in error page.

### DIFF
--- a/app/views/errors/case_submitted.html.erb
+++ b/app/views/errors/case_submitted.html.erb
@@ -10,6 +10,6 @@
       <%= link_to t('.save_or_print_pdf'), steps_details_check_answers_path(format: :pdf), target: '_blank' %>
     </h2>
 
-    <%= render partial: 'steps/shared/finish_button', locals: {name: t('.start_again')} %>
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('.finish')} %>
   </div>
 </div>

--- a/app/views/shared/_confirmation_case_reference.html.erb
+++ b/app/views/shared/_confirmation_case_reference.html.erb
@@ -1,4 +1,4 @@
-<% if tribunal_case.case_reference.present? %>
+<% if tribunal_case&.case_reference.present? %>
 
   <h1 class="heading-large">
     <span class="heading-secondary"><%= t '.case_reference' %></span>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -11,6 +11,7 @@ en:
       lead_text_html: To make changes to your case, please contact the tax tribunal on %{tax_tribunal_phone} (find out about
               <a href="https://www.gov.uk/call-charges">call charges</a>).
       start_again: Start again
+      finish: Finish
       case_reference: "Your case reference number is:"
       note_number: Please make a note of this number in case you need to contact us.
       save_or_print_pdf: Save or print your case details


### PR DESCRIPTION
As per Josh suggestion. Also ensure we don't blow up if no tribunal case is in the session.