### PR TITLE
Add optional document uploads to closure and lateness. Refactor.

### DIFF
--- a/app/controllers/concerns/document_attachable.rb
+++ b/app/controllers/concerns/document_attachable.rb
@@ -1,0 +1,47 @@
+module DocumentAttachable
+  extend ActiveSupport::Concern
+
+  included do
+    validate :valid_uploaded_file
+  end
+
+  # :nocov:
+  def document_key
+    raise 'implement in the class including this module'
+  end
+  # :nocov:
+
+  private
+
+  def document_attribute
+    [document_key, '_document'].join.to_sym
+  end
+
+  def document
+    self[document_attribute]
+  end
+
+  def document_provided?
+    tribunal_case&.documents(document_key)&.any? || document.present?
+  end
+
+  def valid_uploaded_file
+    return true if document.nil? || document.valid?
+    retrieve_document_errors
+  end
+
+  def upload_document_if_present
+    return true if document.nil?
+
+    document.upload!(document_key: document_key, collection_ref: tribunal_case.files_collection_ref)
+    retrieve_document_errors
+
+    errors.empty?
+  end
+
+  def retrieve_document_errors
+    document.errors.each do |error|
+      errors.add(document_attribute, error)
+    end
+  end
+end

--- a/app/forms/steps/closure/additional_info_form.rb
+++ b/app/forms/steps/closure/additional_info_form.rb
@@ -1,18 +1,22 @@
 module Steps::Closure
   class AdditionalInfoForm < BaseForm
+    include DocumentAttachable
+
     attribute :closure_additional_info, String
+    attribute :closure_additional_info_document, DocumentUpload
+
+    def document_key
+      :closure_additional_info
+    end
 
     private
 
-    def changed?
-      tribunal_case.closure_additional_info != closure_additional_info
-    end
-
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      return true unless changed?
 
-      tribunal_case.update(closure_additional_info: closure_additional_info)
+      upload_document_if_present && tribunal_case.update(
+        closure_additional_info: closure_additional_info
+      )
     end
   end
 end

--- a/app/forms/steps/details/grounds_for_appeal_form.rb
+++ b/app/forms/steps/details/grounds_for_appeal_form.rb
@@ -1,10 +1,15 @@
 module Steps::Details
   class GroundsForAppealForm < BaseForm
+    include DocumentAttachable
+
     attribute :grounds_for_appeal, String
     attribute :grounds_for_appeal_document, DocumentUpload
 
     validates_presence_of :grounds_for_appeal, unless: :document_provided?
-    validate :valid_uploaded_file
+
+    def document_key
+      :grounds_for_appeal
+    end
 
     private
 
@@ -14,30 +19,6 @@ module Steps::Details
       upload_document_if_present && tribunal_case.update(
         grounds_for_appeal: grounds_for_appeal
       )
-    end
-
-    def valid_uploaded_file
-      return true if grounds_for_appeal_document.nil? || grounds_for_appeal_document.valid?
-      retrieve_document_errors
-    end
-
-    def document_provided?
-      tribunal_case&.documents(:grounds_for_appeal)&.any? || grounds_for_appeal_document.present?
-    end
-
-    def upload_document_if_present
-      return true if grounds_for_appeal_document.nil?
-
-      grounds_for_appeal_document.upload!(document_key: :grounds_for_appeal, collection_ref: tribunal_case.files_collection_ref)
-      retrieve_document_errors
-
-      errors.empty?
-    end
-
-    def retrieve_document_errors
-      grounds_for_appeal_document.errors.each do |error|
-        errors.add(:grounds_for_appeal_document, error)
-      end
     end
   end
 end

--- a/app/forms/steps/details/representative_approval_form.rb
+++ b/app/forms/steps/details/representative_approval_form.rb
@@ -1,33 +1,18 @@
 module Steps::Details
   class RepresentativeApprovalForm < BaseForm
+    include DocumentAttachable
+
     attribute :representative_approval_document, DocumentUpload
-    validate :valid_uploaded_file
+
+    def document_key
+      :representative_approval
+    end
 
     private
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
       upload_document_if_present
-    end
-
-    def valid_uploaded_file
-      return true if representative_approval_document.nil? || representative_approval_document.valid?
-      retrieve_document_errors
-    end
-
-    def upload_document_if_present
-      return true if representative_approval_document.nil?
-
-      representative_approval_document.upload!(document_key: :representative_approval, collection_ref: tribunal_case.files_collection_ref)
-      retrieve_document_errors
-
-      errors.empty?
-    end
-
-    def retrieve_document_errors
-      representative_approval_document.errors.each do |error|
-        errors.add(:representative_approval_document, error)
-      end
     end
   end
 end

