### PR TITLE
add a database.yml file with the adapter defined

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,13 @@
+# This file is only present to fix a Jenkins
+# build error that started to occur after
+# adding devise, but which we could not
+# reproduce on our local machines
+default: &default
+  adapter: postgresql
+
+development:
+  <<: *default
+test:
+  <<: *default
+production:
+  <<: *default


### PR DESCRIPTION
This is fixes a jenkins build error that we could
not reproduce on our development machines, which started
happening after adding devise. It seems that devise needs
to have a database.yml file, or at least a way to determine
the DB adapter in use, at load time, and it cannot infer this
from the ENV['DATABASE_URL']