### PR TITLE
Restoration case 'decision challenge' to list indirect options.

### DIFF
--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -20,9 +20,8 @@ class AppealDecisionTree < DecisionTree
 
   private
 
-  def tribunal_case_is_unchallenged_indirect_tax?
-    !tribunal_case.case_type.direct_tax? &&
-      tribunal_case.challenged_decision == ChallengedDecision::NO
+  def direct_tax_or_restoration?
+    tribunal_case.case_type.direct_tax? || tribunal_case.case_type == CaseType::RESTORATION_CASE
   end
 
   def tribunal_case_is_challenged?
@@ -42,10 +41,10 @@ class AppealDecisionTree < DecisionTree
   def after_challenged_decision_step
     if tribunal_case_is_challenged?
       edit(:challenged_decision_status)
-    elsif tribunal_case_is_unchallenged_indirect_tax?
-      dispute_or_penalties_decision
-    else
+    elsif direct_tax_or_restoration?
       show(:must_challenge_hmrc)
+    else
+      dispute_or_penalties_decision
     end
   end
 

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -60,7 +60,7 @@ class CaseType < ValueObject
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),
     REMOTE_GAMING_DUTY           = new(:remote_gaming_duty,           indirect_tax_properties),
     REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, appeal_or_application: :application),
-    RESTORATION_CASE             = new(:restoration_case,             direct_tax: true, ask_challenged: true, appeal_or_application: :application),
+    RESTORATION_CASE             = new(:restoration_case,             direct_tax: false, ask_challenged: true, appeal_or_application: :application),
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),

--- a/spec/services/appeal_decision_tree/challenged_decision_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_spec.rb
@@ -56,4 +56,20 @@ RSpec.describe AppealDecisionTree, '#destination' do
       it { is_expected.to have_destination(:challenged_decision_status, :edit) }
     end
   end
+
+  context 'for a restoration case' do
+    let(:case_type) { CaseType::RESTORATION_CASE }
+
+    context 'and the case has not been challenged' do
+      let(:challenged_decision) { ChallengedDecision::NO }
+
+      it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
+    end
+
+    context 'and the case has been challenged' do
+      let(:challenged_decision) { ChallengedDecision::YES }
+
+      it { is_expected.to have_destination(:challenged_decision_status, :edit) }
+    end
+  end
 end


### PR DESCRIPTION
This change will take care of the `decision challenge` for restoration cases, where:

- when asking YES, the list of options must behave as an indirect tax.
- when asking NO, there should be a kickout like for direct tax.

Also, we are not asking for disputes and we jump directly to lateness.

As part of another PR we need to revisit the 2 possible kickout pages to change the copy
depending if it is a direct or indirect tax (as we did for the header of the challenge question).

https://www.pivotaltracker.com/story/show/142498857