### PR TITLE
Allow users to provide their own case reference

### DIFF
--- a/app/controllers/users/cases_controller.rb
+++ b/app/controllers/users/cases_controller.rb
@@ -6,6 +6,17 @@ module Users
       @tribunal_cases = current_user.pending_tribunal_cases
     end
 
+    def edit
+      @tribunal_case = current_user.pending_tribunal_cases.find(params[:id])
+    end
+
+    def update
+      @tribunal_case = current_user.pending_tribunal_cases.find(params[:id])
+      @tribunal_case.update(user_case_reference: permitted_params[:user_case_reference])
+
+      redirect_to users_cases_path
+    end
+
     def resume
       tribunal_case = current_user.pending_tribunal_cases.find(params[:case_id])
       session[:tribunal_case_id] = tribunal_case.id
@@ -28,6 +39,10 @@ module Users
       else
         steps_closure_check_answers_path
       end
+    end
+
+    def permitted_params
+      params.require(:tribunal_case).permit(:user_case_reference)
     end
   end
 end

--- a/app/views/users/cases/_case_row.html.erb
+++ b/app/views/users/cases/_case_row.html.erb
@@ -1,9 +1,15 @@
 <tr>
   <td><%= tribunal_case.created_at %></td>
   <% if tribunal_case.user_case_reference? %>
-    <td><%= tribunal_case.user_case_reference %></td>
+    <td>
+      <%= tribunal_case.user_case_reference %><br>
+      <%= link_to t('.edit_reference'), edit_users_case_path(tribunal_case) %>
+    </td>
   <% else %>
-    <td class="not-entered"><%=t '.reference_not_entered' %></td>
+    <td class="not-entered">
+      <%=t '.reference_not_entered' %><br>
+      <%= link_to t('.create_reference'), edit_users_case_path(tribunal_case) %>
+    </td>
   <% end %>
   <% if tribunal_case.taxpayer_name? %>
     <td><%= tribunal_case.taxpayer_name %></td>

--- a/app/views/users/cases/edit.html.erb
+++ b/app/views/users/cases/edit.html.erb
@@ -1,0 +1,9 @@
+<h1 class="heading-large"><%=t '.heading' %></h1>
+<p class="lede"><%=t '.lead_text' %></p>
+
+<%= form_for @tribunal_case, url: users_case_path do |f| %>
+  <%= f.text_field :user_case_reference %>
+
+  <%= f.submit class: 'button' %>
+  <%= link_to t('helpers.submit.cancel'), users_cases_path, class: 'button button-secondary' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -759,6 +759,8 @@ en:
       user:
         email: Your email address
         password: Your password
+      tribunal_case:
+        user_case_reference: Your reference (optional)
     hint:
       user:
         password: Must be at least 8 characters
@@ -766,6 +768,7 @@ en:
     submit:
       create: Continue
       update: Continue
+      cancel: Cancel
       save_and_come_back_later: Save and come back later
       create_account: Save
       sign_in: Sign in
@@ -1228,7 +1231,12 @@ en:
             your_reference: Your reference
             taxpayer_name: Taxpayer name
             case_actions: Case actions
+      edit:
+        heading: Edit case reference
+        lead_text: You can give this case a reference so you know which one it is.
       case_row:
+        edit_reference: Edit reference
+        create_reference: Add a reference
         reference_not_entered: Not entered
         name_not_entered: Not entered
         resume: Resume

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,7 @@ Rails.application.routes.draw do
       get 'login/save_confirmation', to: 'logins#save_confirmation'
     end
 
-    resources :cases, only: [:index, :destroy] do
+    resources :cases, only: [:index, :destroy, :edit, :update] do
       get :resume
     end
   end

--- a/spec/controllers/users/cases_controller_spec.rb
+++ b/spec/controllers/users/cases_controller_spec.rb
@@ -25,6 +25,41 @@ RSpec.describe Users::CasesController, type: :controller do
     end
   end
 
+  describe '#edit' do
+    let(:tribunal_cases) { double('tribunal cases') }
+
+    before do
+      sign_in(user)
+    end
+
+    it 'renders the edit page' do
+      expect(user).to receive(:pending_tribunal_cases).and_return(tribunal_cases)
+      expect(tribunal_cases).to receive(:find).with('124').and_return(double)
+
+      get :edit, params: { id: 124 }
+      expect(assigns[:tribunal_case]).not_to be_nil
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe '#update' do
+    let(:tribunal_cases) { double('tribunal cases') }
+    let(:tribunal_case) { instance_double(TribunalCase) }
+
+    before do
+      sign_in(user)
+    end
+
+    it 'updates the tribunal case' do
+      expect(user).to receive(:pending_tribunal_cases).and_return(tribunal_cases)
+      expect(tribunal_cases).to receive(:find).with('124').and_return(tribunal_case)
+      expect(tribunal_case).to receive(:update).with(user_case_reference: 'lolz')
+
+      patch :update, params: { id: 124, tribunal_case: { user_case_reference: 'lolz' } }
+      expect(response).to redirect_to(users_cases_path)
+    end
+  end
+
   describe '#destroy' do
     context 'when user is logged out' do
       it 'redirects to the sign-in page' do


### PR DESCRIPTION
Users should be able to edit a custom case reference for their cases on
the dashboard so they can keep on top of which case is which.