### PR TITLE
All translations under a single root.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,58 +1,58 @@
----
-YESNO: &YESNO
-  'yes': 'Yes'
-  'no': 'No'
-
-REP_ADDRESS: &REP_ADDRESS
-  representative_contact_address: Address
-  representative_contact_postcode: Postcode
-  representative_contact_email: Email address
-  representative_contact_phone: Contact phone number (optional)
-
-TAXPAYER_ADDRESS: &TAXPAYER_ADDRESS
-  taxpayer_contact_address: Address
-  taxpayer_contact_postcode: Postcode
-  taxpayer_contact_email: Email address
-  taxpayer_contact_phone: Contact phone number (optional)
-
-PENALTY_LEVELS: &PENALTY_LEVELS
-  penalty_level_1: "£100 or less"
-  penalty_level_2: over £100 – £20,000
-  penalty_level_3: over £20,000
-
-CASE_TYPE_QUESTION: &CASE_TYPE_QUESTION
-  edit:
-    heading: What is your appeal about?
-    lead_text: Check the original notice letter or review conclusion letter.
-
-START_FINISH: &START_FINISH
-  start_again: Start again
-  finish: Finish
-
-CYA_CONFIRMATION: &CYA_CONFIRMATION
-  check_answers:
-    show:
-      heading: Check your answers
-  confirmation:
-    show:
-      case_submitted: Case submitted
-      confirmation_email: We will send confirmation by email
-      save_or_print_pdf: Save or print your case details
-      what_happens_next_html: |
-        <p>Please save or print your case details for your records.</p>
-        <h2 class="heading-medium">What happens next?</h2>
-        <p>The tax tribunal will:</p>
-        <ul class="list list-bullet">
-          <li>check your details and may ask you for more information</li>
-          <li>write to confirm the next steps and if there will be a hearing</li>
-          <li>contact any other parties and ask them to respond</li>
-        </ul>
-        <p>
-          If you have any questions, you can contact the tax tribunal on %{tax_tribunal_phone} (find out about
-          <a href="https://www.gov.uk/call-charges">call charges</a>).
-        </p>
-
 en:
+  dictionary:
+    YESNO: &YESNO
+      'yes': 'Yes'
+      'no': 'No'
+
+    REP_ADDRESS: &REP_ADDRESS
+      representative_contact_address: Address
+      representative_contact_postcode: Postcode
+      representative_contact_email: Email address
+      representative_contact_phone: Contact phone number (optional)
+
+    TAXPAYER_ADDRESS: &TAXPAYER_ADDRESS
+      taxpayer_contact_address: Address
+      taxpayer_contact_postcode: Postcode
+      taxpayer_contact_email: Email address
+      taxpayer_contact_phone: Contact phone number (optional)
+
+    PENALTY_LEVELS: &PENALTY_LEVELS
+      penalty_level_1: "£100 or less"
+      penalty_level_2: over £100 – £20,000
+      penalty_level_3: over £20,000
+
+    CASE_TYPE_QUESTION: &CASE_TYPE_QUESTION
+      edit:
+        heading: What is your appeal about?
+        lead_text: Check the original notice letter or review conclusion letter.
+
+    START_FINISH: &START_FINISH
+      start_again: Start again
+      finish: Finish
+
+    CYA_CONFIRMATION: &CYA_CONFIRMATION
+      check_answers:
+        show:
+          heading: Check your answers
+      confirmation:
+        show:
+          case_submitted: Case submitted
+          confirmation_email: We will send confirmation by email
+          save_or_print_pdf: Save or print your case details
+          what_happens_next_html: |
+            <p>Please save or print your case details for your records.</p>
+            <h2 class="heading-medium">What happens next?</h2>
+            <p>The tax tribunal will:</p>
+            <ul class="list list-bullet">
+              <li>check your details and may ask you for more information</li>
+              <li>write to confirm the next steps and if there will be a hearing</li>
+              <li>contact any other parties and ask them to respond</li>
+            </ul>
+            <p>
+              If you have any questions, you can contact the tax tribunal on %{tax_tribunal_phone} (find out about
+              <a href="https://www.gov.uk/call-charges">call charges</a>).
+            </p>
+
   steps:
     appeal:
       start:


### PR DESCRIPTION
Avoid syntax error `Rails i18n locale file should have single root`,
even tho translations were working just fine.