### PR TITLE
Respond to all formats in errors controller.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -21,7 +21,7 @@ class ErrorsController < ApplicationController
   def respond_with_status(status)
     respond_to do |format|
       format.html
-      format.json { head status }
+      format.all { head status }
     end
   end
 end


### PR DESCRIPTION
Probably a bit too late as the pentesting is well undergoing but for the future I think
it is a good idea to catch all formats in the `errors controller`, specially 404, so for
example robots/crawlers scanning for vulnerabilities don't raise a Sentry excetion due to
our app not responding to `.xml` or `.ini`