### PR TITLE
If already logged in, assign any new cases to the user.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,8 +31,8 @@ class ApplicationController < ActionController::Base
     session.delete(:tribunal_case_id)
   end
 
-  def initialize_tribunal_case(intent:)
-    TribunalCase.create(intent: intent).tap do |tribunal_case|
+  def initialize_tribunal_case(attributes = {})
+    TribunalCase.create(attributes).tap do |tribunal_case|
       session[:tribunal_case_id] = tribunal_case.id
     end
   end

--- a/app/controllers/concerns/starting_point_step.rb
+++ b/app/controllers/concerns/starting_point_step.rb
@@ -6,7 +6,7 @@ module StartingPointStep
   def current_tribunal_case
     # Only the step including this concern should create a tribunal case
     # if there isn't one in the session - because it's the first
-    super || initialize_tribunal_case(intent: intent)
+    super || initialize_tribunal_case(intent: intent, user: current_user)
   end
 
   def update_navigation_stack

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,6 +17,7 @@ module Users
     def sign_up(_resource_name, user)
       SaveCaseForLater.new(current_tribunal_case, user).save
       session[:confirmation_email_address] = user.email
+      reset_tribunal_case_session  # so we redirect the user to the portfolio after login back
     end
 
     def after_sign_up_path_for(_)

--- a/spec/controllers/steps/appeal/start_controller_spec.rb
+++ b/spec/controllers/steps/appeal/start_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Appeal::StartController, type: :controller do
-  it_behaves_like 'a starting point step controller'
+  it_behaves_like 'a starting point step controller', intent: Intent::TAX_APPEAL
 end

--- a/spec/controllers/steps/closure/start_controller_spec.rb
+++ b/spec/controllers/steps/closure/start_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Closure::StartController, type: :controller do
-  it_behaves_like 'a starting point step controller'
+  it_behaves_like 'a starting point step controller', intent: Intent::CLOSE_ENQUIRY
 end

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe Users::RegistrationsController do
           do_post
           expect(session[:confirmation_email_address]).to eq('foo@bar.com')
         end
+
+        it 'resets the tribunal case in the session' do
+          expect(subject).to receive(:reset_tribunal_case_session)
+          do_post
+        end
       end
 
       context 'when the registration was unsuccessful' do

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -70,7 +70,9 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
   end
 end
 
-RSpec.shared_examples 'a starting point step controller' do |_form_class, _decision_tree_class|
+RSpec.shared_examples 'a starting point step controller' do |options|
+  let(:intent) { options.fetch(:intent) }
+
   describe '#show' do
     context 'when no case exists in the session yet' do
       it 'creates a new case' do
@@ -85,6 +87,36 @@ RSpec.shared_examples 'a starting point step controller' do |_form_class, _decis
       it 'sets the case ID in the session' do
         get :show
         expect(session[:tribunal_case_id]).to eq(TribunalCase.first.id)
+      end
+
+      context 'attributes initialization' do
+        context 'for a logged in user' do
+          let(:user) { instance_double(User) }
+
+          before do
+            sign_in(user)
+          end
+
+          it 'sets the appropriate attributes' do
+            expect(TribunalCase).to receive(:create).with(
+              intent: intent,
+              user: user
+            ).at_least(:once).and_return(double.as_null_object)
+
+            get :show
+          end
+        end
+
+        context 'for a logged out user' do
+          it 'sets the appropriate attributes' do
+            expect(TribunalCase).to receive(:create).with(
+              intent: intent,
+              user: nil
+            ).at_least(:once).and_return(double.as_null_object)
+
+            get :show
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This fixes an issue where, if already logged in, new cases were not being assigned to
the user and they could not see them in the portfolio page.

This also fixes a wrong redirect after creating an account and signing in immediately after.