### PR TITLE
Branching of challenge kickout pages for direct/indirect/restoration cases.

### DIFF
--- a/app/controllers/steps/challenge/must_ask_for_review_controller.rb
+++ b/app/controllers/steps/challenge/must_ask_for_review_controller.rb
@@ -1,0 +1,6 @@
+module Steps::Challenge
+  class MustAskForReviewController < Steps::ChallengeStepController
+    def show
+    end
+  end
+end

--- a/app/controllers/steps/challenge/must_wait_for_review_decision_controller.rb
+++ b/app/controllers/steps/challenge/must_wait_for_review_decision_controller.rb
@@ -1,0 +1,6 @@
+module Steps::Challenge
+  class MustWaitForReviewDecisionController < Steps::ChallengeStepController
+    def show
+    end
+  end
+end

--- a/app/controllers/steps/challenge_step_controller.rb
+++ b/app/controllers/steps/challenge_step_controller.rb
@@ -1,0 +1,10 @@
+class Steps::ChallengeStepController < StepController
+  private
+
+  # TODO: no coverage temporary until we move the logic from AppealDecisionTree
+  # :nocov:
+  def decision_tree_class
+    ChallengeDecisionTree
+  end
+  # :nocov:
+end

--- a/app/services/challenge_decision_tree.rb
+++ b/app/services/challenge_decision_tree.rb
@@ -1,0 +1,13 @@
+class ChallengeDecisionTree < DecisionTree
+  def destination
+    return next_step if next_step
+
+    # TODO: challenge decisions to be moved here from AppealDecisionTree
+    case step_name.to_sym
+    when :challenged_decision
+    when :challenged_decision_status
+    else
+      raise "Invalid step '#{step_params}'"
+    end
+  end
+end

--- a/app/views/steps/challenge/must_ask_for_review/show.html.erb
+++ b/app/views/steps/challenge/must_ask_for_review/show.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede">
+      <%=t '.lead_text_html' %>
+    </p>
+
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
+  </div>
+</div>

--- a/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-large"><%=t '.heading' %></h1>
+
+    <p class="lede">
+      <%=t '.lead_text_html' %>
+    </p>
+
+    <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
+  </div>
+</div>

--- a/config/locales/challenge.yml
+++ b/config/locales/challenge.yml
@@ -1,0 +1,16 @@
+en:
+  steps:
+    challenge:
+      must_ask_for_review:
+        show:
+          heading: You must ask for a review of the original decision
+          lead_text_html: The original notice letter will explain what to do.
+      must_wait_for_review_decision:
+        show:
+          heading: You must wait before you can appeal
+          lead_text_html: |
+            <p>If you've accepted or asked for a review, you can only appeal to the tax tribunal when you have:</p>
+            <ul class="list list-bullet">
+              <li>received a review conclusion letter</li>
+              <li>waited 45 days and not received a letter</li>
+            </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,11 @@ Rails.application.routes.draw do
       edit_step :penalty_and_tax_amounts
     end
 
+    namespace :challenge do
+      show_step :must_ask_for_review
+      show_step :must_wait_for_review_decision
+    end
+
     namespace :hardship do
       edit_step :disputed_tax_paid
       edit_step :hardship_review_requested

--- a/spec/controllers/steps/challenge/must_ask_for_review_controller_spec.rb
+++ b/spec/controllers/steps/challenge/must_ask_for_review_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Challenge::MustAskForReviewController, type: :controller do
+  it_behaves_like 'an end point step controller'
+end

--- a/spec/controllers/steps/challenge/must_wait_for_review_decision_controller_spec.rb
+++ b/spec/controllers/steps/challenge/must_wait_for_review_decision_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Challenge::MustWaitForReviewDecisionController, type: :controller do
+  it_behaves_like 'an end point step controller'
+end

--- a/spec/services/appeal_decision_tree/challenged_decision_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe AppealDecisionTree, '#destination' do
     context 'and the case has not been challenged' do
       let(:challenged_decision) { ChallengedDecision::NO }
 
-      it { is_expected.to have_destination(:must_challenge_hmrc, :show) }
+      it { is_expected.to have_destination('/steps/challenge/must_ask_for_review', :show) }
     end
 
     context 'and the case has been challenged' do

--- a/spec/services/appeal_decision_tree/challenged_decision_status_spec.rb
+++ b/spec/services/appeal_decision_tree/challenged_decision_status_spec.rb
@@ -18,7 +18,17 @@ RSpec.describe AppealDecisionTree, '#destination' do
     context 'and the status is `pending`' do
       let(:challenged_decision_status) { ChallengedDecisionStatus::PENDING }
 
-      it { is_expected.to have_destination(:must_wait_for_challenge_decision, :show) }
+      context 'for a direct tax case' do
+        let(:case_type) { CaseType.new(:anything, direct_tax: true) }
+
+        it { is_expected.to have_destination(:must_wait_for_challenge_decision, :show) }
+      end
+
+      context 'for an indirect tax case' do
+        let(:case_type) { CaseType.new(:anything, direct_tax: false) }
+
+        it { is_expected.to have_destination('/steps/challenge/must_wait_for_review_decision', :show) }
+      end
     end
 
     context 'and the status is other than `pending`' do

--- a/spec/services/challenge_decision_tree_spec.rb
+++ b/spec/services/challenge_decision_tree_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe ChallengeDecisionTree do
+  let(:tribunal_case) { double('TribunalCase') }
+  let(:step_params)   { double('Step') }
+  let(:next_step)     { nil }
+  subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
+
+  describe '#destination' do
+    context 'when the step is invalid' do
+      let(:step_params) { { ungueltig: { waschmaschine: 'nein' } } }
+
+      it 'raises an error' do
+        expect { subject.destination }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR will implement the neccessary logic to branch the kickout challenge pages depending on
the kind of tax (direct/indirect) and the snowflake `restoration case`.

Also as part of this PR, we lay out the path to a slight refactor to group together all the challenge
logic and decision in their own decision tree class.
There are several TODOs which is going to be the next PR.

https://www.pivotaltracker.com/story/show/142498857