### PR TITLE
Add relationship between User and TribunalCase.

### DIFF
--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -1,6 +1,8 @@
 class TribunalCase < ApplicationRecord
   include MappingCodeDeterminer
 
+  belongs_to :user, optional: true
+
   has_value_object :intent
   has_value_object :case_status
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  has_many :tribunal_cases, dependent: :destroy
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,9 @@ module TaxTribunalsDatacapture
   class Application < Rails::Application
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
 
+    # This automatically adds id: :uuid to create_table in all future migrations
+    config.active_record.primary_key = :uuid
+
     config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
     config.feedback_email = 'taxtribunals_helpdesk@digital.justice.gov.uk'
     config.tax_tribunal_email = 'taxappeals@hmcts.gsi.gov.uk'

--- a/db/migrate/20170411095720_add_user_cases_relationship.rb
+++ b/db/migrate/20170411095720_add_user_cases_relationship.rb
@@ -1,0 +1,5 @@
+class AddUserCasesRelationship < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :tribunal_cases, :user, type: :uuid, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170410154935) do
+ActiveRecord::Schema.define(version: 20170411095720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,7 +73,9 @@ ActiveRecord::Schema.define(version: 20170410154935) do
     t.string   "dispute_type_other_value"
     t.string   "case_status"
     t.text     "hardship_reason"
+    t.uuid     "user_id"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
+    t.index ["user_id"], name: "index_tribunal_cases_on_user_id", using: :btree
   end
 
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -88,4 +90,5 @@ ActiveRecord::Schema.define(version: 20170410154935) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "tribunal_cases", "users"
 end


### PR DESCRIPTION
This add the foreign key to the `tribunal_cases` table, and prepares the way to
be able to return all cases for a given user.

The relationship between `tribunal_case` and `user` is optional as we will not
have a user to associate to the case until the user actually creates an account.

This PR is part of the big ticket:
https://www.pivotaltracker.com/story/show/143050769