### PR TITLE
rename /healthcheck.json to /status.json

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,7 +1,0 @@
-class HealthcheckController < ApplicationController
-  respond_to :json
-
-  def index
-    respond_with(Healthcheck.check.to_json)
-  end
-end

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,0 +1,7 @@
+class StatusController < ApplicationController
+  respond_to :json
+
+  def index
+    respond_with(Status.check.to_json)
+  end
+end

--- a/app/services/status.rb
+++ b/app/services/status.rb
@@ -1,5 +1,5 @@
 require 'glimr_api_client'
-class Healthcheck
+class Status
   def self.check
     new.check
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :healthcheck, only: [:index]
+  resources :status, only: [:index]
 
   resource :errors, only: [] do
     get :case_not_found

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe HealthcheckController do
+RSpec.describe StatusController do
   let(:status) do
     {
       service_status: 'ok',
@@ -21,11 +21,11 @@ RSpec.describe HealthcheckController do
     stub_request(:get, /healthcheck/).
       to_return(status: 200, body: { service_status: 'ok' }.to_json)
     expect(ActiveRecord::Base).to receive(:connection).and_return(double)
-    allow_any_instance_of(Healthcheck).to receive(:version).and_return('ABC123')
+    allow_any_instance_of(Status).to receive(:version).and_return('ABC123')
   end
 
   # This is very-happy-path to ensure the controller responds.  The bulk of the
-  # healthcheck is tested in spec/services/healthcheck_spec.rb.
+  # status is tested in spec/services/status_spec.rb.
   describe '#index' do
     describe 'happy path' do
       specify do

--- a/spec/services/status_spec.rb
+++ b/spec/services/status_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Healthcheck do
+RSpec.describe Status do
   let(:glimr_available) {
     instance_double(GlimrApiClient::Available, available?: true)
   }


### PR DESCRIPTION
"healthcheck" has a specific meaning for the
platforms team (should this endpoint receive
traffic from the load-balancer), so we should be
using /status.json for our system status endpoints