### PR TITLE
prevent spec warnings about expectation on nil

### DIFF
--- a/app/forms/steps/details/documents_checklist_form.rb
+++ b/app/forms/steps/details/documents_checklist_form.rb
@@ -15,7 +15,7 @@ module Steps::Details
       # which may erroneously return an empty array if the user previously ticked
       # "I'm having trouble" but then unticked it again.
       # This ensures having_problems_uploading is the correct value before validation.
-      tribunal_case.having_problems_uploading = having_problems_uploading
+      tribunal_case&.having_problems_uploading = having_problems_uploading
 
       super
     end

--- a/spec/forms/steps/details/documents_checklist_form_spec.rb
+++ b/spec/forms/steps/details/documents_checklist_form_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    before do
-      allow(tribunal_case).to receive(:having_problems_uploading=).with(having_problems_uploading)
-    end
-
     context 'when no tribunal_case is associated with the form' do
       let(:tribunal_case) { nil }
 
@@ -32,91 +28,97 @@ RSpec.describe Steps::Details::DocumentsChecklistForm do
       end
     end
 
-    context 'validations on checkboxes' do
+    context 'when there is a tribunal_case' do
       before do
-        allow(tribunal_case).to receive(:documents).with(:supporting_documents).and_return(documents)
+        allow(tribunal_case).to receive(:having_problems_uploading=).with(having_problems_uploading)
       end
 
-      context 'when no checkboxes are selected' do
-        let(:original_notice_provided) { false }
-        let(:review_conclusion_provided) { false }
-
-        it 'has a validation error on the field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:original_notice_provided]).to_not be_empty
+      context 'validations on checkboxes' do
+        before do
+          allow(tribunal_case).to receive(:documents).with(:supporting_documents).and_return(documents)
         end
 
-        context 'unless having_problems_uploading checkbox selected' do
-          let(:having_problems_uploading) { true }
-          let(:having_problems_uploading_explanation) { 'my explanation' }
+        context 'when no checkboxes are selected' do
+          let(:original_notice_provided) { false }
+          let(:review_conclusion_provided) { false }
 
-          it 'returns validations true' do
-            expect(subject).to be_valid
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors[:original_notice_provided]).to_not be_empty
+          end
+
+          context 'unless having_problems_uploading checkbox selected' do
+            let(:having_problems_uploading) { true }
+            let(:having_problems_uploading_explanation) { 'my explanation' }
+
+            it 'returns validations true' do
+              expect(subject).to be_valid
+            end
           end
         end
-      end
 
-      context 'when no documents uploaded' do
-        let(:documents) { [] }
+        context 'when no documents uploaded' do
+          let(:documents) { [] }
 
-        it 'has validation errors on the fields' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:original_notice_provided]).to_not be_empty
-        end
+          it 'has validation errors on the fields' do
+            expect(subject).to_not be_valid
+            expect(subject.errors[:original_notice_provided]).to_not be_empty
+          end
 
-        context 'unless having_problems_uploading checkbox selected' do
-          let(:having_problems_uploading) { true }
-          let(:having_problems_uploading_explanation) { 'my explanation' }
+          context 'unless having_problems_uploading checkbox selected' do
+            let(:having_problems_uploading) { true }
+            let(:having_problems_uploading_explanation) { 'my explanation' }
 
-          it 'returns validations true' do
-            expect(subject).to be_valid
+            it 'returns validations true' do
+              expect(subject).to be_valid
+            end
           end
         end
-      end
 
-      context 'when having_problems_uploading is not selected' do
-        let(:having_problems_uploading) { false }
-        it { should_not validate_presence_of(:having_problems_uploading_explanation) }
-      end
+        context 'when having_problems_uploading is not selected' do
+          let(:having_problems_uploading) { false }
+          it { should_not validate_presence_of(:having_problems_uploading_explanation) }
+        end
 
-      context 'when having_problems_uploading is selected' do
-        let(:having_problems_uploading) { true }
-        it { should validate_presence_of(:having_problems_uploading_explanation) }
-      end
-    end
-
-    context 'when valid' do
-      before do
-        allow(tribunal_case).to receive(:documents).with(:supporting_documents).and_return(documents)
-      end
-
-      context 'and having_problems_uploading is true' do
-        let(:having_problems_uploading) { true }
-        let(:having_problems_uploading_explanation) { 'Much sad. Very broken. Wow.' }
-
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            original_notice_provided: original_notice_provided,
-            review_conclusion_provided: review_conclusion_provided,
-            having_problems_uploading: having_problems_uploading,
-            having_problems_uploading_explanation: having_problems_uploading_explanation
-          ).and_return(true)
-          expect(subject.save).to be(true)
+        context 'when having_problems_uploading is selected' do
+          let(:having_problems_uploading) { true }
+          it { should validate_presence_of(:having_problems_uploading_explanation) }
         end
       end
 
-      context 'and having_problems_uploading is false' do
-        let(:having_problems_uploading) { false }
-        let(:having_problems_uploading_explanation) { 'Much sad. Very broken. Wow.' }
+      context 'when valid' do
+        before do
+          allow(tribunal_case).to receive(:documents).with(:supporting_documents).and_return(documents)
+        end
 
-        it 'saves the record and disregards having_problems_uploading_explanation' do
-          expect(tribunal_case).to receive(:update).with(
-            original_notice_provided: original_notice_provided,
-            review_conclusion_provided: review_conclusion_provided,
-            having_problems_uploading: having_problems_uploading,
-            having_problems_uploading_explanation: nil
-          ).and_return(true)
-          expect(subject.save).to be(true)
+        context 'and having_problems_uploading is true' do
+          let(:having_problems_uploading) { true }
+          let(:having_problems_uploading_explanation) { 'Much sad. Very broken. Wow.' }
+
+          it 'saves the record' do
+            expect(tribunal_case).to receive(:update).with(
+              original_notice_provided: original_notice_provided,
+              review_conclusion_provided: review_conclusion_provided,
+              having_problems_uploading: having_problems_uploading,
+              having_problems_uploading_explanation: having_problems_uploading_explanation
+            ).and_return(true)
+            expect(subject.save).to be(true)
+          end
+        end
+
+        context 'and having_problems_uploading is false' do
+          let(:having_problems_uploading) { false }
+          let(:having_problems_uploading_explanation) { 'Much sad. Very broken. Wow.' }
+
+          it 'saves the record and disregards having_problems_uploading_explanation' do
+            expect(tribunal_case).to receive(:update).with(
+              original_notice_provided: original_notice_provided,
+              review_conclusion_provided: review_conclusion_provided,
+              having_problems_uploading: having_problems_uploading,
+              having_problems_uploading_explanation: nil
+            ).and_return(true)
+            expect(subject.save).to be(true)
+          end
         end
       end
     end


### PR DESCRIPTION
Also, don't try to set 'having_problems_uploading'
on nil.
The spec changes are entirely moving things into
a new context and re-indenting.