### PR TITLE
Add the survey link to the personalisation for the email confirmation.

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -22,7 +22,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
       case_reference: mail_presenter.case_reference,
       case_reference_present: mail_presenter.case_reference_present?,
       case_reference_absent: mail_presenter.case_reference_absent?,
-      appeal_or_application: mail_presenter.appeal_or_application
+      appeal_or_application: mail_presenter.appeal_or_application,
+      survey_link: mail_presenter.survey_link
     )
 
     mail(to: mail_presenter.recipient_email)

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -39,6 +39,10 @@ class CaseMailPresenter < SimpleDelegator
     ENV.fetch('TAX_TRIBUNAL_EMAIL')
   end
 
+  def survey_link
+    Rails.configuration.survey_link
+  end
+
   private
 
   def representative_contact_name

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       it 'sets the personalisation' do
         expect(
           mail.govuk_notify_personalisation.keys
-        ).to eq([:recipient_name, :case_reference, :case_reference_present, :case_reference_absent, :appeal_or_application])
+        ).to eq([:recipient_name, :case_reference, :case_reference_present, :case_reference_absent, :appeal_or_application, :survey_link])
       end
     end
 
@@ -48,6 +48,7 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     context 'capturing unexpected errors' do
       before do
+        allow(Rails).to receive_message_chain(:configuration, :survey_link).and_return('www.survey.com')
         allow(tribunal_case).to receive(:taxpayer_contact_email).and_raise('boom')
       end
 
@@ -62,7 +63,8 @@ RSpec.describe NotifyMailer, type: :mailer do
               case_reference: 'TC/2017/00001',
               case_reference_present: 'yes',
               case_reference_absent: 'no',
-              appeal_or_application: :appeal
+              appeal_or_application: :appeal,
+              survey_link: 'www.survey.com'
             }
           }
         )

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -161,4 +161,11 @@ RSpec.describe CaseMailPresenter do
       subject.ftt_recipient_email
     end
   end
+
+  describe '#survey_link' do
+    it 'should retrieve it from the Rails config' do
+      expect(Rails).to receive_message_chain(:configuration, :survey_link)
+      subject.survey_link
+    end
+  end
 end


### PR DESCRIPTION
We want to add the link to the survey in the confirmation emails so there is a
bigger chance for users to fill the questionnaire.

Merge this PR once we've made the proper changes to the templates (dev & prod).

https://www.pivotaltracker.com/story/show/142932417