### PR TITLE
Associate current tribunal case with user on sign up

### DIFF
--- a/app/forms/users/registration_form.rb
+++ b/app/forms/users/registration_form.rb
@@ -15,6 +15,7 @@ module Users
       raise 'No TribunalCase given' unless tribunal_case
 
       @user = User.create(email: email, password: password)
+      tribunal_case.update(user: @user, user_case_reference: user_case_reference)
     end
   end
 end

--- a/app/views/cases/_case_row.html.erb
+++ b/app/views/cases/_case_row.html.erb
@@ -1,6 +1,10 @@
 <tr>
   <td><%= tribunal_case.created_at %></td>
-  <td class="not-entered"><%=t '.reference_not_entered' %></td>
+  <% if tribunal_case.user_case_reference? %>
+    <td><%= tribunal_case.user_case_reference %></td>
+  <% else %>
+    <td class="not-entered"><%=t '.reference_not_entered' %></td>
+  <% end %>
   <td><%= tribunal_case.taxpayer_name %></td>
   <td class="right">
     <span class="right actions actions-tight">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1198,7 +1198,6 @@ en:
     sessions:
       new:
         heading: Sign into your account
-        create_account: I need to create an account
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."

--- a/db/migrate/20170412153336_add_user_case_reference_to_tribunal_case.rb
+++ b/db/migrate/20170412153336_add_user_case_reference_to_tribunal_case.rb
@@ -1,0 +1,5 @@
+class AddUserCaseReferenceToTribunalCase < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tribunal_cases, :user_case_reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170411095720) do
+ActiveRecord::Schema.define(version: 20170412153336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20170411095720) do
     t.string   "case_status"
     t.text     "hardship_reason"
     t.uuid     "user_id"
+    t.string   "user_case_reference"
     t.index ["case_reference"], name: "index_tribunal_cases_on_case_reference", unique: true, using: :btree
     t.index ["user_id"], name: "index_tribunal_cases_on_user_id", using: :btree
   end

--- a/spec/forms/users/registration_form_spec.rb
+++ b/spec/forms/users/registration_form_spec.rb
@@ -97,8 +97,15 @@ RSpec.describe Users::RegistrationForm do
     end
 
     context 'when the registration is valid' do
+      let(:user) { instance_double(User) }
+      let(:user_case_reference) { 'FOO-BAR-BAZ' }
+
       it 'creates a user' do
-        expect(User).to receive(:create).with(email: email, password: password).and_return(true)
+        expect(User).to receive(:create).with(email: email, password: password).and_return(user)
+        expect(tribunal_case).to receive(:update).with(
+          user: user,
+          user_case_reference: user_case_reference
+        ).and_return(true)
         expect(subject.save).to eq(true)
       end
     end


### PR DESCRIPTION
When a user follows the "Save and come back later" link, the sign up
page should associate the current case with the user and also set the
optional reference provided against the case.