### PR TITLE
Test for presence of SAVE_AND_RETURN_ENABLED env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,6 @@ module TaxTribunalsDatacapture
     config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
     # TODO: Feature flags - remove when no longer needed
-    config.x.features.save_and_return_enabled = (ENV['SAVE_AND_RETURN_ENABLED'] == 'true')
+    config.x.features.save_and_return_enabled = ENV.has_key?('SAVE_AND_RETURN_ENABLED')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,6 @@ module TaxTribunalsDatacapture
     config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
     # TODO: Feature flags - remove when no longer needed
-    config.x.features.save_and_return_enabled = ENV.has_key?('SAVE_AND_RETURN_ENABLED')
+    config.x.features.save_and_return_enabled = (ENV['SAVE_AND_RETURN_ENABLED'].to_s.downcase == 'true')
   end
 end


### PR DESCRIPTION
Template deploy converts 'true' in the deploy repo to "True"
when the env var is read, by the ruby code. This commit means
any value found for SAVE_AND_RETURN_ENABLED (including "false")
will turn on the feature. This means, to disable the feature,
we need to ensure the env var is unset, not set to false.