### PR TITLE
Tweak database column types

### DIFF
--- a/db/migrate/20170330143358_tweak_column_types.rb
+++ b/db/migrate/20170330143358_tweak_column_types.rb
@@ -1,0 +1,8 @@
+class TweakColumnTypes < ActiveRecord::Migration[5.0]
+  def change
+    change_column :tribunal_cases, :hardship_reason, :text
+    change_column :tribunal_cases, :outcome, :text
+    change_column :tribunal_cases, :taxpayer_contact_postcode, :string
+    change_column :tribunal_cases, :representative_contact_postcode, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170330130111) do
+ActiveRecord::Schema.define(version: 20170330143358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20170330130111) do
     t.text     "lateness_reason"
     t.string   "taxpayer_type"
     t.text     "taxpayer_contact_address"
-    t.text     "taxpayer_contact_postcode"
+    t.string   "taxpayer_contact_postcode"
     t.string   "taxpayer_contact_email"
     t.string   "taxpayer_contact_phone"
     t.string   "taxpayer_organisation_name"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20170330130111) do
     t.string   "penalty_amount"
     t.string   "tax_amount"
     t.string   "challenged_decision_status"
-    t.string   "outcome"
+    t.text     "outcome"
     t.string   "case_type_other_value"
     t.string   "intent"
     t.string   "closure_case_type"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20170330130111) do
     t.string   "representative_individual_first_name"
     t.string   "representative_individual_last_name"
     t.text     "representative_contact_address"
-    t.text     "representative_contact_postcode"
+    t.string   "representative_contact_postcode"
     t.string   "representative_contact_email"
     t.string   "representative_contact_phone"
     t.string   "representative_organisation_name"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20170330130111) do
     t.string   "representative_professional_status"
     t.string   "dispute_type_other_value"
     t.string   "case_status"
-    t.string   "hardship_reason"
+    t.text     "hardship_reason"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
   end
 

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe TribunalCase, type: :model do
 
   describe '#save' do
     context 'columns that store strings' do
-      let(:attributes) { { outcome: 'some text' } }
+      let(:attributes) { { taxpayer_contact_postcode: 'some text' } }
       include_examples 'sanitizing actions'
     end
 


### PR DESCRIPTION
Some of the column types in the schema aren't appropriate for the data
they are storing.

While in our current DB (PostgreSQL) there is no difference between
`:string` (`CHARACTER VARYING`) and `:text` (`TEXT`), and we are
unlikely to ever migrate, we should still have more representative
data types.