### PR TITLE
Fix issues with "I'm having trouble uploading docs"

### DIFF
--- a/app/controllers/steps/closure/support_documents_controller.rb
+++ b/app/controllers/steps/closure/support_documents_controller.rb
@@ -5,8 +5,8 @@ module Steps::Closure
     def edit
       @form_object = SupportDocumentsForm.new(
         tribunal_case: current_tribunal_case,
-        having_problems_uploading_documents: current_tribunal_case.having_problems_uploading_documents,
-        having_problems_uploading_details: current_tribunal_case.having_problems_uploading_details
+        having_problems_uploading: current_tribunal_case.having_problems_uploading,
+        having_problems_uploading_explanation: current_tribunal_case.having_problems_uploading_explanation
       )
     end
 

--- a/app/controllers/steps/details/documents_checklist_controller.rb
+++ b/app/controllers/steps/details/documents_checklist_controller.rb
@@ -7,8 +7,8 @@ module Steps::Details
         tribunal_case: current_tribunal_case,
         original_notice_provided: current_tribunal_case.original_notice_provided,
         review_conclusion_provided: current_tribunal_case.review_conclusion_provided,
-        having_problems_uploading_documents: current_tribunal_case.having_problems_uploading_documents,
-        having_problems_uploading_details: current_tribunal_case.having_problems_uploading_details
+        having_problems_uploading: current_tribunal_case.having_problems_uploading,
+        having_problems_uploading_explanation: current_tribunal_case.having_problems_uploading_explanation
       )
     end
 

--- a/app/forms/steps/closure/support_documents_form.rb
+++ b/app/forms/steps/closure/support_documents_form.rb
@@ -1,9 +1,9 @@
 module Steps::Closure
   class SupportDocumentsForm < BaseForm
-    attribute :having_problems_uploading_documents, Boolean
-    attribute :having_problems_uploading_details, String
+    attribute :having_problems_uploading, Boolean
+    attribute :having_problems_uploading_explanation, String
 
-    validates_presence_of :having_problems_uploading_details, if: :having_problems_uploading_documents
+    validates_presence_of :having_problems_uploading_explanation, if: :having_problems_uploading
 
     private
 
@@ -11,8 +11,8 @@ module Steps::Closure
       raise 'No TribunalCase given' unless tribunal_case
 
       tribunal_case.update(
-        having_problems_uploading_documents: having_problems_uploading_documents,
-        having_problems_uploading_details: having_problems_uploading_details
+        having_problems_uploading: having_problems_uploading,
+        having_problems_uploading_explanation: having_problems_uploading_explanation
       )
     end
   end

--- a/app/forms/steps/details/documents_checklist_form.rb
+++ b/app/forms/steps/details/documents_checklist_form.rb
@@ -2,13 +2,23 @@ module Steps::Details
   class DocumentsChecklistForm < BaseForm
     attribute :original_notice_provided, Boolean
     attribute :review_conclusion_provided, Boolean
-    attribute :having_problems_uploading_documents, Boolean
-    attribute :having_problems_uploading_details, String
+    attribute :having_problems_uploading, Boolean
+    attribute :having_problems_uploading_explanation, String
 
     validate :documents_uploaded, :letter_checkboxes_ticked,
-             if: :tribunal_case, unless: :having_problems_uploading_documents
+             if: :tribunal_case, unless: :having_problems_uploading
 
-    validates_presence_of :having_problems_uploading_details, if: :having_problems_uploading_documents
+    validates_presence_of :having_problems_uploading_explanation, if: :having_problems_uploading
+
+    def save
+      # The validation in #documents_uploaded below checks TribunalCase#documents,
+      # which may erroneously return an empty array if the user previously ticked
+      # "I'm having trouble" but then unticked it again.
+      # This ensures having_problems_uploading is the correct value before validation.
+      tribunal_case.having_problems_uploading = having_problems_uploading
+
+      super
+    end
 
     private
 
