### PR TITLE
Replace default Devise login functionality

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,16 +25,6 @@ class ApplicationController < ActionController::Base
     session[:current_step_path]
   end
 
-  protected
-
-  def authenticate_user!
-    if user_signed_in?
-      super
-    else
-      redirect_to new_users_login_path
-    end
-  end
-
   private
 
   def initialize_tribunal_case(intent:)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,8 +25,14 @@ class ApplicationController < ActionController::Base
     session[:current_step_path]
   end
 
-  def after_sign_in_path_for(_)
-    users_cases_path
+  protected
+
+  def authenticate_user!
+    if user_signed_in?
+      super
+    else
+      redirect_to new_users_login_path
+    end
   end
 
   private

--- a/app/controllers/users/logins_controller.rb
+++ b/app/controllers/users/logins_controller.rb
@@ -1,0 +1,28 @@
+module Users
+  class LoginsController < ApplicationController
+    def new
+      @form_object = LoginForm.new(
+        tribunal_case: current_tribunal_case
+      )
+    end
+
+    def create
+      @form_object = LoginForm.new(
+        permitted_params.to_h.merge(tribunal_case: current_tribunal_case)
+      )
+
+      if @form_object.save
+        sign_in(@form_object.user)
+        redirect_to users_cases_path
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def permitted_params
+      params.fetch(:users_login_form, {}).permit(:email, :password)
+    end
+  end
+end

--- a/app/forms/users/login_form.rb
+++ b/app/forms/users/login_form.rb
@@ -1,0 +1,32 @@
+module Users
+  class LoginForm < BaseForm
+    attr_reader :user
+
+    attribute :email, String
+    attribute :password, String
+
+    validates :email, email: true
+    validates :password, presence: true
+
+    validate :username_and_password_correct
+
+    private
+
+    def persist!
+      true
+    end
+
+    def username_and_password_correct
+      user = User.find_by(email: email)
+
+      unless user && user.valid_password?(password)
+        errors.add(:base, :invalid_credentials)
+
+        # Return so we only assign the user if the username and password are correct
+        return
+      end
+
+      @user = user
+    end
+  end
+end

--- a/app/views/home/start.html.erb
+++ b/app/views/home/start.html.erb
@@ -17,7 +17,7 @@
       <%# TODO: Move this into the @link_sections and add i18n %>
       <% if save_and_return_enabled? %>
         <li>
-          <%= link_to 'Return to an existing appeal or application', new_users_login_path, class: 'task-link ga-pageLink' %>
+          <%= link_to 'Return to an existing appeal or application', users_login_path, class: 'task-link ga-pageLink' %>
           <p>Continue completing a saved appeal or application.</p>
         </li>
       <% end %>

--- a/app/views/home/start.html.erb
+++ b/app/views/home/start.html.erb
@@ -17,7 +17,7 @@
       <%# TODO: Move this into the @link_sections and add i18n %>
       <% if save_and_return_enabled? %>
         <li>
-          <%= link_to 'Return to an existing appeal or application', new_user_session_path, class: 'task-link ga-pageLink' %>
+          <%= link_to 'Return to an existing appeal or application', new_users_login_path, class: 'task-link ga-pageLink' %>
           <p>Continue completing a saved appeal or application.</p>
         </li>
       <% end %>

--- a/app/views/users/logins/new.html.erb
+++ b/app/views/users/logins/new.html.erb
@@ -2,11 +2,9 @@
   <div class="column-two-thirds">
     <h2 class="heading-large"><%=t '.heading' %></h2>
 
-    <%= error_summary(resource) %>
+    <%= error_summary(@form_object) %>
 
-    <%= form_for(resource, as: resource_name, url: user_session_path) do |f| %>
-      <%= devise_error_messages! %>
-
+    <%= form_for(@form_object, url: users_login_path) do |f| %>
       <%= f.email_field :email, autofocus: true %>
       <%= f.password_field :password, class: 'js-toggleable-password', autocomplete: 'off' %>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -8,7 +8,7 @@
   </i>
   <strong class="font-small">You must create an account before we can save your details</strong>
 </p>
-<p><%= link_to t('.existing_account'), new_user_session_path %></p>
+<p><%= link_to t('.existing_account'), users_login_path %></p>
 
 <%= form_for(@form_object, url: users_registration_path) do |f| %>
   <%= f.email_field :email, autofocus: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -516,6 +516,14 @@ en:
             email:
               invalid: Enter a valid email address
               not_unique: This email address has already been used
+        users/login_form:
+          attributes:
+            base:
+              invalid_credentials: There is no account with the username and password you entered
+            email:
+              invalid: Enter a valid email address
+            password:
+              blank: Enter your password
   activerecord:
     errors:
       models:
@@ -1196,9 +1204,6 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
       updated: "Your account has been updated successfully."
     sessions:
-      new:
-        heading: Sign into your account
-        forgot_password: "I've forgotten my password"
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
@@ -1207,6 +1212,10 @@ en:
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
   users:
+    logins:
+      new:
+        heading: Sign into your account
+        forgot_password: "I've forgotten my password"
     registrations:
       new:
         heading: Create account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ class ActionDispatch::Routing::Mapper
 end
 
 Rails.application.routes.draw do
-  devise_for :users, only: :passwords
+  devise_for :users,
+             controllers: { sessions: 'users/logins' },
+             path_names:  { sign_in: 'login', sign_out: 'logout' }
 
   namespace :steps do
     namespace :appeal do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ class ActionDispatch::Routing::Mapper
 end
 
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, only: :passwords
 
   namespace :steps do
     namespace :appeal do
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
 
   namespace :users do
     resource :registration, only: [:new, :create]
