### PR TITLE
Remove Inaccurate return penalty from case types.

### DIFF
--- a/app/forms/steps/appeal/case_type_form.rb
+++ b/app/forms/steps/appeal/case_type_form.rb
@@ -10,9 +10,8 @@ module Steps::Appeal
         CaseType::VAT,
         CaseType::CAPITAL_GAINS_TAX,
         CaseType::CORPORATION_TAX,
-        CaseType::INACCURATE_RETURN_PENALTY,
-        CaseType::INFORMATION_NOTICE,
         CaseType::NI_CONTRIBUTIONS,
+        CaseType::INFORMATION_NOTICE,
         SHOW_MORE
       ].map(&:to_s)
     end

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -48,7 +48,6 @@ class CaseType < ValueObject
     GAMING_DUTY                  = new(:gaming_duty,                  indirect_tax_properties),
     GENERAL_BETTING_DUTY         = new(:general_betting_duty,         indirect_tax_properties),
     HYDROCARBON_OIL_DUTIES       = new(:hydrocarbon_oil_duties,       indirect_tax_properties),
-    INACCURATE_RETURN_PENALTY    = new(:inaccurate_return_penalty,    ask_penalty: true, appeal_or_application: :appeal),
     INCOME_TAX                   = new(:income_tax,                   direct_tax_properties),
     INFORMATION_NOTICE           = new(:information_notice,           ask_dispute_type: true, ask_penalty: true, appeal_or_application: :appeal),
     INHERITANCE_TAX              = new(:inheritance_tax,              direct_tax_properties),

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -142,7 +142,6 @@ en:
           vat_html: <strong>Value Added Tax (VAT)</strong>
           capital_gains_tax_html: <strong>Capital Gains Tax</strong>
           corporation_tax_html: <strong>Corporation Tax</strong>
-          inaccurate_return_penalty_html: <strong>Inaccurate return penalty</strong>
           information_notice_html: <strong>Information notice</strong><br>a request for further information about your tax position
           ni_contributions_html: <strong>National Insurance (NI) contributions</strong>
           _show_more_html: <strong>Other type of tax, appeal or application</strong>

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -165,7 +165,6 @@ en:
               vat: Value Added Tax (VAT)
               capital_gains_tax: Capital Gains Tax
               corporation_tax: Corporation Tax
-              inaccurate_return_penalty: Inaccurate return penalty
               information_notice: Information notice
               ni_contributions: National Insurance (NI) contributions
               apn_penalty: Accelerated Payment Notice (APN) penalty

--- a/spec/forms/steps/appeal/case_type_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_form_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe Steps::Appeal::CaseTypeForm do
         vat
         capital_gains_tax
         corporation_tax
-        inaccurate_return_penalty
-        information_notice
         ni_contributions
+        information_notice
         _show_more
       ))
     end


### PR DESCRIPTION
It is now included in the dispute types (penalties and surcharges).
Also, move NI contributions above information notices in the list of case types.

https://www.pivotaltracker.com/story/show/140765873