### PR TITLE
Make Tyhpoeus work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID          replace_this_at_build_time
 
 RUN touch /etc/inittab
 
-RUN apt-get update && apt-get install -y
+RUN apt-get update && apt-get install -y && apt-get install libcurl4-gnutls-dev -y
 
 EXPOSE $PUMA_PORT
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -17,7 +17,7 @@ ENV NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID    replace_this_at_build_time
 
 RUN touch /etc/inittab
 
-RUN apt-get update && apt-get install -y
+RUN apt-get update && apt-get install -y && apt-get install libcurl4-gnutls-dev -y
 
 EXPOSE $PUMA_PORT
 

--- a/Dockerfile.smoketests
+++ b/Dockerfile.smoketests
@@ -3,6 +3,6 @@ FROM ruby:2.3.3-onbuild
 RUN touch /etc/inittab
 
 ENV DATACAPTURE_URI https://tax-tribunals-datacapture-dev.dsd.io
-RUN apt-get update && apt-get install -y
+RUN apt-get update && apt-get install -y && apt-get install libcurl4-gnutls-dev -y
 
 CMD bundle exec cucumber


### PR DESCRIPTION
It looks like Typhoeus is loosely coupled with libcurl and so does not
fail at build time if libcurl is not installed. This *should* fix that.