### PR TITLE
restrict file-types for single uploads

### DIFF
--- a/app/views/steps/shared/document_upload/_document_upload_field.html.erb
+++ b/app/views/steps/shared/document_upload/_document_upload_field.html.erb
@@ -2,6 +2,6 @@
   <%= form.label(field_name, label_text) %>
 </p>
 
-<%= form.file_field(field_name) %>
+<%= form.file_field(field_name, accept: DocumentUpload::ALLOWED_CONTENT_TYPES.join(','), src: 'camera') %>
 
 <%= render partial: 'steps/shared/file_upload_requirements' %>


### PR DESCRIPTION
Adding these attributes to single file uploads restricts mobile browsers to images only on iOS and just the whitelisted document types on Android.

On desktop browsers, it limits the displayed file picker to "Custom file types" i.e. the whitelisted file types, but if the user wishes to try a different type they can select one by changing the file picker to "All files", but a non-valid file will then be rejected by the back end.