+    resource :login, only: [:new, :create]
     resource :email_confirmation, only: [:edit, :update]
     resources :cases, only: [:index, :destroy] do
       get :resume

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,15 +7,6 @@ RSpec.describe ApplicationController do
     def another_exception; raise Exception; end
   end
 
-  describe '#after_sign_in_path_for' do
-    let(:resource) { double('resource') }
-
-    it 'returns the root path' do
-      allow(subject).to receive(:users_cases_path).and_return('foo')
-      expect(subject.after_sign_in_path_for(resource)).to eq('foo')
-    end
-  end
-
   context 'Exceptions handling' do
     before do
       allow(Rails).to receive_message_chain(:application, :config, :consider_all_requests_local).and_return(false)

--- a/spec/controllers/users/cases_controller_spec.rb
+++ b/spec/controllers/users/cases_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Users::CasesController, type: :controller do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do
         get :index
-        expect(response).to redirect_to(new_users_login_path)
+        expect(response).to redirect_to(users_login_path)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Users::CasesController, type: :controller do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do
         delete :destroy, params: { id: 'any' }
-        expect(response).to redirect_to(new_users_login_path)
+        expect(response).to redirect_to(users_login_path)
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe Users::CasesController, type: :controller do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do
         get :resume, params: { case_id: 'any' }
-        expect(response).to redirect_to(new_users_login_path)
+        expect(response).to redirect_to(users_login_path)
       end
     end
 

--- a/spec/controllers/users/cases_controller_spec.rb
+++ b/spec/controllers/users/cases_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Users::CasesController, type: :controller do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do
         get :index
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(new_users_login_path)
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe Users::CasesController, type: :controller do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do
         delete :destroy, params: { id: 'any' }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(new_users_login_path)
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe Users::CasesController, type: :controller do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do
         get :resume, params: { case_id: 'any' }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(new_users_login_path)
       end
     end
 

--- a/spec/controllers/users/logins_controller_spec.rb
+++ b/spec/controllers/users/logins_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Users::LoginsController do
+  let(:tribunal_case) { nil }
+
+  before do
+    allow(subject).to receive(:current_tribunal_case).and_return(tribunal_case)
+  end
+
+  describe '#new' do
+    it 'responds with HTTP success' do
+      get :new
+      expect(response).to be_successful
+    end
+  end
+
+  describe '#create' do
+    let(:form_object) { double('form object', save: saved, user: user) }
+    let(:user) { User.new }
+
+    before do
+      expect(Users::LoginForm).to receive(:new).with(
+        tribunal_case: tribunal_case,
+        email: 'foo@bar.com',
+        password: 'passw0rd'
+      ).and_return(form_object)
+    end
+
+    context 'when the form object saves successfully' do
+      let(:saved) { true }
+
+      it 'signs the user in and redirects to the email confirmation' do
+        expect(subject).to receive(:sign_in).with(user).and_return(true)
+
+        post :create, params: { 'users_login_form' => {
+          email: 'foo@bar.com',
+          password: 'passw0rd'
+        }}
+
+        expect(response).to redirect_to(users_cases_path)
+      end
+    end
+
+    context 'when the form object does not save' do
+      let(:saved) { false }
+
+      it 'does not sign a user in and re-renders the page' do
+        expect(subject).to_not receive(:sign_in)
+
+        post :create, params: { 'users_login_form' => {
+          email: 'foo@bar.com',
+          password: 'passw0rd'
+        }}
+
+        expect(subject).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/forms/users/login_form_spec.rb
+++ b/spec/forms/users/login_form_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+RSpec.describe Users::LoginForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    email: email,
+    password: password
+  } }
+  let(:tribunal_case) { instance_double(TribunalCase) }
+  let(:email) { 'shirley.schmidt@cranepooleandschmidt.com' }
+  let(:password) { 'passw0rd' }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'when email is not given' do
+      let(:email) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:email]).to_not be_empty
+      end
+    end
+
+    context 'when email is not valid' do
+      let(:email) { '123 Anytown Road, Poughkeepsie' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:email]).to_not be_empty
+      end
+    end
+
+    context 'when password is not given' do
+      let(:password) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:password]).to_not be_empty
+      end
+    end
+
+    context 'when the user does not exist' do
+      before do
+        expect(User).to receive(:find_by).with(email: email).and_return(nil)
+      end
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the object itself' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:base]).to_not be_empty
+      end
+
+      it 'does not set the user' do
+        subject.save
+        expect(subject.user).to be_nil
+      end
+    end
+
+    context 'when the password is wrong' do
+      let(:user) { instance_double(User) }
+
+      before do
+        expect(User).to receive(:find_by).with(email: email).and_return(user)
+        expect(user).to receive(:valid_password?).with(password).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the object itself' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:base]).to_not be_empty
+      end
+
+      it 'does not set the user' do
+        subject.save
+        expect(subject.user).to be_nil
+      end
+    end
+
+    context 'when the credentials are correct' do
+      let(:user) { instance_double(User) }
+
+      before do
+        expect(User).to receive(:find_by).with(email: email).and_return(user)
+        expect(user).to receive(:valid_password?).with(password).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(subject.save).to eq(true)
+      end
+
+      it 'sets the user' do
+        subject.save
+        expect(subject.user).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces the default sign_in functionality in Devise with a custom
controller and form object so we can add case association and user
reference in the future.