### PR TITLE
Add missing dispute_type translations & start again copy

### DIFF
--- a/app/views/steps/appeal/must_wait_for_challenge_decision/show.html.erb
+++ b/app/views/steps/appeal/must_wait_for_challenge_decision/show.html.erb
@@ -7,6 +7,6 @@
       <%=t '.lead_text_html' %>
     </p>
 
-    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.finish'), show_survey: false} %>
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
   </div>
 </div>

--- a/config/locales/check_answers.yml
+++ b/config/locales/check_answers.yml
@@ -95,6 +95,8 @@ en:
         amount_of_tax_owed_by_taxpayer: HMRC claim you owe tax
         amount_and_penalty: HMRC claim you owe tax and a penalty or surcharge
         information_notice: Information notice
+        refusal_to_register_applicant: Refusal to register an applicant
+        cancellation_of_registration: Cancellation of registration
     penalty_level:
       question: What is the penalty or surcharge amount?
       question_pdf: Penalty or surcharge amount

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -21,6 +21,7 @@ en:
           <li>If you're still having trouble, enter reasons and click 'continue' to print and complete your appeal by post.</li>
         </ul>
     finish: Finish
+    start_again: Start again
   steps:
     details:
       user_type:


### PR DESCRIPTION
- Add missing translations for money laundering dispute types
- Change copy on kickout page button from "Finish" to "Start again"

cf. https://www.pivotaltracker.com/story/show/141401419

Supersedes #325 