--- a/app/forms/steps/hardship/hardship_reason_form.rb
+++ b/app/forms/steps/hardship/hardship_reason_form.rb
@@ -1,42 +1,24 @@
 module Steps::Hardship
   class HardshipReasonForm < BaseForm
+    include DocumentAttachable
+
     attribute :hardship_reason, String
     attribute :hardship_reason_document, DocumentUpload
 
     validates_presence_of :hardship_reason, unless: :document_provided?
-    validate :valid_uploaded_file
+
+    def document_key
+      :hardship_reason
+    end
 
     private
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
+
       upload_document_if_present && tribunal_case.update(
         hardship_reason: hardship_reason
       )
-    end
-
-    def valid_uploaded_file
-      return true if hardship_reason_document.nil? || hardship_reason_document.valid?
-      retrieve_document_errors
-    end
-
-    def document_provided?
-      tribunal_case&.documents(:hardship_reason)&.any? || hardship_reason_document.present?
-    end
-
-    def upload_document_if_present
-      return true if hardship_reason_document.nil?
-
-      hardship_reason_document.upload!(document_key: :hardship_reason, collection_ref: tribunal_case.files_collection_ref)
-      retrieve_document_errors
-
-      errors.empty?
-    end
-
-    def retrieve_document_errors
-      hardship_reason_document.errors.each do |error|
-        errors.add(:hardship_reason_document, error)
-      end
     end
   end
 end

--- a/app/forms/steps/lateness/lateness_reason_form.rb
+++ b/app/forms/steps/lateness/lateness_reason_form.rb
@@ -1,8 +1,15 @@
 module Steps::Lateness
   class LatenessReasonForm < BaseForm
-    attribute :lateness_reason, String
+    include DocumentAttachable
 
-    validates_presence_of :lateness_reason
+    attribute :lateness_reason, String
+    attribute :lateness_reason_document, DocumentUpload
+
+    validates_presence_of :lateness_reason, unless: :document_provided?
+
+    def document_key
+      :lateness_reason
+    end
 
     def lateness_unknown?
       tribunal_case.in_time == InTime::UNSURE
@@ -12,7 +19,10 @@ module Steps::Lateness
 
     def persist!
       raise 'No TribunalCase given' unless tribunal_case
-      tribunal_case.update(lateness_reason: lateness_reason)
+
+      upload_document_if_present && tribunal_case.update(
+        lateness_reason: lateness_reason
+      )
     end
   end
 end

--- a/app/presenters/check_answers/closure_details_section_presenter.rb
+++ b/app/presenters/check_answers/closure_details_section_presenter.rb
@@ -9,8 +9,7 @@ module CheckAnswers
         Answer.new(:closure_hmrc_reference, tribunal_case.closure_hmrc_reference, change_path: edit_steps_closure_enquiry_details_path, raw: true),
         Answer.new(:closure_years_under_enquiry, tribunal_case.closure_years_under_enquiry, raw: true),
         Answer.new(:closure_hmrc_officer, tribunal_case.closure_hmrc_officer, raw: true),
-        # nil file because no upload option (yet)
-        FileOrTextAnswer.new(:closure_additional_info, tribunal_case.closure_additional_info, nil, change_path: edit_steps_closure_additional_info_path),
+        FileOrTextAnswer.new(:closure_additional_info, tribunal_case.closure_additional_info, tribunal_case.documents(:closure_additional_info).first, change_path: edit_steps_closure_additional_info_path),
         DocumentsSubmittedAnswer.new(:documents_submitted, tribunal_case.documents(:supporting_documents), change_path: edit_steps_closure_support_documents_path)
       ].select(&:show?)
     end

--- a/app/presenters/check_answers/lateness_section_presenter.rb
+++ b/app/presenters/check_answers/lateness_section_presenter.rb
@@ -7,8 +7,7 @@ module CheckAnswers
     def answers
       [
         Answer.new(:in_time, tribunal_case.in_time, change_path: edit_steps_lateness_in_time_path),
-        # file is nil because there is no file upload on this one (yet)
-        FileOrTextAnswer.new(:lateness_reason, tribunal_case.lateness_reason, nil, change_path: edit_steps_lateness_lateness_reason_path)
+        FileOrTextAnswer.new(:lateness_reason, tribunal_case.lateness_reason, tribunal_case.documents(:lateness_reason).first, change_path: edit_steps_lateness_lateness_reason_path)
       ].select(&:show?)
     end
   end

