### PR TITLE
Ensure PDF translations include appeal_or_application

### DIFF
--- a/app/views/application/_contact_details_row.pdf.erb
+++ b/app/views/application/_contact_details_row.pdf.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="question">
-    <%=t "check_answers.#{contact_details_row.question}.question" %>
+    <%= translate_with_appeal_or_application "check_answers.#{contact_details_row.question}.question" %>
   </td>
 
   <td class="answer answer-contact-details">

--- a/app/views/application/_documents_submitted_row.pdf.erb
+++ b/app/views/application/_documents_submitted_row.pdf.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="question">
-    <%=t "check_answers.#{documents_submitted_row.question}.question" %>
+    <%= translate_with_appeal_or_application "check_answers.#{documents_submitted_row.question}.question" %>
   </td>
 
   <td class="answer answer-documents-submitted">

--- a/app/views/application/_file_or_text_row.pdf.erb
+++ b/app/views/application/_file_or_text_row.pdf.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="question">
-    <%=t "check_answers.#{file_or_text_row.question}.question" %>
+    <%= translate_with_appeal_or_application "check_answers.#{file_or_text_row.question}.question" %>
   </td>
 
   <td class="answer answer-file-or-text">

--- a/app/views/application/_row.pdf.erb
+++ b/app/views/application/_row.pdf.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="question">
-    <%=t "check_answers.#{row.question}.question" %>
+    <%= translate_with_appeal_or_application "check_answers.#{row.question}.question" %>
   </td>
 
   <td class="answer answer-value">

--- a/app/views/application/_section.pdf.erb
+++ b/app/views/application/_section.pdf.erb
@@ -1,4 +1,4 @@
-<h2 class="section-header"><%=t "check_answers.sections.#{section.name}" %></h2>
+<h2 class="section-header"><%= translate_with_appeal_or_application "check_answers.sections.#{section.name}" %></h2>
 
 <table>
   <%= render section.answers %>

--- a/app/views/steps/closure/check_answers/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/show.pdf.erb
@@ -7,9 +7,9 @@
 
   <body id="case-details-pdf">
     <div class="pdf-header">
-      <h2><%=t 'check_answers.pdf.header.tax_chamber' %></h2>
+      <h2><%= translate_with_appeal_or_application 'check_answers.pdf.header.tax_chamber' %></h2>
       <h1>
-        <%=t 'check_answers.pdf.header.closure_heading' %>
+        <%= translate_with_appeal_or_application 'check_answers.pdf.header.closure_heading' %>
         <% if @presenter.case_reference? %>
           &ndash; <%= @presenter.case_reference %>
         <% end %>

--- a/app/views/steps/details/check_answers/show.pdf.erb
+++ b/app/views/steps/details/check_answers/show.pdf.erb
@@ -7,9 +7,9 @@
 
   <body id="case-details-pdf">
     <div class="pdf-header">
-      <h2><%=t 'check_answers.pdf.header.tax_chamber' %></h2>
+      <h2><%= translate_with_appeal_or_application 'check_answers.pdf.header.tax_chamber' %></h2>
       <h1>
-        <%=t 'check_answers.pdf.header.appeal_heading' %>
+        <%= translate_with_appeal_or_application 'check_answers.pdf.header.appeal_heading' %>
         <% if @presenter.case_reference? %>
           &ndash; <%= @presenter.case_reference %>
         <% end %>


### PR DESCRIPTION
The "Check your answers" PDF changes removed the `pdf_t` method and
replaced it with regular `t` - however the headings, and questions,
require us to interpolate the appeal or application value.