### PR TITLE
Fix for `check your answers` not showing representative details sometimes.

### DIFF
--- a/app/forms/steps/details/has_representative_form.rb
+++ b/app/forms/steps/details/has_representative_form.rb
@@ -24,6 +24,7 @@ module Steps::Details
       tribunal_case.update(
         has_representative: has_representative_value,
         # The following are dependent attributes that need to be reset
+        representative_professional_status: nil,
         representative_individual_first_name: nil,
         representative_individual_last_name: nil,
         representative_organisation_name: nil,

--- a/app/forms/steps/details/representative_professional_status_form.rb
+++ b/app/forms/steps/details/representative_professional_status_form.rb
@@ -22,6 +22,7 @@ module Steps::Details
       return true unless changed?
 
       tribunal_case.update(
+        has_representative: HasRepresentative::YES,
         representative_professional_status: representative_professional_status_value
       )
     end

--- a/app/forms/steps/details/user_type_form.rb
+++ b/app/forms/steps/details/user_type_form.rb
@@ -22,7 +22,10 @@ module Steps::Details
       return true unless changed?
 
       tribunal_case.update(
-        user_type: user_type_value
+        user_type: user_type_value,
+        # The following are dependent attributes that need to be reset
+        has_representative: nil,
+        representative_professional_status: nil
       )
     end
   end

--- a/spec/forms/steps/details/has_representative_form_spec.rb
+++ b/spec/forms/steps/details/has_representative_form_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Steps::Details::HasRepresentativeForm do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           has_representative: HasRepresentative::YES,
+          representative_professional_status: nil,
           representative_individual_first_name: nil,
           representative_individual_last_name: nil,
           representative_organisation_name: nil,

--- a/spec/forms/steps/details/representative_professional_status_form_spec.rb
+++ b/spec/forms/steps/details/representative_professional_status_form_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Steps::Details::RepresentativeProfessionalStatusForm do
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
+          has_representative: HasRepresentative::YES,
           representative_professional_status: RepresentativeProfessionalStatus::ACCOUNTANT
         ).and_return(true)
         expect(subject.save).to be(true)

--- a/spec/forms/steps/details/user_type_form_spec.rb
+++ b/spec/forms/steps/details/user_type_form_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe Steps::Details::UserTypeForm do
 
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          user_type: UserType::REPRESENTATIVE
+          user_type: UserType::REPRESENTATIVE,
+          has_representative: nil,
+          representative_professional_status: nil
         ).and_return(true)
         expect(subject.save).to be(true)
       end


### PR DESCRIPTION
A condition exists where filling the form as a representative, instead of as a taxpayer
having a representative, will not set the attribute `has_representative` and thus, even
if the details are filled, we don't show them in the `check your answers` page.

With this small change we ensure that regardless of the path the user follows to fill the
form, if they are asked for representative details, we set the `has_representative` to YES.
This will catch both scenarios just fine.

https://www.pivotaltracker.com/story/show/141957833