### PR TITLE
Tailor challenge copy for direct/indirect taxes.

### DIFF
--- a/app/presenters/appeal_type_answers_presenter.rb
+++ b/app/presenters/appeal_type_answers_presenter.rb
@@ -14,7 +14,7 @@ class AppealTypeAnswersPresenter < BaseAnswersPresenter
   def challenged_decision_question
     row(
       tribunal_case.challenged_decision,
-      as: :challenged_decision
+      as: direct_tax? ? 'challenged_decision.direct_tax' : 'challenged_decision.indirect_tax'
     )
   end
 
@@ -82,5 +82,11 @@ class AppealTypeAnswersPresenter < BaseAnswersPresenter
       as: :tax_amount,
       i18n_value: false
     )
+  end
+
+  private
+
+  def direct_tax?
+    tribunal_case.case_type.direct_tax?
   end
 end

--- a/app/views/steps/appeal/challenged_decision/edit.html.erb
+++ b/app/views/steps/appeal/challenged_decision/edit.html.erb
@@ -2,7 +2,8 @@
   <div class="column-two-thirds">
     <%= step_header %>
 
-    <h1 class="heading-large"><%=t '.heading' %></h1>
+    <% i18n_heading_key = current_tribunal_case.case_type.direct_tax? ? '.heading_direct_tax' : '.heading_indirect_tax' %>
+    <h1 class="heading-large"><%=t i18n_heading_key %></h1>
 
     <%= step_form @form_object, html:{ class: 'ga-radioButtonGroup'  } do |f| %>
       <%= f.radio_button_fieldset :challenged_decision, choices: Steps::Appeal::ChallengedDecisionForm.choices %>

--- a/config/locales/appeal.yml
+++ b/config/locales/appeal.yml
@@ -21,7 +21,8 @@ en:
           continue: Continue
       challenged_decision:
         edit:
-          heading: Did you appeal the original decision with HMRC?
+          heading_direct_tax: Did you appeal the original decision with HMRC?
+          heading_indirect_tax: Did you ask for a review of the original decision?
           help_panel:
             heading: Help with challenging a tax decision
             content_html: >
@@ -88,7 +89,7 @@ en:
         steps/appeal/challenged_decision_form:
           attributes:
             challenged_decision:
-              inclusion: Select whether you made an appeal to HMRC
+              inclusion: Select an option
         steps/appeal/challenged_decision_status_form:
           attributes:
             challenged_decision_status:

--- a/config/locales/details.pdf.yml
+++ b/config/locales/details.pdf.yml
@@ -12,7 +12,6 @@ en:
             notice: Notice of appeal
           show:
             questions:
-              challenged_decision: Decision challenged with HMRC?
               tax_amount: Amount of tax under dispute
               penalty_level: Penalty or surcharge amount
               penalty_amount: Penalty or surcharge amount

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -122,7 +122,9 @@ en:
           grounds_for_appeal_heading: Grounds for appeal
           hardship_heading: Hardship application
           questions:
-            challenged_decision: Did you appeal the original decision with HMRC?
+            challenged_decision:
+              direct_tax: Did you appeal the original decision with HMRC?
+              indirect_tax: Did you ask for a review of the original decision?
             challenged_decision_status: What reponse did you receive?
             case_type: What is your %{appeal_or_application} about?
             dispute_type: What is your dispute about?
@@ -143,8 +145,12 @@ en:
             hardship_reason: Why will paying the tax under dispute cause financial hardship?
           answers:
             challenged_decision:
-              'yes': 'Yes'
-              'no': 'No'
+              direct_tax:
+                'yes': 'Yes'
+                'no': 'No'
+              indirect_tax:
+                'yes': 'Yes'
+                'no': 'No'
             disputed_tax_paid:
               'yes': 'Yes'
               'no': 'No'

--- a/spec/presenters/appeal_type_answers_presenter_spec.rb
+++ b/spec/presenters/appeal_type_answers_presenter_spec.rb
@@ -57,22 +57,49 @@ RSpec.describe AppealTypeAnswersPresenter do
   describe '`challenged_decision` question' do
     let(:row) { subject.challenged_decision_question }
     let(:challenged_decision) { true }
+    let(:case_type) { instance_double(CaseType, direct_tax?: direct_tax) }
 
-    context 'when appeal is challenged' do
-      it 'has the correct attributes' do
-        expect(row.question).to    eq('.questions.challenged_decision')
-        expect(row.answer).to      eq('.answers.challenged_decision.true')
-        expect(row.change_path).to be_nil
+    context 'for a direct tax' do
+      let(:direct_tax) { true }
+
+      context 'when appeal is challenged' do
+        it 'has the correct attributes' do
+          expect(row.question).to eq('.questions.challenged_decision.direct_tax')
+          expect(row.answer).to eq('.answers.challenged_decision.direct_tax.true')
+          expect(row.change_path).to be_nil
+        end
+      end
+
+      context 'when appeal is unchallenged' do
+        let(:challenged_decision) { false }
+
+        it 'has the correct attributes' do
+          expect(row.question).to eq('.questions.challenged_decision.direct_tax')
+          expect(row.answer).to eq('.answers.challenged_decision.direct_tax.false')
+          expect(row.change_path).to be_nil
+        end
       end
     end
 
-    context 'when appeal is unchallenged' do
-      let(:challenged_decision) { false }
+    context 'for an indirect tax' do
+      let(:direct_tax) { false }
 
-      it 'has the correct attributes' do
-        expect(row.question).to    eq('.questions.challenged_decision')
-        expect(row.answer).to      eq('.answers.challenged_decision.false')
-        expect(row.change_path).to be_nil
+      context 'when appeal is challenged' do
+        it 'has the correct attributes' do
+          expect(row.question).to eq('.questions.challenged_decision.indirect_tax')
+          expect(row.answer).to eq('.answers.challenged_decision.indirect_tax.true')
+          expect(row.change_path).to be_nil
+        end
+      end
+
+      context 'when appeal is unchallenged' do
+        let(:challenged_decision) { false }
+
+        it 'has the correct attributes' do
+          expect(row.question).to eq('.questions.challenged_decision.indirect_tax')
+          expect(row.answer).to eq('.answers.challenged_decision.indirect_tax.false')
+          expect(row.change_path).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
Depending on the case type being direct or indirect tax, we need to show a slighly different
copy in the challenge step, but also in the check your answers.

The solution is not pretty but probably not worth overengineering it, specially as there is a
big PR to change the check your answers presenters waiting to be merge and there will be conflicts.

https://www.pivotaltracker.com/story/show/140878591