### PR TITLE
Silence Sentry debug on app startup.

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,9 +1,8 @@
+# Will use SENTRY_DSN environment variable if set
 # :nocov:
-if %w( production ).include?(Rails.env) && ENV['SENTRY_DSN'].present?
-  Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN']
-    config.environments = %w( production )
-    config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  end
+Raven.configure do |config|
+  config.environments = %w( production )
+  config.silence_ready = true
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end
 # :nocov:


### PR DESCRIPTION
Also, no need to explicitely set the sentry DSN, as it will use the env variable if set, nor
need to check for the environment as we are telling Sentry to only report on production.