### PR TITLE
Update 'Return to a saved appeal or application'.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def reset_tribunal_case_session
+    session.delete(:tribunal_case_id)
+  end
+
   def initialize_tribunal_case(intent:)
     TribunalCase.create(intent: intent).tap do |tribunal_case|
       session[:tribunal_case_id] = tribunal_case.id

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def start
-    reset_session
+    reset_tribunal_case_session
     @link_sections = link_sections
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,9 +4,13 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    reset_session
+    # When redirecting to the survey, we want to logout the user. But when only taking the users to the home,
+    # we don't want to log them out but instead only reset the current case in session.
+    show_survey = params[:survey] == 'true'
+    show_survey ? reset_session : reset_tribunal_case_session
+
     respond_to do |format|
-      format.html { redirect_to params[:survey] == 'true' ? Rails.configuration.survey_link : root_path }
+      format.html { redirect_to show_survey ? Rails.configuration.survey_link : root_path }
       format.json { render json: {} }
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,4 +60,8 @@ module ApplicationHelper
   def save_and_return_enabled?
     Rails.configuration.x.features.save_and_return_enabled
   end
+
+  def login_or_portfolio_path
+    user_signed_in? ? users_cases_path : user_session_path
+  end
 end

--- a/app/views/home/start.html.erb
+++ b/app/views/home/start.html.erb
@@ -1,8 +1,5 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-
-    <div class="breadcrumbs"></div>
-
     <h1 class="heading-large"><%= t '.heading' %></h1>
 
     <ul class="list task-list">
@@ -17,11 +14,10 @@
       <%# TODO: Move this into the @link_sections and add i18n %>
       <% if save_and_return_enabled? %>
         <li>
-          <%= link_to 'Return to a saved appeal or application', user_session_path, class: 'task-link ga-pageLink' %>
-          <p>Continue completing an appeal or application you haven't submitted.</p>
+          <%= link_to t('.return_to_saved_case'), login_or_portfolio_path, class: 'task-link ga-pageLink' %>
+          <p><%=t '.continue_a_case_info' %></p>
         </li>
       <% end %>
     </ul>
-
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1104,6 +1104,8 @@ en:
           or the National Crime Agency.
         close: Ask the judge for a closure, counteraction or no-counteraction notice.
       link_time_estimate: "%{minutes} minutes to complete"
+      continue_a_case_info: "Continue completing an appeal or application you haven't submitted."
+      return_to_saved_case: Return to a saved appeal or application
     contact:
       heading: Contact
       lead_text: Useful information if you need help using this service.

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe HomeController do
   end
 
   describe '#start' do
-    it 'resets the session' do
-      expect(subject).to receive(:reset_session)
+    it 'resets the tribunal case in the session' do
+      expect(subject).to receive(:reset_tribunal_case_session)
       get :start
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -9,18 +9,25 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   describe '#destroy' do
-    it 'resets the session' do
-      get :destroy, session: { foo: 'BAR' }
-      expect(session).to be_empty
-    end
+    context 'when survey param is not provided' do
+      it 'resets the tribunal case session' do
+        expect(subject).to receive(:reset_tribunal_case_session)
+        get :destroy
+      end
 
-    it 'redirects to the home page' do
-      get :destroy
-      expect(subject).to redirect_to(root_path)
+      it 'redirects to the home page' do
+        get :destroy
+        expect(subject).to redirect_to(root_path)
+      end
     end
 
     context 'when survey param is provided' do
       context 'for a `true` value' do
+        it 'resets the session' do
+          expect(subject).to receive(:reset_session)
+          get :destroy, params: {survey: true}
+        end
+
         it 'redirects to the survey page' do
           get :destroy, params: {survey: true}
           expect(response.location).to match(/goo\.gl\/forms/)
@@ -28,6 +35,11 @@ RSpec.describe SessionsController, type: :controller do
       end
 
       context 'for a `false` value' do
+        it 'resets the tribunal case session' do
+          expect(subject).to receive(:reset_tribunal_case_session)
+          get :destroy, params: {survey: false}
+        end
+
         it 'redirects to the home page' do
           get :destroy, params: {survey: false}
           expect(subject).to redirect_to(root_path)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -150,4 +150,26 @@ RSpec.describe ApplicationHelper do
       specify { expect(helper).to_not be_save_and_return_enabled }
     end
   end
+
+  describe '#login_or_portfolio_path' do
+    context 'when user is logged in' do
+      before do
+        expect(helper).to receive(:user_signed_in?).and_return(true)
+      end
+
+      it 'return the portfolio path' do
+        expect(helper.login_or_portfolio_path).to eq(users_cases_path)
+      end
+    end
+
+    context 'when user is logged out' do
+      before do
+        expect(helper).to receive(:user_signed_in?).and_return(false)
+      end
+
+      it 'returns the login path' do
+        expect(helper.login_or_portfolio_path).to eq(user_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR changes the link in the task list to the portfolio if the user is already
logged in, or the login page otherwise.

Also fixes the issue where by going back to the task list the whole session gets reset.

https://www.pivotaltracker.com/story/show/143050733