--- a/app/views/steps/closure/additional_info/edit.html.erb
+++ b/app/views/steps/closure/additional_info/edit.html.erb
@@ -4,9 +4,16 @@
 
     <h1 class="heading-large"><%=t '.heading' %></h1>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.text_area :closure_additional_info, size: '40x6', class: 'form-control form-control-3-4' %>
-      <%= f.submit class: 'button' %>
-    <% end %>
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
+      <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'closure', ga_label: 'additional info'} do |f| %>
+        <%= f.text_area :closure_additional_info, size: '40x4', class: 'form-control form-control-3-4 form-control-large' %>
+
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+
+        <%= f.submit class: 'button document_upload_continue' %>
+      <% end %>
+
+      <%= display_current_document(@form_object.document_key) %>
+    </div>
   </div>
 </div>

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -6,16 +6,16 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(:grounds_for_appeal) %>">
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'grounds', ga_label: 'grounds for appeal'} do |f| %>
         <%= f.text_area :grounds_for_appeal, size: '40x4', class: 'form-control form-control-3-4 form-control-large' %>
 
-        <%= document_upload_field(f, :grounds_for_appeal, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
 
         <%= f.submit class: 'button document_upload_continue' %>
       <% end %>
 
-      <%= display_current_document(:grounds_for_appeal) %>
+      <%= display_current_document(@form_object.document_key) %>
     </div>
   </div>
 </div>

--- a/app/views/steps/details/representative_approval/edit.html.erb
+++ b/app/views/steps/details/representative_approval/edit.html.erb
@@ -19,14 +19,14 @@
       </div>
     </details>
 
-    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(:representative_approval) %>">
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'representative approval', ga_label: 'representative approval'} do |f| %>
-        <%= document_upload_field(f, :representative_approval, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
 
         <%= f.submit class: 'button document_upload_continue' %>
       <% end %>
 
-      <%= display_current_document(:representative_approval) %>
+      <%= display_current_document(@form_object.document_key) %>
     </div>
   </div>
 </div>

--- a/app/views/steps/hardship/hardship_reason/edit.html.erb
+++ b/app/views/steps/hardship/hardship_reason/edit.html.erb
@@ -6,16 +6,16 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(:hardship_reason) %>">
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'hardship', ga_label: 'hardship reasons'} do |f| %>
         <%= f.text_area :hardship_reason, size: '60x10', class: 'form-control form-control-3-4 form-control-large' %>
 
-        <%= document_upload_field(f, :hardship_reason, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
 
         <%= f.submit class: 'button document_upload_continue' %>
       <% end %>
 
-      <%= display_current_document(:hardship_reason) %>
+      <%= display_current_document(@form_object.document_key) %>
     </div>
   </div>
 </div>

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -10,10 +10,17 @@
       <%= @form_object.lateness_unknown? ? translate_with_appeal_or_application('.lead_text_unsure') : translate_with_appeal_or_application('.lead_text') %>
     </p>
 
-    <%= step_form @form_object do |f| %>
-      <%= f.text_area :lateness_reason, size: '40x4', class: 'form-control-3-4' %>
-      <%= f.submit class: 'button' %>
-    <% end %>
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
+      <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'lateness', ga_label: 'lateness reasons'} do |f| %>
+        <%= f.text_area :lateness_reason, size: '60x10', class: 'form-control form-control-3-4 form-control-large' %>
+
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+
+        <%= f.submit class: 'button document_upload_continue' %>
+      <% end %>
+
+      <%= display_current_document(@form_object.document_key) %>
+    </div>
 
     <details>
       <summary>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   dictionary:
+    attach_reasons_document: &attach_reasons_document "<strong>Attach reasons as a document</strong>"
+    attach_reasons_blank_error: &attach_reasons_blank_error "You must enter reasons or attach a document"
+
     YESNO: &YESNO
       'yes': 'Yes'
       'no': 'No'
@@ -182,6 +185,7 @@ en:
       additional_info:
         edit:
           heading: Say why you think the enquiry should close (optional)
+          attach_document_html: "<strong>Attach reasons as a document (optional)</strong>"
       support_documents:
         edit:
           heading: Add documents to support your application (optional)
