### PR TITLE
Purge old records

### DIFF
--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -33,6 +33,10 @@ class TribunalCase < ApplicationRecord
   # third-party APIs.
   before_save :sanitize
 
+  def self.purge!(date)
+    where(['created_at < ?', date]).delete_all
+  end
+
   def documents(document_key)
     # We do not return uploaded documents when the user states they have trouble uploading
     # because otherwise they may believe they don't have to send them in again

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -18,9 +18,9 @@ namespace :case_reminders do
 end
 
 namespace :tribunal_case do
-  desc "Expire cases older than ENV['EXPIRE_AFTER'] || 30 days"
+  desc "Expire cases older than ENV['EXPIRE_AFTER'] || 14 days"
   task purge: :environment do
-    expire_after = ENV.fetch('EXPIRE_AFTER', 30).to_i
+    expire_after = ENV.fetch('EXPIRE_AFTER', 14).to_i
     puts "Purging tribunal_cases older than #{expire_after} days."
     purged = TribunalCase.purge!(expire_after.days.ago)
     puts "Purged #{purged} tribunal cases."

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -4,6 +4,7 @@ task :daily_tasks do
   # TODO: to be enabled once we have save and return
   # Rake::Task['case_reminders:first_email'].invoke
   # Rake::Task['case_reminders:last_email'].invoke
+  # Rake::Task['tribunal_case:purge'].invoke
 end
 
 namespace :case_reminders do
@@ -13,5 +14,15 @@ namespace :case_reminders do
 
   task :last_email => :environment do
     CaseReminders.new(rule_set: ReminderRuleSet.last_reminder).run
+  end
+end
+
+namespace :tribunal_case do
+  desc "Expire cases older than ENV['EXPIRE_AFTER'] || 30 days"
+  task purge: :environment do
+    expire_after = ENV.fetch('EXPIRE_AFTER', 30).to_i
+    puts "Purging tribunal_cases older than #{expire_after} days."
+    purged = TribunalCase.purge!(expire_after.days.ago)
+    puts "Purged #{purged} tribunal cases."
   end
 end

--- a/spec/models/sanitizer_shared_examples.rb
+++ b/spec/models/sanitizer_shared_examples.rb
@@ -1,0 +1,44 @@
+RSpec.shared_examples 'sanitizing actions' do
+  let(:value) { double.as_null_object }
+
+  specify 'are sanitized' do
+    expect(Sanitize).to receive(:fragment).with('some text').and_return(value)
+    subject.send(:sanitize)
+  end
+
+  specify 'scrub *' do
+    allow(Sanitize).to receive(:fragment).and_return(value)
+    expect(value).to receive(:gsub).with('*', '&#42;')
+    subject.send(:sanitize)
+  end
+
+  specify 'scrub =' do
+    allow(Sanitize).to receive(:fragment).and_return(value)
+    expect(value).to receive(:gsub).with('=', '&#61;')
+    subject.send(:sanitize)
+  end
+
+  specify 'scrub -' do # kills SQL comments
+    allow(Sanitize).to receive(:fragment).and_return(value)
+    expect(value).to receive(:gsub).with('-', '&dash;')
+    subject.send(:sanitize)
+  end
+
+  specify 'scrub %' do
+    allow(Sanitize).to receive(:fragment).and_return(value)
+    expect(value).to receive(:gsub).with('%', '&#37;')
+    subject.send(:sanitize)
+  end
+
+  specify 'remove `drop table` case-insensitively'do
+    allow(Sanitize).to receive(:fragment).and_return(value)
+    expect(value).to receive(:gsub).with(/drop\s+table/i, '')
+    subject.send(:sanitize)
+  end
+
+  specify 'remove `insert into` case-insensitively'do
+    allow(Sanitize).to receive(:fragment).and_return(value)
+    expect(value).to receive(:gsub).with(/insert\s+into/i, '')
+    subject.send(:sanitize)
+  end
+end

--- a/spec/models/tribunal_case/tribunal_case_purge_spec.rb
+++ b/spec/models/tribunal_case/tribunal_case_purge_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe TribunalCase, '.purge!', type: :model do
+  subject { described_class }
+  let(:cases) { class_double(described_class) }
+
+  before do
+    allow(subject).to receive(:where).and_return(cases)
+    allow(cases).to receive(:delete_all)
+    subject.purge!('2017-01-01')
+  end
+
+  it 'finds cases created before a specified date' do
+    expect(subject).to have_received(:where).with(['created_at < ?', '2017-01-01'])
+  end
+
+  it 'deletes the cases it finds' do
+    expect(cases).to have_received(:delete_all)
+  end
+end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -1,49 +1,5 @@
 require 'spec_helper'
-
-RSpec.shared_examples 'sanitizing actions' do
-  let(:value) { double.as_null_object }
-
-  specify 'are sanitized' do
-    expect(Sanitize).to receive(:fragment).with('some text').and_return(value)
-    subject.send(:sanitize)
-  end
-
-  specify 'scrub *' do
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with('*', '&#42;')
-    subject.send(:sanitize)
-  end
-
-  specify 'scrub =' do
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with('=', '&#61;')
-    subject.send(:sanitize)
-  end
-
-  specify 'scrub -' do # kills SQL comments
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with('-', '&dash;')
-    subject.send(:sanitize)
-  end
-
-  specify 'scrub %' do
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with('%', '&#37;')
-    subject.send(:sanitize)
-  end
-
-  specify 'remove `drop table` case-insensitively'do
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with(/drop\s+table/i, '')
-    subject.send(:sanitize)
-  end
-
-  specify 'remove `insert into` case-insensitively'do
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with(/insert\s+into/i, '')
-    subject.send(:sanitize)
-  end
-end
+require_relative 'sanitizer_shared_examples'
 
 RSpec.describe TribunalCase, type: :model do
   subject { described_class.new(attributes) }
@@ -209,4 +165,3 @@ RSpec.describe TribunalCase, type: :model do
     end
   end
 end
-


### PR DESCRIPTION
Method and rake task to clear out old content.

Includes a small lift-and-shift refactor of the `TribunalCase` spec shared examples as these were making the spec more difficult to read. 