### PR TITLE
Show message when taxpayer name not given on portfolio

### DIFF
--- a/app/presenters/portfolio_case_presenter.rb
+++ b/app/presenters/portfolio_case_presenter.rb
@@ -5,7 +5,11 @@ class PortfolioCasePresenter < SimpleDelegator
 
   def taxpayer_name
     return taxpayer_organisation_fao if taxpayer_type&.organisation?
-    [taxpayer_individual_first_name, taxpayer_individual_last_name].join(' ')
+    [taxpayer_individual_first_name, taxpayer_individual_last_name].compact.join(' ')
+  end
+
+  def taxpayer_name?
+    taxpayer_name.present?
   end
 
   private

--- a/app/views/cases/_case_row.html.erb
+++ b/app/views/cases/_case_row.html.erb
@@ -5,7 +5,11 @@
   <% else %>
     <td class="not-entered"><%=t '.reference_not_entered' %></td>
   <% end %>
-  <td><%= tribunal_case.taxpayer_name %></td>
+  <% if tribunal_case.taxpayer_name? %>
+    <td><%= tribunal_case.taxpayer_name %></td>
+  <% else %>
+    <td class="not-entered"><%=t '.name_not_entered' %></td>
+  <% end %>
   <td class="right">
     <span class="right actions actions-tight">
       <%= button_to t('.delete'), case_path(tribunal_case), method: :delete, data: {confirm: t('.delete_confirmation')}, class: 'button button-secondary' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1229,6 +1229,7 @@ en:
           case_actions: Case actions
     case_row:
       reference_not_entered: Not entered
+      name_not_entered: Not entered
       resume: Resume
       delete: Delete
       delete_confirmation: Are you sure you want to delete this case?

--- a/spec/presenters/portfolio_case_presenter_spec.rb
+++ b/spec/presenters/portfolio_case_presenter_spec.rb
@@ -31,4 +31,15 @@ RSpec.describe PortfolioCasePresenter do
       it { expect(subject.taxpayer_name).to eq('TP Org Fao') }
     end
   end
+
+  describe '#taxpayer_name?' do
+    let(:taxpayer_type) { ContactableEntityType::COMPANY }
+
+    it { expect(subject.taxpayer_name?).to eq(true) }
+
+    context 'when no name is given' do
+      let(:tribunal_case_attributes) { super().merge(taxpayer_organisation_fao: '') }
+      it { expect(subject.taxpayer_name?).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
We should show a similar message on the save and return page when the
taxpayer name hasn't been entered to when the user's reference hasn't
been entered.