@@ -303,7 +307,7 @@ en:
             supports your case.
           footer_description_text: You will next have to upload any supporting documents
             including any correspondence with HMRC and evidence to support your case.
-          attach_document_html: "<strong>Attach reasons as a document</strong>"
+          attach_document_html: *attach_reasons_document
       documents_checklist:
         edit:
           heading: Upload your letter(s)
@@ -378,7 +382,7 @@ en:
           heading: Why will paying the tax under dispute cause financial hardship?
           lead_text: The judge will decide whether your appeal can continue without
             paying the tax first.
-          attach_document_html: "<strong>Attach reasons as a document</strong>"
+          attach_document_html: *attach_reasons_document
     lateness:
       in_time:
         edit:
@@ -403,6 +407,7 @@ en:
             %{appeal_or_application} late. These are usually unforeseen circumstances
             or events beyond your control which meant you weren't able to meet the
             tax tribunal deadline.
+          attach_document_html: *attach_reasons_document
   activemodel:
     errors:
       models:
@@ -467,7 +472,7 @@ en:
         steps/details/grounds_for_appeal_form:
           attributes:
             grounds_for_appeal:
-              blank: You must enter reasons or attach a document
+              blank: *attach_reasons_blank_error
         steps/details/documents_checklist_form:
           attributes:
             original_notice_provided:
@@ -490,11 +495,15 @@ en:
         steps/hardship/hardship_reason_form:
           attributes:
             hardship_reason:
-              blank: You must enter reasons or attach a document
+              blank: *attach_reasons_blank_error
         steps/lateness/in_time_form:
           attributes:
             in_time:
               inclusion: Select whether you are in time to appeal to the tax tribunal
+        steps/lateness/lateness_reason_form:
+          attributes:
+            lateness_reason:
+              blank: *attach_reasons_blank_error
   activerecord:
     errors:
       models:

--- a/spec/forms/steps/closure/additional_info_form_spec.rb
+++ b/spec/forms/steps/closure/additional_info_form_spec.rb
@@ -3,53 +3,16 @@ require 'spec_helper'
 RSpec.describe Steps::Closure::AdditionalInfoForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
-    closure_additional_info: closure_additional_info
+    closure_additional_info: text_attribute_value,
+    closure_additional_info_document: document_attribute_value,
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, closure_additional_info: nil) }
-  let(:closure_additional_info) { nil }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', closure_additional_info: text_attribute_value) }
+  let(:text_attribute_value) { nil }
+  let(:document_attribute_value) { nil }
 
   subject { described_class.new(arguments) }
 
   describe '#save' do
-    context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)  { nil }
-
-      it 'raises an error' do
-        expect { subject.save }.to raise_error(RuntimeError)
-      end
-    end
-
-    context 'when closure_additional_info is provided' do
-      let(:closure_additional_info) { 'my info' }
-
-      it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with(
-          closure_additional_info: 'my info'
-        ).and_return(true)
-        expect(subject.save).to be(true)
-      end
-    end
-
-    context 'when closure_additional_info is not provided' do
-      let(:tribunal_case) { instance_double(TribunalCase, closure_additional_info: 'my info') }
-      let(:closure_additional_info) { nil }
-
-      it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with(
-          closure_additional_info: nil
-        ).and_return(true)
-        expect(subject.save).to be(true)
-      end
-    end
-
-    context 'when closure_additional_info is already the same on the model' do
-      let(:tribunal_case) { instance_double(TribunalCase, closure_additional_info: 'my info') }
-      let(:closure_additional_info) { 'my info' }
-
-      it 'does not save the record but returns true' do
-        expect(tribunal_case).to_not receive(:update)
-        expect(subject.save).to be(true)
-      end
-    end
+    it_behaves_like 'a document attachable optional step form', attribute_name: :closure_additional_info
   end
 end

--- a/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
+++ b/spec/forms/steps/details/grounds_for_appeal_form_spec.rb
@@ -5,117 +5,16 @@ include ActionDispatch::TestProcess
 RSpec.describe Steps::Details::GroundsForAppealForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
