### PR TITLE
uncomment the lines in robots.txt that block bots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /


### PR DESCRIPTION
We've always had a robots.txt file, but it wasn't doing anything
because the relevant lines were commented out. This commit fixes
that.