### PR TITLE
Fix 404 on live environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.3.3'
 
 gem 'devise'
 gem 'email_validator'
-gem 'glimr-api-client', '~> 0.3.1'
+gem 'glimr-api-client', '~> 0.3.2'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     gherkin (4.0.0)
-    glimr-api-client (0.3.1)
+    glimr-api-client (0.3.2)
       typhoeus (~> 1.1.2)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -403,7 +403,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator
   faker
-  glimr-api-client (~> 0.3.1)
+  glimr-api-client (~> 0.3.2)
   govuk_elements_form_builder!
   govuk_elements_rails
   govuk_frontend_toolkit


### PR DESCRIPTION
This was failing because the API gem was not sending JSON.  Fixed from
GlimrApiClient version 0.3.2.