-    grounds_for_appeal: grounds_for_appeal,
-    grounds_for_appeal_document: grounds_for_appeal_document,
+    grounds_for_appeal: text_attribute_value,
+    grounds_for_appeal_document: document_attribute_value,
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', grounds_for_appeal: nil) }
-  let(:grounds_for_appeal) { nil }
-  let(:grounds_for_appeal_document) { nil }
-  let(:documents) { [] }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', grounds_for_appeal: text_attribute_value) }
+  let(:text_attribute_value) { nil }
+  let(:document_attribute_value) { nil }
 
   subject { described_class.new(arguments) }
 
-  before do
-    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
-    allow(Uploader).to receive(:list_files).and_return([])
-  end
-
   describe '#save' do
-    context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)  { nil }
-      let(:grounds_for_appeal) { 'value' }
-
-      it 'raises an error' do
-        expect { subject.save }.to raise_error(RuntimeError)
-      end
-    end
-
-    context 'when validations fail' do
-      before do
-        allow(tribunal_case).to receive(:documents).with(:grounds_for_appeal).and_return(documents)
-      end
-
-      context 'when grounds_for_appeal nor grounds_for_appeal_document are present' do
-        let(:grounds_for_appeal) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the grounds_for_appeal field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:grounds_for_appeal]).to eq(['You must enter reasons or attach a document'])
-        end
-      end
-
-      context 'when grounds_for_appeal_document is not valid' do
-        let(:grounds_for_appeal_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
-
-        it 'should retrieve the errors from the uploader' do
-          expect(subject.errors).to receive(:add).with(:grounds_for_appeal_document, :content_type).and_call_original
-          expect(subject).to_not be_valid
-        end
-      end
-    end
-
-    context 'when grounds_for_appeal is valid' do
-      before do
-        allow(tribunal_case).to receive(:documents).with(:grounds_for_appeal).and_return(documents)
-      end
-
-      context 'when providing appeal text' do
-        let(:grounds_for_appeal) { 'I disagree with HMRC.' }
-        let(:grounds_for_appeal_document) { nil }
-
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            grounds_for_appeal: 'I disagree with HMRC.'
-          ).and_return(true)
-          expect(subject.save).to be(true)
-        end
-      end
-
-      context 'when providing an attached document' do
-        let(:grounds_for_appeal) { nil }
-        let(:grounds_for_appeal_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
-
-        context 'document upload successful' do
-          it 'saves the record' do
-            expect(tribunal_case).to receive(:update).with(
-              grounds_for_appeal: nil
-            ).and_return(true)
-
-            expect(Uploader).to receive(:add_file).with(hash_including(document_key: :grounds_for_appeal)).and_return({})
-
-            expect(subject.save).to be(true)
-          end
-        end
-
-        context 'document upload unsuccessful' do
-          it 'doesn\'t save the record' do
-            expect(tribunal_case).not_to receive(:update)
-            expect(subject).to receive(:upload_document_if_present).and_return(false)
-            expect(subject.save).to be(false)
-          end
-        end
-      end
-
-      context 'when providing appeal text and document' do
-        let(:grounds_for_appeal) { 'I disagree with HMRC.' }
-        let(:grounds_for_appeal_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
-        let(:upload_response) { double(code: 200, body: {}, error?: false) }
-
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            grounds_for_appeal: 'I disagree with HMRC.'
-          ).and_return(true)
-
-          expect(Uploader).to receive(:add_file).and_return({})
-
-          expect(subject.save).to be(true)
-        end
-      end
-    end
+    it_behaves_like 'a document attachable step form', attribute_name: :grounds_for_appeal
   end
 end
-

--- a/spec/forms/steps/hardship/hardship_reason_form_spec.rb
+++ b/spec/forms/steps/hardship/hardship_reason_form_spec.rb
@@ -5,117 +5,16 @@ include ActionDispatch::TestProcess
 RSpec.describe Steps::Hardship::HardshipReasonForm do
   let(:arguments) { {
     tribunal_case: tribunal_case,
-    hardship_reason: hardship_reason,
-    hardship_reason_document: hardship_reason_document
+    hardship_reason: text_attribute_value,
+    hardship_reason_document: document_attribute_value
   } }
-  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', hardship_reason: hardship_reason) }
-  let(:hardship_reason) { nil }
-  let(:hardship_reason_document) { nil }
-  let(:documents) { [] }
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: '12345', hardship_reason: text_attribute_value) }
+  let(:text_attribute_value) { nil }
+  let(:document_attribute_value) { nil }
 
   subject { described_class.new(arguments) }
 
-  before do
-    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
-    allow(Uploader).to receive(:list_files).and_return([])
-  end
-
   describe '#save' do