@@ -16,10 +26,10 @@ module Steps::Details
       raise 'No TribunalCase given' unless tribunal_case
 
       tribunal_case.update(
-        original_notice_provided:             original_notice_provided,
-        review_conclusion_provided:           review_conclusion_provided,
-        having_problems_uploading_documents:  having_problems_uploading_documents,
-        having_problems_uploading_details:    having_problems_uploading_details
+        original_notice_provided: original_notice_provided,
+        review_conclusion_provided: review_conclusion_provided,
+        having_problems_uploading: having_problems_uploading,
+        having_problems_uploading_explanation: having_problems_uploading ? having_problems_uploading_explanation : nil
       )
     end
 

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -38,7 +38,7 @@ class TribunalCase < ApplicationRecord
   def documents(document_key)
     # We do not return uploaded documents when the user states they have trouble uploading
     # because otherwise they may believe they don't have to send them in again
-    return [] if having_problems_uploading_documents?
+    return [] if having_problems_uploading?
 
     @_documents_cache ||= Document.all_for_collection(files_collection_ref)
     @_documents_cache.fetch(document_key, [])

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -90,7 +90,7 @@ class DetailsDecisionTree < DecisionTree
   end
 
   def after_documents_checklist
-    if tribunal_case.having_problems_uploading_documents?
+    if tribunal_case.having_problems_uploading?
       show(:documents_upload_problems)
     else
       show(:check_answers)

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -17,13 +17,13 @@
 
     <%= step_form @form_object do |f| %>
       <div class="form-group util_mt-large">
-        <%= f.label :having_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
-          <%= f.check_box :having_problems_uploading_documents, 'aria-controls': 'unable_to_upload_panel' %>
+        <%= f.label :having_problems_uploading, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
+          <%= f.check_box :having_problems_uploading, 'aria-controls': 'unable_to_upload_panel' %>
           <%= t('shared.file_upload.having_problems') %>
         <% end %>
 
         <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
-          <%= f.text_area :having_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
+          <%= f.text_area :having_problems_uploading_explanation, size: '40x4', class: 'form-control form-control-3-4' %>
         </div>
       </div>
 

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -31,14 +31,14 @@
       </div>
 
       <div class="form-group util_mt-large">
-        <%= f.label :having_problems_uploading_documents, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
-          <%= f.check_box :having_problems_uploading_documents, class: 'ga-checkbox', 'data-ga-label': 'having problems' %>
+        <%= f.label :having_problems_uploading, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
+          <%= f.check_box :having_problems_uploading, class: 'ga-checkbox', 'data-ga-label': 'having problems' %>
           <%= t 'shared.file_upload.having_problems' %>
         <% end %>
 
         <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
           <%= t 'shared.file_upload.explanation_html', contact_url: contact_page_path %>
-          <%=f.text_area :having_problems_uploading_details, size: '40x4', class: 'form-control form-control-3-4' %>
+          <%=f.text_area :having_problems_uploading_explanation, size: '40x4', class: 'form-control form-control-3-4' %>
         </div>
       </div>
 

--- a/config/locales/closure.yml
+++ b/config/locales/closure.yml
@@ -29,7 +29,7 @@ en:
         edit:
           heading: Add documents to support your application (optional)
           lead_text: The tax tribunal is independent and doesn't have access to any information you may have sent to HMRC.
-          having_problems_uploading_documents_html: I am having trouble uploading my documents
+          having_problems_uploading_html: I am having trouble uploading my documents
       check_answers:
         show:
           heading: Check your answers
@@ -76,7 +76,7 @@ en:
       steps_closure_additional_info_form:
         closure_additional_info: Enter reasons why the enquiry should close (optional)
       steps_closure_support_documents_form:
-        having_problems_uploading_details: Reasons you can't upload
+        having_problems_uploading_explanation: Reasons you can't upload
 
   activemodel:
     errors:

