### PR TITLE
Logged in state for header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,6 +48,7 @@
 @import 'local/inputs';
 @import 'local/buttons';
 @import 'local/typography';
+@import 'local/header';
 @import 'local/panels';
 @import 'local/banners';
 @import 'local/case_details_pdf';

--- a/app/assets/stylesheets/local/header.scss
+++ b/app/assets/stylesheets/local/header.scss
@@ -1,0 +1,10 @@
+#global-header .header-proposition #proposition-links li {
+  color: $grey-4;
+  list-style-type: none;
+
+  @media (max-width: 768px) {
+    width: auto;
+    clear: both;
+    border: none;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 <% content_for(:proposition_header) do %>
   <div class="header-proposition">
     <div class="content">
-      <!-- ONLY SHOW IF LOGGED IN -->
+      <!-- TODO: ONLY SHOW IF LOGGED IN -->
       <!-- <a href="#proposition-links" class="js-header-toggle menu">Menu</a> -->
       <!-- END ONLY SHOW IF LOGGED IN -->
       <nav id="proposition-menu">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,14 +14,18 @@
 <% content_for(:proposition_header) do %>
   <div class="header-proposition">
     <div class="content">
-      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+      <!-- ONLY SHOW IF LOGGED IN -->
+      <!-- <a href="#proposition-links" class="js-header-toggle menu">Menu</a> -->
+      <!-- END ONLY SHOW IF LOGGED IN -->
       <nav id="proposition-menu">
         <a href="/" id="proposition-name">Appeal to the tax tribunal</a>
-        <ul id="proposition-links">
+        <!-- ONLY SHOW IF LOGGED IN -->
+        <!-- <ul id="proposition-links">
           <li>quite.long.name.actually@also-fairly-long-domain.dom</li>
           <li><a href="#">Change password</a></li>
           <li><a href="#">Sign out</a></li>
-        </ul>
+        </ul> -->
+        <!-- END ONLY SHOW IF LOGGED IN -->
       </nav>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,14 @@
 <% content_for(:proposition_header) do %>
   <div class="header-proposition">
     <div class="content">
+      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
       <nav id="proposition-menu">
         <a href="/" id="proposition-name">Appeal to the tax tribunal</a>
+        <ul id="proposition-links">
+          <li>quite.long.name.actually@also-fairly-long-domain.dom</li>
+          <li><a href="#">Change password</a></li>
+          <li><a href="#">Sign out</a></li>
+        </ul>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
Non-logged-in state remains unchanged

Example HTML commented out so that it doesn't display by default. Links go to "#" at the moment – dev to replace with actual links when required.

Logged in state looks like:

desktop
---
![screen shot 2017-04-19 at 11 30 47](https://cloud.githubusercontent.com/assets/988436/25175715/c21d5d80-24f3-11e7-8ee4-59293eaa7a33.png)

smaller desktop
---
![screen shot 2017-04-19 at 11 52 42](https://cloud.githubusercontent.com/assets/988436/25176647/c673583c-24f6-11e7-81c2-13e1c8ea3ea1.png)

small screen
---
![screen shot 2017-04-19 at 11 31 01](https://cloud.githubusercontent.com/assets/988436/25175733/c9a89e16-24f3-11e7-952f-65e6b593b3c3.png)

small screen expanded
---
![screen shot 2017-04-19 at 11 31 06](https://cloud.githubusercontent.com/assets/988436/25175744/d1dfe184-24f3-11e7-8b02-8ae8e84a96e4.png)


