### PR TITLE
Cases portfolio (list of user's cases), and authentication.

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -1,5 +1,6 @@
 class CasesController < ApplicationController
   before_action :check_tribunal_case_presence, :check_tribunal_case_status, only: [:create]
+  before_action :authenticate_user!, except: [:create]
 
   def create
     @presenter = presenter_class.new(current_tribunal_case, format: :pdf)
@@ -12,11 +13,14 @@ class CasesController < ApplicationController
   end
 
   def destroy
-    tribunal_case = TribunalCase.find(params[:id])
+    tribunal_case = current_user.tribunal_cases.find(params[:id])
     tribunal_case.destroy
 
-    # TODO: redirecting to the prototype portfolio for now, this might change later
-    redirect_to saved_appeals_path
+    redirect_to cases_path
+  end
+
+  def index
+    @tribunal_cases = current_user.tribunal_cases
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -25,6 +25,7 @@ class HomeController < ApplicationController
   def sign_in
   end
 
+  # TODO: remove this (and view) once the 'real' page (CasesController#index) matches the prototype
   def saved_appeals
   end
 

--- a/app/presenters/portfolio_case_presenter.rb
+++ b/app/presenters/portfolio_case_presenter.rb
@@ -1,0 +1,16 @@
+class PortfolioCasePresenter < SimpleDelegator
+  def created_at
+    I18n.localize(tribunal_case.created_at, format: :portfolio)
+  end
+
+  def taxpayer_name
+    return taxpayer_organisation_fao if taxpayer_type&.organisation?
+    [taxpayer_individual_first_name, taxpayer_individual_last_name].join(' ')
+  end
+
+  private
+
+  def tribunal_case
+    __getobj__
+  end
+end

--- a/app/views/cases/_case_row.html.erb
+++ b/app/views/cases/_case_row.html.erb
@@ -1,0 +1,11 @@
+<tr>
+  <td><%= tribunal_case.created_at %></td>
+  <td class="not-entered"><%=t '.reference_not_entered' %></td>
+  <td><%= tribunal_case.taxpayer_name %></td>
+  <td class="right">
+    <span class="right actions actions-tight">
+      <%= button_to t('.delete'), case_path(tribunal_case), method: :delete, data: {confirm: t('.delete_confirmation')}, class: 'button button-secondary' %>
+      <a href="example_saved_appeal" class="button">Resume</a>
+    </span>
+  </td>
+</tr>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -1,0 +1,36 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+
+    <h1 class="heading-large">
+      <%=t '.heading' %>
+    </h1>
+
+    <%= t('.expire_warning_html', expire_in_days: Rails.configuration.x.cases.expire_in_days) %>
+  </div>
+</div>
+
+<table class="saved-appeals">
+  <caption class="visuallyhidden"><%=t '.table.caption' %></caption>
+  <thead>
+  <tr>
+    <th><%=t '.table.heading.date_created' %></th>
+    <th><%=t '.table.heading.your_reference' %></th>
+    <th><%=t '.table.heading.taxpayer_name' %></th>
+    <th><span class="visuallyhidden"><%=t '.table.heading.case_actions' %></span>&nbsp;</th>
+  </tr>
+  </thead>
+
+  <tbody>
+    <% @tribunal_cases.present_each(PortfolioCasePresenter) do |tribunal_case| %>
+      <%= render partial: 'case_row', locals: {tribunal_case: tribunal_case} %>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <p>
+      <%= link_to t('.new_case'), start_path %>
+    </p>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,8 @@ module TaxTribunalsDatacapture
     config.x.session.expires_in_minutes = ENV.fetch('SESSION_EXPIRES_IN_MINUTES', 30).to_i
     config.x.session.warning_when_remaining = ENV.fetch('SESSION_WARNING_WHEN_REMAINING', 5).to_i
 
+    config.x.cases.expire_in_days = ENV.fetch('EXPIRE_AFTER', 14).to_i
+
     config.action_mailer.default_url_options = { host: ENV.fetch('EXTERNAL_URL') }
 
     # TODO: Feature flags - remove when no longer needed

--- a/config/initializers/present_collection.rb
+++ b/config/initializers/present_collection.rb
@@ -1,0 +1,17 @@
+module PresentCollection
+  # :nocov:
+  def present_each(presenter)
+    each do |obj|
+      yield presenter.new(obj)
+    end
+  end
+  # :nocov:
+end
+
+class ActiveRecord::Relation
+  include PresentCollection
+end
+
+class Array
+  include PresentCollection
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -969,6 +969,9 @@ en:
       format:
         unit: "£"
         precision: 0
+  time:
+    formats:
+      portfolio: '%d %B %Y'
   generic:
     back_link: Back
     appeal_or_application:
@@ -1196,3 +1199,29 @@ en:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  cases:
+    index:
+      heading: Your saved appeals
+      expire_warning_html: |
+        <p>Your appeals will be saved for %{expire_in_days} days.</p>
+        <p class="notice">
+          <i class="icon icon-important">
+            <span class="visuallyhidden">Warning</span>
+          </i>
+          <strong class="font-small">
+            You have 30 calendar days from the date of the original notice or review
+            conclusion letter. If you appeal any later, you'll need to explain why.
+          </strong>
+        </p>
+      new_case: Start a new appeal or application
+      table:
+        caption: Table of saved appeals/applications
+        heading:
+          date_created: Date created
+          your_reference: Your reference
+          taxpayer_name: Taxpayer name
+          case_actions: Case actions
+    case_row:
+      reference_not_entered: Not entered
+      delete: Delete
+      delete_confirmation: Are you sure you want to delete this case?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
   end
 
   resources :appeal_cases, :closure_cases, only: [:create]
-  resources :cases, only: [:destroy]
+  resources :cases, only: [:index, :destroy]
 
   resource :session, only: [:destroy] do
     member do

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -20,7 +20,7 @@ end
 namespace :tribunal_case do
   desc "Expire cases older than ENV['EXPIRE_AFTER'] || 14 days"
   task purge: :environment do
-    expire_after = ENV.fetch('EXPIRE_AFTER', 14).to_i
+    expire_after = Rails.configuration.x.cases.expire_in_days
     puts "Purging tribunal_cases older than #{expire_after} days."
     purged = TribunalCase.purge!(expire_after.days.ago)
     puts "Purged #{purged} tribunal cases."

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -1,24 +1,68 @@
 require 'rails_helper'
 
 RSpec.describe CasesController, type: :controller do
+  let(:user) { User.new }
+
+  describe '#index' do
+    context 'when user is logged out' do
+      it 'redirects to the sign-in page' do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when user is logged in' do
+      before do
+        sign_in(user)
+      end
+
+      it 'renders the cases portfolio page' do
+        get :index
+        expect(assigns[:tribunal_cases]).not_to be_nil
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+
   describe '#destroy' do
-    let!(:tribunal_case) { TribunalCase.create }
-
-    it 'deletes the tribunal case by ID' do
-      expect {
-        delete :destroy, params: { id: tribunal_case.id }
-      }.to change { TribunalCase.count }.by(-1)
+    context 'when user is logged out' do
+      it 'redirects to the sign-in page' do
+        delete :destroy, params: { id: 'any' }
+        expect(response).to redirect_to(new_user_session_path)
+      end
     end
 
-    it 'redirects to the cases portfolio' do
-      delete :destroy, params: { id: tribunal_case.id }
-      expect(response).to redirect_to(saved_appeals_path)
-    end
+    context 'when user is logged in' do
+      let!(:tribunal_case) { TribunalCase.create }
+      let(:scoped_result) { double('result') }
 
-    it 'raises an exception if case is not found' do
-      expect {
-        delete :destroy, params: { id: '123' }
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      before do
+        sign_in(user)
+      end
+
+      it 'raises an exception if case is not found' do
+        expect {
+          delete :destroy, params: {id: '123'}
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context 'when tribunal case exists' do
+        before do
+          expect(user).to receive(:tribunal_cases).and_return(scoped_result)
+          expect(scoped_result).to receive(:find).with(tribunal_case.id).and_return(tribunal_case)
+        end
+
+        it 'deletes the tribunal case by ID' do
+          expect {
+            delete :destroy, params: {id: tribunal_case.id}
+          }.to change { TribunalCase.count }.by(-1)
+        end
+
+        it 'redirects to the cases portfolio' do
+          delete :destroy, params: {id: tribunal_case.id}
+          expect(response).to redirect_to(cases_path)
+        end
+      end
     end
   end
 end

--- a/spec/helpers/authentication_helpers_spec.rb
+++ b/spec/helpers/authentication_helpers_spec.rb
@@ -1,0 +1,6 @@
+module AuthenticationHelpers
+  def sign_in(user = double('user'))
+    allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+end

--- a/spec/presenters/portfolio_case_presenter_spec.rb
+++ b/spec/presenters/portfolio_case_presenter_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe PortfolioCasePresenter do
+  subject { described_class.new(tribunal_case) }
+
+  let(:tribunal_case) { instance_double(TribunalCase, tribunal_case_attributes) }
+  let(:tribunal_case_attributes) {
+    {
+      taxpayer_type: taxpayer_type,
+      taxpayer_individual_first_name: 'John',
+      taxpayer_individual_last_name: 'Harrison',
+      taxpayer_organisation_fao: 'TP Org Fao',
+      created_at: created_at
+    }
+  }
+  let(:taxpayer_type) { nil }
+  let(:created_at) { Time.at(0) }
+
+  describe '#created_at' do
+    it { expect(subject.created_at).to eq('01 January 1970') }
+  end
+
+  describe '#taxpayer_name' do
+    context 'for an individual filling the form' do
+      let(:taxpayer_type) { ContactableEntityType::INDIVIDUAL }
+      it { expect(subject.taxpayer_name).to eq('John Harrison') }
+    end
+
+    context 'for an organisation filling the form' do
+      let(:taxpayer_type) { ContactableEntityType::COMPANY }
+      it { expect(subject.taxpayer_name).to eq('TP Org Fao') }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require_relative '../spec/support/view_spec_helpers'
+require_relative '../spec/helpers/authentication_helpers_spec'
 
 ActiveRecord::Migration.maintain_test_schema!
 
@@ -20,6 +21,10 @@ RSpec.configure do |config|
 
   config.include(ViewSpecHelpers, type: :helper)
   config.include(ActiveSupport::Testing::TimeHelpers)
+
+  config.include(Devise::Test::ControllerHelpers, type: :view)
+  config.include(Devise::Test::ControllerHelpers, type: :controller)
+  config.include(AuthenticationHelpers, type: :controller)
 
   config.before(:each, type: :helper) { initialize_view_helpers(helper) }
 end


### PR DESCRIPTION
This PR implements the `index` action, which will show the portfolio view with
a list of current logged-in user cases and some basic information (still WIP).

The `delete` button is also implemented, and now only cases owned by the
currently logged-in user can be deleted.

As part of this PR, both actions (#index and #create) are authenticated (Devise).

https://www.pivotaltracker.com/story/show/143050769