--- a/config/locales/details.yml
+++ b/config/locales/details.yml
@@ -295,6 +295,6 @@ en:
         grounds_for_appeal: Enter reasons below or attach as a document
         grounds_for_appeal_document: Attach reasons as a document
       steps_details_documents_checklist_form:
-        having_problems_uploading_details: Enter reasons why you can't upload documents
+        having_problems_uploading_explanation: Enter reasons why you can't upload documents
       steps_details_outcome_form:
         outcome: Enter the outcome you want

--- a/db/migrate/20161205154426_add_documents_checklist_to_tribunal_case.rb
+++ b/db/migrate/20161205154426_add_documents_checklist_to_tribunal_case.rb
@@ -4,6 +4,6 @@ class AddDocumentsChecklistToTribunalCase < ActiveRecord::Migration[5.0]
     add_column :tribunal_cases, :review_conclusion_provided, :boolean, default: false
     add_column :tribunal_cases, :additional_documents_provided, :boolean, default: false
     add_column :tribunal_cases, :additional_documents_info, :text
-    add_column :tribunal_cases, :having_problems_uploading_documents, :boolean, default: false
+    add_column :tribunal_cases, :having_problems_uploading, :boolean, default: false
   end
 end

--- a/db/migrate/20170202144329_add_having_problems_uploading_details_to_tribunal_case.rb
+++ b/db/migrate/20170202144329_add_having_problems_uploading_details_to_tribunal_case.rb
@@ -1,5 +1,5 @@
 class AddHavingProblemsUploadingDetailsToTribunalCase < ActiveRecord::Migration[5.0]
   def change
-    add_column :tribunal_cases, :having_problems_uploading_details, :text
+    add_column :tribunal_cases, :having_problems_uploading_explanation, :text
   end
 end

--- a/db/migrate/20170330130111_rename_having_trouble_uploading_fields.rb
+++ b/db/migrate/20170330130111_rename_having_trouble_uploading_fields.rb
@@ -1,0 +1,6 @@
+class RenameHavingTroubleUploadingFields < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :tribunal_cases, :having_problems_uploading_documents, :having_problems_uploading
+    rename_column :tribunal_cases, :having_problems_uploading_details, :having_problems_uploading_explanation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170320133224) do
+ActiveRecord::Schema.define(version: 20170330130111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 20170320133224) do
     t.uuid     "files_collection_ref",                            default: -> { "uuid_generate_v4()" }
     t.boolean  "original_notice_provided",                        default: false
     t.boolean  "review_conclusion_provided",                      default: false
-    t.boolean  "having_problems_uploading_documents",             default: false
+    t.boolean  "having_problems_uploading",                       default: false
     t.string   "challenged_decision"
     t.string   "disputed_tax_paid"
     t.string   "hardship_review_requested"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 20170320133224) do
     t.string   "representative_organisation_name"
     t.string   "representative_organisation_fao"
     t.string   "representative_organisation_registration_number"
-    t.text     "having_problems_uploading_details"
+    t.text     "having_problems_uploading_explanation"
     t.string   "user_type"
     t.string   "navigation_stack",                                default: [],                                       array: true
     t.string   "representative_professional_status"

--- a/spec/forms/steps/closure/support_documents_form_spec.rb
+++ b/spec/forms/steps/closure/support_documents_form_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 RSpec.describe Steps::Closure::SupportDocumentsForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
-    having_problems_uploading_documents: having_problems_uploading_documents,
-    having_problems_uploading_details: having_problems_uploading_details
+    having_problems_uploading: having_problems_uploading,
+    having_problems_uploading_explanation: having_problems_uploading_explanation
   } }
 
   let(:tribunal_case) { instance_double(TribunalCase, documents: documents) }
 
-  let(:having_problems_uploading_documents) { false }
-  let(:having_problems_uploading_details) { nil }
+  let(:having_problems_uploading) { false }
+  let(:having_problems_uploading_explanation) { nil }
   let(:documents) { ['test.doc'] }
 
   subject { described_class.new(arguments) }
