### PR TITLE
Removing 'Counteraction notice' from list of other appeals.

### DIFF
--- a/app/services/mapping_code_determiner.rb
+++ b/app/services/mapping_code_determiner.rb
@@ -50,8 +50,6 @@ module MappingCodeDeterminer
   def case_type_mapping_code
     # TODO: Add further when-branches once we have additional case types
     case case_type
-    when CaseType::COUNTERACTION_NOTICE
-      MappingCode::APPN_DECISION_ENQRY
     when CaseType::REQUEST_LATE_REVIEW
       MappingCode::APPN_LATE
     when CaseType::OTHER

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -35,7 +35,6 @@ class CaseType < ValueObject
     AGGREGATES_LEVY              = new(:aggregates_levy,              indirect_tax_properties),
     AIR_PASSENGER_DUTY           = new(:air_passenger_duty,           indirect_tax_properties),
     ALCOHOLIC_LIQUOR_DUTIES      = new(:alcoholic_liquor_duties,      indirect_tax_properties),
-    COUNTERACTION_NOTICE         = new(:counteraction_notice,         direct_tax_properties),
     BINGO_DUTY                   = new(:bingo_duty,                   indirect_tax_properties),
     CAPITAL_GAINS_TAX            = new(:capital_gains_tax,            direct_tax_properties),
     CLIMATE_CHANGE_LEVY          = new(:climate_change_levy,          indirect_tax_properties),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -541,8 +541,6 @@ en:
           aggregates_levy_html: "<strong>Aggregates Levy</strong>"
           air_passenger_duty_html: "<strong>Air Passenger Duty</strong>"
           alcoholic_liquor_duties_html: "<strong>Alcoholic Liquor Duties</strong>"
-          counteraction_notice_html: "<strong>Counteraction notice</strong><br>request
-            HMRC issue a counteraction notice or no counteraction notice"
           bingo_duty_html: "<strong>Bingo Duty</strong>"
           climate_change_levy_html: "<strong>Climate Change Levy</strong>"
           construction_industry_scheme_html: "<strong>Construction Industry Scheme
@@ -771,7 +769,6 @@ en:
         construction_industry_scheme: Construction Industry Scheme (CIS)
         corporation_tax: Corporation Tax
         counter_terrorism: Counter-terrorism decision
-        counteraction_notice: Counteraction notice
         customs_duty: Customs Duty
         dotas_penalty: Disclosure Of Tax Avoidance Schemes (DOTAS) penalty
         export_regulations_penalty: Export (Penalty) Regulations / FA 2003 decision

--- a/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
         aggregates_levy
         air_passenger_duty
         alcoholic_liquor_duties
-        counteraction_notice
         bingo_duty
         climate_change_levy
         construction_industry_scheme

--- a/spec/services/mapping_code_determiner_spec.rb
+++ b/spec/services/mapping_code_determiner_spec.rb
@@ -117,12 +117,6 @@ RSpec.describe MappingCodeDeterminer do
     it { is_expected.to have_mapping_code(:appn_late) }
   end
 
-  context 'when the case type is to apply for a decision on an enquiry' do
-    let(:case_type) { CaseType::COUNTERACTION_NOTICE }
-
-    it { is_expected.to have_mapping_code(:appn_decision_enqry) }
-  end
-
   context 'when there is a case type but it is an unhandled value' do
     let(:case_type) { CaseType.new(:anything_else) }
 


### PR DESCRIPTION
It is already present in the `closure` flow. Copy changes were done as part of a
previous PR, so this is only a cleaning.

https://www.pivotaltracker.com/story/show/137891423