### PR TITLE
Scope the reminders resultset to cases with an owner (user is not nil).

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -61,11 +61,10 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     # TODO: decide what personalisation we might need based on the template copy
     set_personalisation(
-      recipient_name: mail_presenter.recipient_name,
       appeal_or_application: mail_presenter.appeal_or_application
     )
 
-    mail(to: mail_presenter.recipient_email)
+    mail(to: mail_presenter.account_user_email)
   end
 
   private

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -4,6 +4,7 @@ class TribunalCase < ApplicationRecord
   belongs_to :user, optional: true
 
   scope :not_submitted, -> { where(case_status: nil).or(where.not(case_status: CaseStatus::SUBMITTED)) }
+  scope :with_owner,    -> { where.not(user: nil) }
 
   has_value_object :intent
   has_value_object :case_status

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -15,6 +15,10 @@ class CaseMailPresenter < SimpleDelegator
     tribunal_case.case_reference.to_s
   end
 
+  def account_user_email
+    tribunal_case.user.email
+  end
+
   # Email address of whoever filled the form out first. If it's the representative,
   # they would get it, otherwise the taxpayer would
   def recipient_email

--- a/app/services/reminder_rule_set.rb
+++ b/app/services/reminder_rule_set.rb
@@ -31,6 +31,7 @@ class ReminderRuleSet
 
   def find_each(&block)
     TribunalCase.
+      with_owner.
       where(case_status: status_in).
       where('created_at <= ?', created_days_ago.days.ago).
       find_each(&block)

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -114,14 +114,23 @@ RSpec.describe NotifyMailer, type: :mailer do
 
   describe 'incomplete_case_reminder' do
     let(:mail) { described_class.incomplete_case_reminder(tribunal_case, 'reminder-template-id') }
+    let(:user) { instance_double(User, email: 'user@example.com') }
+
+    before do
+      allow(tribunal_case).to receive(:user).and_return(user)
+    end
 
     it_behaves_like 'a Notify mail', template_id: 'reminder-template-id'
+
+    context 'recipient' do
+      it { expect(mail.to).to eq(['user@example.com']) }
+    end
 
     context 'personalisation' do
       it 'sets the personalisation' do
         expect(
           mail.govuk_notify_personalisation.keys
-        ).to eq([:recipient_name, :appeal_or_application])
+        ).to eq([:appeal_or_application])
       end
     end
   end

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe CaseMailPresenter do
   let(:representative_type) { nil }
   let(:additional_attributes) { {} }
   let(:case_reference) { 'TC/2017/00001' }
+  let(:user) { instance_double(User, email: 'user@example.com') }
 
   describe '#case_reference' do
     context 'for a case with reference number' do
@@ -54,6 +55,16 @@ RSpec.describe CaseMailPresenter do
     context 'for a case without reference number' do
       let(:case_reference) { nil }
       it { expect(subject.case_reference_absent?).to eq('yes') }
+    end
+  end
+
+  describe '#account_user_email' do
+    before do
+      allow(tribunal_case).to receive(:user).and_return(user)
+    end
+
+    it 'returns the email address from the User account' do
+      expect(subject.account_user_email).to eq('user@example.com')
     end
   end
 

--- a/spec/services/reminder_rule_set_spec.rb
+++ b/spec/services/reminder_rule_set_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe ReminderRuleSet do
         email_template_id: 'test-template'
       }
     end
+    let(:finder_double) { double.as_null_object }
 
     subject { described_class.new(dummy_config) }
 
@@ -63,8 +64,9 @@ RSpec.describe ReminderRuleSet do
     end
 
     it 'filters the cases' do
-      expect(TribunalCase).to receive(:where).with(case_status: ['status']).and_return(TribunalCase)
-      expect(TribunalCase).to receive(:where).with('created_at <= ?', 3.days.ago).and_return(TribunalCase)
+      expect(TribunalCase).to receive(:with_owner).and_return(finder_double)
+      expect(finder_double).to receive(:where).with(case_status: ['status']).and_return(finder_double)
+      expect(finder_double).to receive(:where).with('created_at <= ?', 3.days.ago).and_return(finder_double)
       subject.find_each
     end
 


### PR DESCRIPTION
Also, send the email to the account's email address.
Email copy and personalisation variables TBC.

This is part of this ticket:
https://www.pivotaltracker.com/story/show/140915567