### PR TITLE
fix remove button styling on dropzone page

### DIFF
--- a/app/assets/stylesheets/local/lists.scss
+++ b/app/assets/stylesheets/local/lists.scss
@@ -50,8 +50,16 @@ ul.buttons {
     list-style-position: inside;
     padding-left: 20px;
 
+    &.js-only {
+      padding-bottom: 25px;
+    }
+
     a {
       float: right;
+    }
+
+    form {
+      padding-bottom: 0;
     }
   }
 }

--- a/app/views/steps/shared/_dropzone.html.erb
+++ b/app/views/steps/shared/_dropzone.html.erb
@@ -30,12 +30,12 @@
         <% document_list.each do |doc| %>
             <li class="file no-js-only">
               <%= doc.name %>
-              <%= button_to 'Remove', document_path(doc, document_key: :supporting_documents), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button' %>
+              <%= button_to 'Remove', document_path(doc, document_key: :supporting_documents), method: :delete, data: { confirm: 'Are you sure?' }, class: 'button button-secondary' %>
             </li>
 
             <li class="file js-only">
               <%= doc.name %>
-              <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name %>
+              <%= link_to 'Remove', '#', 'data-delete-name': doc.encoded_name, class: 'button button-secondary' %>
             </li>
         <% end %>
     <% else %>


### PR DESCRIPTION
We're trying to use buttons for actions, rather than links. The 'Remove file' button on the single file uploads page has already been fixed to look like a secondary (i.e. not green) action button, but the one on the dropzone page had not.

Before
---
![screen shot 2017-04-12 at 14 11 22](https://cloud.githubusercontent.com/assets/988436/24959251/1e8a15f0-1f8a-11e7-967d-bca78d47e995.png)

After
---
![screen shot 2017-04-12 at 14 11 36](https://cloud.githubusercontent.com/assets/988436/24959255/24151632-1f8a-11e7-8e26-4af5c3c0fd16.png)
