### PR TITLE
Improve PDF filename generation

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -14,7 +14,7 @@ class CasesController < ApplicationController
   private
 
   def generate_and_upload_pdf
-    CaseDetailsPdf.new(current_tribunal_case, self).generate_and_upload
+    CaseDetailsPdf.new(current_tribunal_case, self, @presenter).generate_and_upload
   end
 
   def send_emails

--- a/app/controllers/steps/closure/check_answers_controller.rb
+++ b/app/controllers/steps/closure/check_answers_controller.rb
@@ -7,7 +7,7 @@ module Steps::Closure
 
       respond_to do |format|
         format.html
-        format.pdf { render pdf: 'check_answers' }
+        format.pdf { render pdf: @presenter.pdf_filename }
       end
     end
   end

--- a/app/controllers/steps/details/check_answers_controller.rb
+++ b/app/controllers/steps/details/check_answers_controller.rb
@@ -7,7 +7,7 @@ module Steps::Details
 
       respond_to do |format|
         format.html
-        format.pdf { render pdf: 'check_answers' }
+        format.pdf { render pdf: @presenter.pdf_filename }
       end
     end
   end

--- a/app/presenters/check_answers/answers_presenter.rb
+++ b/app/presenters/check_answers/answers_presenter.rb
@@ -15,10 +15,22 @@ module CheckAnswers
       tribunal_case.case_reference
     end
 
+    def pdf_filename
+      [tribunal_case.case_reference, taxpayer_name_for_filename].compact.join('_').tr('/', '_')
+    end
+
     private
 
     def pdf?
       format == :pdf
+    end
+
+    def taxpayer_name_for_filename
+      [
+        tribunal_case.taxpayer_individual_first_name,
+        tribunal_case.taxpayer_individual_last_name,
+        tribunal_case.taxpayer_organisation_name
+      ].compact.join.gsub(/\s+/, '')
     end
   end
 end

--- a/app/services/case_details_pdf.rb
+++ b/app/services/case_details_pdf.rb
@@ -1,7 +1,7 @@
 require 'tempfile'
 
 class CaseDetailsPdf
-  attr_reader :tribunal_case, :controller_ctx, :pdf
+  attr_reader :tribunal_case, :controller_ctx, :presenter, :pdf
 
   PDF_CONFIG = {
     formats: [:pdf],
@@ -9,9 +9,10 @@ class CaseDetailsPdf
     encoding: 'UTF-8'
   }
 
-  def initialize(tribunal_case, controller_ctx)
+  def initialize(tribunal_case, controller_ctx, presenter)
     @tribunal_case  = tribunal_case
     @controller_ctx = controller_ctx
+    @presenter = presenter
   end
 
   def generate
@@ -23,7 +24,7 @@ class CaseDetailsPdf
   end
 
   def filename
-    [case_reference, 'HMRC', taxpayer_name].join('_') + '.pdf'
+    presenter.pdf_filename + '.pdf'
   end
 
   private
@@ -34,18 +35,6 @@ class CaseDetailsPdf
 
   def collection_ref
     tribunal_case.files_collection_ref
-  end
-
-  def case_reference
-    (tribunal_case.case_reference || 'NO_REF').tr('/', '_')
-  end
-
-  def taxpayer_name
-    [
-      tribunal_case.taxpayer_individual_first_name,
-      tribunal_case.taxpayer_individual_last_name,
-      tribunal_case.taxpayer_organisation_name
-    ].compact.join.gsub(/\s+/, '')
   end
 
   def upload

--- a/spec/controllers/steps/closure/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/closure/check_answers_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::Closure::CheckAnswersController, type: :controller do
   it_behaves_like 'an end point step controller'
 
   let!(:tribunal_case) { TribunalCase.create(case_type: CaseType::OTHER) }
-  let(:presenter) { instance_double(CheckAnswers::ClosureAnswersPresenter) }
+  let(:presenter) { instance_double(CheckAnswers::ClosureAnswersPresenter, pdf_filename: 'check_answers') }
 
   context 'HTML format' do
     it 'assigns the presenter' do