-    context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)  { nil }
-      let(:hardship_reason) { 'Hardship Reason' }
-
-      it 'raises an error' do
-        expect { subject.save }.to raise_error(RuntimeError)
-      end
-    end
-
-    context 'when validations fail' do
-      before do
-        allow(tribunal_case).to receive(:documents).with(:hardship_reason).and_return(documents)
-      end
-
-      context 'when hardship_reason nor hardship_reason_document are present' do
-        let(:hardship_reason) { nil }
-
-        it 'returns false' do
-          expect(subject.save).to be(false)
-        end
-
-        it 'has a validation error on the hardship_reason field' do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:hardship_reason]).to eq(['You must enter reasons or attach a document'])
-        end
-      end
-
-      context 'when hardship_reason_document is not valid' do
-        let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
-
-        it 'should retrieve the errors from the uploader' do
-          expect(subject.errors).to receive(:add).with(:hardship_reason_document, :content_type).and_call_original
-          expect(subject).to_not be_valid
-        end
-      end
-    end
-
-    context 'when hardship_reason is valid' do
-      before do
-        allow(tribunal_case).to receive(:documents).with(:hardship_reason).and_return(documents)
-      end
-
-      context 'when providing appeal text' do
-        let(:hardship_reason) { 'I disagree with HMRC.' }
-        let(:hardship_reason_document) { nil }
-
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            hardship_reason: 'I disagree with HMRC.'
-          ).and_return(true)
-          expect(subject.save).to be(true)
-        end
-      end
-
-      context 'when providing an attached document' do
-        let(:hardship_reason) { nil }
-        let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
-
-        context 'document upload successful' do
-          it 'saves the record' do
-            expect(tribunal_case).to receive(:update).with(
-              hardship_reason: nil
-            ).and_return(true)
-
-            expect(Uploader).to receive(:add_file).with(hash_including(document_key: :hardship_reason)).and_return({})
-
-            expect(subject.save).to be(true)
-          end
-        end
-
-        context 'document upload unsuccessful' do
-          it 'doesn\'t save the record' do
-            expect(tribunal_case).not_to receive(:update)
-            expect(subject).to receive(:upload_document_if_present).and_return(false)
-            expect(subject.save).to be(false)
-          end
-        end
-      end
-
-      context 'when providing appeal text and document' do
-        let(:hardship_reason) { 'A very good reason' }
-        let(:hardship_reason_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
-        let(:upload_response) { double(code: 200, body: {}, error?: false) }
-
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            hardship_reason: 'A very good reason'
-          ).and_return(true)
-
-          expect(Uploader).to receive(:add_file).and_return({})
-
-          expect(subject.save).to be(true)
-        end
-      end
-    end
+    it_behaves_like 'a document attachable step form', attribute_name: :hardship_reason
   end
 end
-

--- a/spec/forms/steps/lateness/lateness_reason_form_spec.rb
+++ b/spec/forms/steps/lateness/lateness_reason_form_spec.rb
@@ -2,12 +2,14 @@ require 'spec_helper'
 
 RSpec.describe Steps::Lateness::LatenessReasonForm do
   let(:arguments) { {
-    tribunal_case:   tribunal_case,
-    lateness_reason: lateness_reason
+    tribunal_case: tribunal_case,
+    lateness_reason: text_attribute_value,
+    lateness_reason_document: document_attribute_value,
   } }
-  let(:tribunal_case)   { instance_double(TribunalCase, lateness_reason: nil, in_time: in_time) }
-  let(:lateness_reason) { nil }
-  let(:in_time)         { nil }
+  let(:tribunal_case) { instance_double(TribunalCase, lateness_reason: text_attribute_value, in_time: in_time, files_collection_ref: '12345') }
+  let(:text_attribute_value) { nil }
+  let(:document_attribute_value) { nil }
+  let(:in_time) { nil }
 
   subject { described_class.new(arguments) }
 
@@ -38,26 +40,6 @@ RSpec.describe Steps::Lateness::LatenessReasonForm do
   end
 
   describe '#save' do
-    it { should validate_presence_of(:lateness_reason) }
-
-    context 'when no tribunal_case is associated with the form' do
-      let(:tribunal_case)  { nil }
-      let(:lateness_reason) { 'I am a gummy bear' }
-
-      it 'raises an error' do
-        expect { subject.save }.to raise_error(RuntimeError)
-      end
-    end
-
-    context 'when lateness_reason is valid' do
-      let(:lateness_reason) { 'Forgive me, dear judge' }
-
-      it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with(
-          lateness_reason: lateness_reason
-        ).and_return(true)
-        expect(subject.save).to be(true)
-      end
-    end
+    it_behaves_like 'a document attachable step form', attribute_name: :lateness_reason
   end
 end