@@ -32,21 +32,21 @@ RSpec.describe Steps::Closure::SupportDocumentsForm do
       end
     end
 
-    context 'when having_problems_uploading_documents is not selected' do
-      let(:having_problems_uploading_documents) { false }
-      it { should_not validate_presence_of(:having_problems_uploading_details) }
+    context 'when having_problems_uploading is not selected' do
+      let(:having_problems_uploading) { false }
+      it { should_not validate_presence_of(:having_problems_uploading_explanation) }
     end
 
-    context 'when having_problems_uploading_documents is selected' do
-      let(:having_problems_uploading_documents) { true }
-      it { should validate_presence_of(:having_problems_uploading_details) }
+    context 'when having_problems_uploading is selected' do
+      let(:having_problems_uploading) { true }
+      it { should validate_presence_of(:having_problems_uploading_explanation) }
     end
 
     context 'when valid' do
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
-          having_problems_uploading_documents: having_problems_uploading_documents,
-          having_problems_uploading_details: having_problems_uploading_details
+          having_problems_uploading: having_problems_uploading,
+          having_problems_uploading_explanation: having_problems_uploading_explanation
         ).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/forms/steps/details/documents_checklist_form_spec.rb
+++ b/spec/forms/steps/details/documents_checklist_form_spec.rb
@@ -5,21 +5,25 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
       tribunal_case: tribunal_case,
       original_notice_provided: original_notice_provided,
       review_conclusion_provided: review_conclusion_provided,
-      having_problems_uploading_documents: having_problems_uploading_documents,
-      having_problems_uploading_details: having_problems_uploading_details
+      having_problems_uploading: having_problems_uploading,
+      having_problems_uploading_explanation: having_problems_uploading_explanation
   } }
 
   let(:tribunal_case) { instance_double(TribunalCase) }
 
   let(:original_notice_provided) { true }
   let(:review_conclusion_provided) { true }
-  let(:having_problems_uploading_documents) { false }
-  let(:having_problems_uploading_details) { nil }
+  let(:having_problems_uploading) { false }
+  let(:having_problems_uploading_explanation) { nil }
   let(:documents) { ['test.doc'] }
 
   subject { described_class.new(arguments) }
 
   describe '#save' do
+    before do
+      allow(tribunal_case).to receive(:having_problems_uploading=).with(having_problems_uploading)
+    end
+
     context 'when no tribunal_case is associated with the form' do
       let(:tribunal_case) { nil }
 
@@ -42,9 +46,9 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
           expect(subject.errors[:original_notice_provided]).to_not be_empty
         end
 
-        context 'unless having_problems_uploading_documents checkbox selected' do
-          let(:having_problems_uploading_documents) { true }
-          let(:having_problems_uploading_details) { 'my explanation' }
+        context 'unless having_problems_uploading checkbox selected' do
+          let(:having_problems_uploading) { true }
+          let(:having_problems_uploading_explanation) { 'my explanation' }
 
           it 'returns validations true' do
             expect(subject).to be_valid
@@ -60,9 +64,9 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
           expect(subject.errors[:original_notice_provided]).to_not be_empty
         end
 
-        context 'unless having_problems_uploading_documents checkbox selected' do
-          let(:having_problems_uploading_documents) { true }
-          let(:having_problems_uploading_details) { 'my explanation' }
+        context 'unless having_problems_uploading checkbox selected' do
+          let(:having_problems_uploading) { true }
+          let(:having_problems_uploading_explanation) { 'my explanation' }
 
           it 'returns validations true' do
             expect(subject).to be_valid
@@ -70,14 +74,14 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
         end
       end
 
-      context 'when having_problems_uploading_documents is not selected' do
-        let(:having_problems_uploading_documents) { false }
-        it { should_not validate_presence_of(:having_problems_uploading_details) }
+      context 'when having_problems_uploading is not selected' do
+        let(:having_problems_uploading) { false }
+        it { should_not validate_presence_of(:having_problems_uploading_explanation) }
       end
 
