### PR TITLE
Some kickout pages should not redirect to the survey.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
   def destroy
     reset_session
     respond_to do |format|
-      format.html { redirect_to params[:survey] ? Rails.configuration.survey_link : root_path }
+      format.html { redirect_to params[:survey] == 'true' ? Rails.configuration.survey_link : root_path }
       format.json { render json: {} }
     end
   end

--- a/app/views/errors/unhandled.html.erb
+++ b/app/views/errors/unhandled.html.erb
@@ -6,8 +6,6 @@
 
     <p class="lede"><%=t '.more_text' %></p>
 
-    <div class="form-group">
-      <%= link_to t('.start_again'), start_path, class: 'button' %>
-    </div>
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('.start_again'), show_survey: false} %>
   </div>
 </div>

--- a/app/views/steps/appeal/must_wait_for_challenge_decision/show.html.erb
+++ b/app/views/steps/appeal/must_wait_for_challenge_decision/show.html.erb
@@ -7,7 +7,6 @@
       <%=t '.lead_text_html' %>
     </p>
 
-<%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish')} %>
-
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish'), show_survey: false} %>
   </div>
 </div>

--- a/app/views/steps/shared/_finish_button.html.erb
+++ b/app/views/steps/shared/_finish_button.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= link_to name, session_path(survey: true), method: :delete, class: 'button' %>
+  <%= link_to name, session_path(survey: local_assigns.fetch(:show_survey, true)), method: :delete, class: 'button' %>
 </div>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -20,9 +20,18 @@ RSpec.describe SessionsController, type: :controller do
     end
 
     context 'when survey param is provided' do
-      it 'redirects to the survey page' do
-        get :destroy, params: {survey: true}
-        expect(response.location).to match(/goo\.gl\/forms/)
+      context 'for a `true` value' do
+        it 'redirects to the survey page' do
+          get :destroy, params: {survey: true}
+          expect(response.location).to match(/goo\.gl\/forms/)
+        end
+      end
+
+      context 'for a `false` value' do
+        it 'redirects to the home page' do
+          get :destroy, params: {survey: false}
+          expect(subject).to redirect_to(root_path)
+        end
       end
     end
 


### PR DESCRIPTION
As per Josh request, some kickout pages should not redirect the user to the survey when
they click the 'Finish' or 'Start again' button, as those kickout are too early into the
journey or are errors and will not provide any meaninful feedback.

We continue to have the survey in some other kickout pages, like the `having problems uploading
documents` as this one is almost to the end of the journey.

https://www.pivotaltracker.com/story/show/142587175