### PR TITLE
Submit docs checkbox fix for ie

### DIFF
--- a/app/assets/javascripts/modules/doc-upload-checkboxes.js
+++ b/app/assets/javascripts/modules/doc-upload-checkboxes.js
@@ -12,10 +12,20 @@ moj.Modules.docUploadCheckboxes = {
 
   init: function () {
     var cbElement = $(this.element_class),
-        container = $(this.containerId);
+        container = $(this.containerId),
+        $form;
 
     if (cbElement.length && container.length) {
+
+      $form = $(cbElement).eq(0).closest('form');
       container.replaceWith(cbElement);
+
+      $form.on('submit', function(e) {
+        e.preventDefault();
+        cbElement.clone().hide().prependTo($form);
+        $form.unbind('submit');
+        $form.trigger('submit');
+      });
     }
   }
 };

--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -102,7 +102,7 @@ moj.Modules.docUpload = {
     var self = this;
 
     self.$fileList.find('.no-files').hide();
-    self.$fileList.append('<li class="file js-only">' + file.name + ' <a href="#" data-delete-name="'+file.encoded_name+'">Remove</a></li>');
+    self.$fileList.append('<li class="file js-only">' + file.name + ' <a href="#" data-delete-name="'+file.encoded_name+'" class="button button-secondary">Remove</a></li>');
   },
 
   removeDropzonePreview: function(file) {

--- a/app/assets/javascripts/modules/ga-events.js
+++ b/app/assets/javascripts/modules/ga-events.js
@@ -56,8 +56,8 @@ moj.Modules.gaEvents = {
     // until the GA event has been send, by sending target to make a
     // callback[2], unless no GA checkboxes in the form are checked, in which
     // case unbind and submit the form directly[3]
-    $checkboxes.each(function(n, $checkbox) {
-      var $form = $($checkbox.closest('form'));
+    $checkboxes.each(function(n, checkbox) {
+      var $form = $(checkbox).closest('form');
 
       $form.on('submit', function(e) {
         var eventDataArray,


### PR DESCRIPTION
Having the letter checkboxes outside the `<form>` tag but associating them with a `form="blah"` attribute doesn't work in IE, so the document upload page can't be successfully completed in IE.

This clones the checkboxes and shoves a hidden copy of them back into the form on submit.