-      context 'when having_problems_uploading_documents is selected' do
-        let(:having_problems_uploading_documents) { true }
-        it { should validate_presence_of(:having_problems_uploading_details) }
+      context 'when having_problems_uploading is selected' do
+        let(:having_problems_uploading) { true }
+        it { should validate_presence_of(:having_problems_uploading_explanation) }
       end
     end
 
@@ -86,14 +90,34 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
         allow(tribunal_case).to receive(:documents).with(:supporting_documents).and_return(documents)
       end
 
-      it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with(
-          original_notice_provided:             original_notice_provided,
-          review_conclusion_provided:           review_conclusion_provided,
-          having_problems_uploading_documents:  having_problems_uploading_documents,
-          having_problems_uploading_details:    having_problems_uploading_details
-        ).and_return(true)
-        expect(subject.save).to be(true)
+      context 'and having_problems_uploading is true' do
+        let(:having_problems_uploading) { true }
+        let(:having_problems_uploading_explanation) { 'Much sad. Very broken. Wow.' }
+
+        it 'saves the record' do
+          expect(tribunal_case).to receive(:update).with(
+            original_notice_provided: original_notice_provided,
+            review_conclusion_provided: review_conclusion_provided,
+            having_problems_uploading: having_problems_uploading,
+            having_problems_uploading_explanation: having_problems_uploading_explanation
+          ).and_return(true)
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'and having_problems_uploading is false' do
+        let(:having_problems_uploading) { false }
+        let(:having_problems_uploading_explanation) { 'Much sad. Very broken. Wow.' }
+
+        it 'saves the record and disregards having_problems_uploading_explanation' do
+          expect(tribunal_case).to receive(:update).with(
+            original_notice_provided: original_notice_provided,
+            review_conclusion_provided: review_conclusion_provided,
+            having_problems_uploading: having_problems_uploading,
+            having_problems_uploading_explanation: nil
+          ).and_return(true)
+          expect(subject.save).to be(true)
+        end
       end
     end
   end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe TribunalCase, type: :model do
       subject.documents(:bar)
     end
 
-    context 'when having_problems_uploading_documents is given' do
-      let(:attributes) { super().merge(having_problems_uploading_documents: 'Oh noes') }
+    context 'when having_problems_uploading is given' do
+      let(:attributes) { super().merge(having_problems_uploading: 'Oh noes') }
 
       it 'does not return any documents' do
         expect(Document).to_not receive(:all_for_collection)

--- a/spec/services/details_decision_tree_spec.rb
+++ b/spec/services/details_decision_tree_spec.rb
@@ -151,13 +151,13 @@ RSpec.describe DetailsDecisionTree do
       let(:step_params) { { documents_checklist: 'anything'  } }
 
       context 'and user had no problems uploading' do
-        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: false) }
+        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading?: false) }
 
         it { is_expected.to have_destination(:check_answers, :show) }
       end
 
       context 'and user had problems uploading' do
-        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading_documents?: true) }
+        let(:tribunal_case) { instance_double(TribunalCase, having_problems_uploading?: true) }
 
         it { is_expected.to have_destination(:documents_upload_problems, :show) }
       end


### PR DESCRIPTION
When a user ticks the "I'm having trouble uploading documents" checkbox
on the multi-upload page, then submits, then goes back to the page
later, they cannot undo that choice because the validation will always
fail.

The documents submitted are checked in a validation _before_ the new
value for "I'm having trouble" is saved - but `TribunalCase#documents`
returns no documents when "I'm having trouble" has previously been saved
as true. So the validation fails, the fields don't get reset, and
everyone is sad.

- Rename 'having trouble uploading' fields to be more clear
- Clear (or do not save in the first place) explanation field if
  'having trouble uploading' isn't ticked
- Ensure `having_problems_uploading` is set on `TribunalCase` **before**
  validations are run