### PR TITLE
Add new case status values to handle future email reminders.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,6 @@ class ApplicationController < ActionController::Base
   end
 
   def check_tribunal_case_status
-    raise Errors::CaseSubmitted unless current_tribunal_case.case_status.nil?
+    raise Errors::CaseSubmitted if current_tribunal_case.case_status&.submitted?
   end
 end

--- a/app/services/case_creator.rb
+++ b/app/services/case_creator.rb
@@ -7,7 +7,7 @@ class CaseCreator
 
   def call
     tribunal_case.update(
-      case_status: CaseStatus::IN_PROGRESS
+      case_status: CaseStatus::SUBMIT_IN_PROGRESS
     )
 
     glimr_case = GlimrNewCase.new(tribunal_case).call

--- a/app/value_objects/case_status.rb
+++ b/app/value_objects/case_status.rb
@@ -1,6 +1,12 @@
 class CaseStatus < ValueObject
   VALUES = [
-    IN_PROGRESS = new(:in_progress),
-    SUBMITTED   = new(:submitted)
+    SUBMITTED           = new(:submitted),
+    SUBMIT_IN_PROGRESS  = new(:submit_in_progress),
+    FIRST_REMINDER_SENT = new(:first_reminder_sent),
+    LAST_REMINDER_SENT  = new(:last_reminder_sent)
   ].freeze
+
+  def submitted?
+    [SUBMITTED, SUBMIT_IN_PROGRESS].include?(self)
+  end
 end

--- a/spec/services/case_creator_spec.rb
+++ b/spec/services/case_creator_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe CaseCreator do
     end
 
     context 'registering the case into glimr' do
-      context 'marking the tribunal case as `in_progress`' do
+      context 'marking the tribunal case as `submit_in_progress`' do
         let(:glimr_new_case_double) {
           instance_double(GlimrNewCase, call: double(case_reference: 'TC/2017/12345', confirmation_code: 'ABCDEF'))
         }
 
-        it 'should mark the tribunal case as `in_progress` while GLiMR call is executed' do
-          expect(tribunal_case).to receive(:update).with(case_status: CaseStatus::IN_PROGRESS)
+        it 'should mark the tribunal case as `submit_in_progress` while GLiMR call is executed' do
+          expect(tribunal_case).to receive(:update).with(case_status: CaseStatus::SUBMIT_IN_PROGRESS)
           expect(tribunal_case).to receive(:update).with(case_reference: 'TC/2017/12345', case_status: CaseStatus::SUBMITTED)
           subject.call
         end

--- a/spec/support/current_tribunal_case_shared_examples.rb
+++ b/spec/support/current_tribunal_case_shared_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'checks the validity of the current tribunal case' do
   end
 
   context 'when there is a case with submission in progress in the session' do
-    let(:current_tribunal_case) { instance_double(TribunalCase, case_status: CaseStatus::IN_PROGRESS) }
+    let(:current_tribunal_case) { instance_double(TribunalCase, case_status: CaseStatus::SUBMIT_IN_PROGRESS) }
 
     it 'redirects to the case already submitted error page' do
       expect(response).to redirect_to(case_submitted_errors_path)

--- a/spec/value_objects/case_status_spec.rb
+++ b/spec/value_objects/case_status_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe CaseStatus do
+  let(:state) { :foo }
+  subject { described_class.new(state) }
+
+  describe '#submitted?' do
+    context 'for a status of `SUBMITTED`' do
+      let(:state) { :submitted }
+
+      it 'returns true' do
+        expect(subject.submitted?).to be(true)
+      end
+    end
+
+    context 'for a status of `SUBMIT_IN_PROGRESS`' do
+      let(:state) { :submit_in_progress }
+
+      it 'returns true' do
+        expect(subject.submitted?).to be(true)
+      end
+    end
+
+    context 'for a status of `FIRST_REMINDER_SENT`' do
+      let(:state) { :first_reminder_sent }
+
+      it 'returns false' do
+        expect(subject.submitted?).to be(false)
+      end
+    end
+
+    context 'for a status of `LAST_REMINDER_SENT`' do
+      let(:state) { :last_reminder_sent }
+
+      it 'returns false' do
+        expect(subject.submitted?).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In preparation for future email reminders, 2 new status are added to the value object,
and changed the logic to detect when a case has been already submitted.

https://www.pivotaltracker.com/story/show/143050857