--- a/spec/support/document_attachable_shared_examples.rb
+++ b/spec/support/document_attachable_shared_examples.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'common scenarios for a document attachable step form' do
+  let(:documents) { [] }
+
+  before do
+    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
+    allow(Uploader).to receive(:list_files).and_return([])
+  end
+
+  context 'when no tribunal_case is associated with the form' do
+    let(:tribunal_case) { nil }
+    let(:text_attribute_value) { 'value' }
+
+    it 'raises an error' do
+      expect { subject.save }.to raise_error(RuntimeError)
+    end
+  end
+
+  context 'when form is valid' do
+    before do
+      allow(tribunal_case).to receive(:documents).with(attribute_name).and_return(documents)
+    end
+
+    context 'when providing appeal text' do
+      let(:text_attribute_value) { 'I disagree with HMRC.' }
+      let(:document_attribute_value) { nil }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+            attribute_name => 'I disagree with HMRC.'
+        ).and_return(true)
+        expect(subject.save).to be(true)
+      end
+    end
+
+    context 'when providing an attached document' do
+      let(:text_attribute_value) { nil }
+      let(:document_attribute_value) { fixture_file_upload('files/image.jpg', 'image/jpeg') }
+
+      context 'document upload successful' do
+        it 'saves the record' do
+          expect(tribunal_case).to receive(:update).with(
+              attribute_name => nil
+          ).and_return(true)
+
+          expect(Uploader).to receive(:add_file).with(hash_including(document_key: attribute_name)).and_return({})
+
+          expect(subject.save).to be(true)
+        end
+      end
+
+      context 'document upload unsuccessful' do
+        it 'doesn\'t save the record' do
+          expect(tribunal_case).not_to receive(:update)
+          expect(subject).to receive(:upload_document_if_present).and_return(false)
+          expect(subject.save).to be(false)
+        end
+      end
+    end
+
+    context 'when providing appeal text and document' do
+      let(:text_attribute_value) { 'I disagree with HMRC.' }
+      let(:document_attribute_value) { fixture_file_upload('files/image.jpg', 'image/jpeg') }
+      let(:upload_response) { double(code: 200, body: {}, error?: false) }
+
+      it 'saves the record' do
+        expect(tribunal_case).to receive(:update).with(
+            attribute_name => 'I disagree with HMRC.'
+        ).and_return(true)
+
+        expect(Uploader).to receive(:add_file).and_return({})
+
+        expect(subject.save).to be(true)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'a document attachable step form' do |options|
+  let(:attribute_name) { options.fetch(:attribute_name) }  # i.e. grounds_for_appeal
+  let(:document_attribute_name) { [attribute_name, '_document'].join.to_sym }  # i.e. grounds_for_appeal_document
+
+  include_examples 'common scenarios for a document attachable step form'
+
+  context 'validations' do
+    before do
+      allow(tribunal_case).to receive(:documents).with(attribute_name).and_return(documents)
+    end
+
+    context 'when text nor document are present' do
+      let(:text_attribute_value) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the text field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[attribute_name]).to eq(['You must enter reasons or attach a document'])
+      end
+    end
+
+    context 'when document is not valid' do
+      let(:document_attribute_value) { fixture_file_upload('files/image.jpg', 'application/zip') }
+
+      it 'should retrieve the errors from the uploader' do
+        expect(subject.errors).to receive(:add).with(document_attribute_name, :content_type).and_call_original
+        expect(subject).to_not be_valid
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'a document attachable optional step form' do |options|
+  let(:attribute_name) { options.fetch(:attribute_name) }  # i.e. grounds_for_appeal
+  let(:document_attribute_name) { [attribute_name, '_document'].join.to_sym }  # i.e. grounds_for_appeal_document
+
+  include_examples 'common scenarios for a document attachable step form'
+end


### PR DESCRIPTION
This will add the optional document upload to a couple more steps (closure reasons and lateness reasons) as well as, due to the huge amount of steps that now use identical or very similar code for the upload, refactored to a concern and made it flexible enough to cope with all our current combinations.

https://www.pivotaltracker.com/story/show/139183333