--- a/spec/controllers/steps/details/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/details/check_answers_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Steps::Details::CheckAnswersController, type: :controller do
   it_behaves_like 'an end point step controller'
 
   let!(:tribunal_case) { TribunalCase.create(case_type: CaseType::OTHER) }
-  let(:presenter) { instance_double(CheckAnswers::AppealAnswersPresenter) }
+  let(:presenter) { instance_double(CheckAnswers::AppealAnswersPresenter, pdf_filename: 'check_answers') }
 
   context 'HTML format' do
     it 'assigns the presenter' do

--- a/spec/presenters/check_answers/answers_presenter_spec.rb
+++ b/spec/presenters/check_answers/answers_presenter_spec.rb
@@ -29,4 +29,28 @@ describe CheckAnswers::AnswersPresenter do
       end
     end
   end
+
+  describe '#pdf_filename' do
+    let(:case_reference) { 'TC/2016/12345' }
+
+    context 'for an organisation' do
+      it 'should generate an appropriate file name' do
+        expect(tribunal_case).to receive(:taxpayer_individual_first_name).and_return(nil)
+        expect(tribunal_case).to receive(:taxpayer_individual_last_name).and_return(nil)
+        expect(tribunal_case).to receive(:taxpayer_organisation_name).and_return('CPS')
+
+        expect(subject.pdf_filename).to eq('TC_2016_12345_CPS')
+      end
+    end
+
+    context 'for an individual' do
+      it 'should generate an appropriate file name' do
+        expect(tribunal_case).to receive(:taxpayer_individual_first_name).and_return('Shirley')
+        expect(tribunal_case).to receive(:taxpayer_individual_last_name).and_return('Schmidt')
+        expect(tribunal_case).to receive(:taxpayer_organisation_name).and_return(nil)
+
+        expect(subject.pdf_filename).to eq('TC_2016_12345_ShirleySchmidt')
+      end
+    end
+  end
 end

--- a/spec/services/case_details_pdf_spec.rb
+++ b/spec/services/case_details_pdf_spec.rb
@@ -17,30 +17,9 @@ RSpec.describe CaseDetailsPdf do
       current_tribunal_case: tribunal_case
     )
   }
+  let(:presenter) { instance_double(CheckAnswers::AnswersPresenter, pdf_filename: 'TC_2016_12345_FirstnameLastname') }
 
-  subject { described_class.new(tribunal_case, controller_ctx) }
-
-  describe '#filename' do
-    context 'for an organisation' do
-      it 'should generate an appropriate file name' do
-        expect(tribunal_case).to receive(:taxpayer_individual_first_name).and_return(nil)
-        expect(tribunal_case).to receive(:taxpayer_individual_last_name).and_return(nil)
-        expect(tribunal_case).to receive(:taxpayer_organisation_name).and_return('CPS')
-
-        expect(subject.filename).to eq('TC_2016_12345_HMRC_CPS.pdf')
-      end
-    end
-
-    context 'for an individual' do
-      it 'should generate an appropriate file name' do
-        expect(tribunal_case).to receive(:taxpayer_individual_first_name).and_return('Shirley')
-        expect(tribunal_case).to receive(:taxpayer_individual_last_name).and_return('Schmidt')
-        expect(tribunal_case).to receive(:taxpayer_organisation_name).and_return(nil)
-
-        expect(subject.filename).to eq('TC_2016_12345_HMRC_ShirleySchmidt.pdf')
-      end
-    end
-  end
+  subject { described_class.new(tribunal_case, controller_ctx, presenter) }
 
   describe '#generate' do
     it 'should generate the PDF' do
@@ -54,7 +33,7 @@ RSpec.describe CaseDetailsPdf do
       expect(DocumentUpload).to receive(:new).with(
         an_instance_of(File),
         document_key: :case_details,
-        filename: 'TC_2016_12345_HMRC_FirstnameLastname.pdf',
+        filename: 'TC_2016_12345_FirstnameLastname.pdf',
         content_type: 'application/pdf',
         collection_ref: 'd29210a8-f2fe-4d6f-ac96-ea4f9fd66687'
       ).and_return(uploader_double)


### PR DESCRIPTION
- Remove HMRC from filename (not always appropriate)
- Move filename generation to presenter to avoid duplication
- Use presenter filename for inline PDF download