### PR TITLE
Add feature flag for Save&Return

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID=c2362d14-f99e-4420-b102-8d297dd3a62f
 
 # Used for `GLiMR is down` emails
 TAX_TRIBUNAL_EMAIL=your_email@example.com
+
+# Feature flags - remove when no longer needed
+SAVE_AND_RETURN_ENABLED=true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,4 +56,8 @@ module ApplicationHelper
   def analytics_tracking_id
     ENV['GA_TRACKING_ID']
   end
+
+  def save_and_return_enabled?
+    Rails.configuration.x.features.save_and_return_enabled
+  end
 end

--- a/app/views/steps/shared/_continue_or_save.html.erb
+++ b/app/views/steps/shared/_continue_or_save.html.erb
@@ -1,4 +1,6 @@
 <p class="actions">
   <%= f.submit class: 'button' %>
-  <a href="/create_account" class="link">Save and come back later</a>
+  <% if save_and_return_enabled? %>
+    <a href="/create_account" class="link">Save and come back later</a>
+  <% end %>
 </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,8 @@ module TaxTribunalsDatacapture
 
     config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 30).to_i
     config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
+
+    # TODO: Feature flags - remove when no longer needed
+    config.x.features.save_and_return_enabled = (ENV['SAVE_AND_RETURN_ENABLED'] == 'true')
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -132,4 +132,22 @@ RSpec.describe ApplicationHelper do
       helper.translate('a_missing_key_here')
     end
   end
+
+  describe '#save_and_return_enabled?' do
+    before do
+      expect(Rails.configuration.x.features).to receive(:save_and_return_enabled).and_return(enabled)
+    end
+
+    context 'when the feature flag is set' do
+      let(:enabled) { true }
+
+      specify { expect(helper).to be_save_and_return_enabled }
+    end
+
+    context 'when the feature flag is not set' do
+      let(:enabled) { false }
+
+      specify { expect(helper).to_not be_save_and_return_enabled }
+    end
+  end
 end


### PR DESCRIPTION
Adds a `SAVE_AND_RETURN_ENABLED` environment variable to allow toggling
of showing various S&R related things - initially the "Save and come
back later" button, which should not be shown unless this variable is
set.