### PR TITLE
Open pro forma in a new window

### DIFF
--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -195,7 +195,11 @@ moj.Modules.gaEvents = {
           if(opts.actionType === 'form') {
             opts.actionValue.unbind('submit').trigger('submit');
           } else if(opts.actionType === 'link') {
-            document.location = opts.actionValue.attr('href');
+            if(opts.actionValue.attr('target')) {
+              window.open(opts.actionValue.attr('href'), opts.actionValue.attr('target'));
+            } else {
+              document.location = opts.actionValue.attr('href');
+            }
           }
         }
       })

--- a/app/views/steps/details/representative_approval/edit.html.erb
+++ b/app/views/steps/details/representative_approval/edit.html.erb
@@ -15,7 +15,7 @@
       <div class="panel" id="details-content-0">
         <%= translate_for_user_type '.details_info_html' %>
         <%=t '.details_example_html' %>
-        <%= link_to t('.download_button_text'), asset_path('proforma.pdf'), class: 'button' %>
+        <%= link_to t('.download_button_text'), asset_path('proforma.pdf'), class: 'button', target: '_blank' %>
       </div>
     </details>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
               <li>friend or family relative</li>
             </ul>
           <p>You can use a representative if you feel you need help or advice. A representative is able to receive correspondence from the tax tribunal and go to any hearings for you.</p>
-          <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href="%{approval_form_href}">authorisation form (%{approval_form_format_and_size})</a>.</p>
+          <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href="%{approval_form_href}" target="_blank">authorisation form (%{approval_form_format_and_size})</a>.</p>
     details:
       user_type:
         edit:


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/143655351)

The link to the pro-forma should open in a new window, but due to the JS link interception we're using for Google Analytics, adding `target="_blank"` wasn't working. This tweak means that any `target` attribute on a GA-tracked link will now work as expected.