### PR TITLE
Create 404 page and catch-all route.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
     when Errors::CaseSubmitted
       redirect_to case_submitted_errors_path
     else
-      raise unless Rails.env.production?
+      raise if Rails.application.config.consider_all_requests_local
 
       Raven.capture_exception(exception)
       redirect_to unhandled_errors_path

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,24 +1,27 @@
 class ErrorsController < ApplicationController
-  def case_not_found
-    respond_to do |format|
-      format.html
-      format.json { head :not_found }
-    end
-  end
-
   def case_submitted
     @tribunal_case = current_tribunal_case
+    respond_with_status(:unprocessable_entity)
+  end
 
-    respond_to do |format|
-      format.html
-      format.json { head :unprocessable_entity }
-    end
+  def case_not_found
+    respond_with_status(:not_found)
+  end
+
+  def not_found
+    respond_with_status(:not_found)
   end
 
   def unhandled
+    respond_with_status(:internal_server_error)
+  end
+
+  private
+
+  def respond_with_status(status)
     respond_to do |format|
       format.html
-      format.json { head :internal_server_error }
+      format.json { head status }
     end
   end
 end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%=t '.more_text' %></p>
+
+    <div class="form-group">
+      <%= link_to t('.start_again'), start_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -20,3 +20,8 @@ en:
       start_again: Start again
       lead_text: "To keep this service secure, any information you've entered hasn't been saved."
       more_text: "You'll need to start again."
+    not_found:
+      heading: Page not found
+      lead_text: If you entered a web address please check if it was correct.
+      more_text: You can also try starting from the homepage to find the information you need.
+      start_again: Start again

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,10 +90,17 @@ Rails.application.routes.draw do
     get :case_not_found
     get :case_submitted
     get :unhandled
+    get :not_found
   end
 
   root to: 'home#index'
   get :start, to: 'home#start'
   get :contact, to: 'home#contact', as: :contact_page
   get :terms_and_conditions, to: 'home#terms_and_conditions'
+
+  # catch-all route
+  # :nocov:
+  match '*path', to: 'errors#not_found', via: :all, constraints:
+    lambda { |_request| !Rails.application.config.consider_all_requests_local }
+  # :nocov:
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ApplicationController do
 
   context 'Exceptions handling' do
     before do
-      allow(Rails).to receive(:env).and_return('production'.inquiry)
+      allow(Rails).to receive_message_chain(:application, :config, :consider_all_requests_local).and_return(false)
     end
 
     context 'Errors::CaseNotFound' do


### PR DESCRIPTION
Dev and test envs will continue raising an exception to enable better debug, but on production
envs routes not found will render a nicer error page.

https://www.pivotaltracker.com/story/show/142305261