### PR TITLE
Resume `check your answers` page.

### DIFF
--- a/app/controllers/steps/closure/check_answers_controller.rb
+++ b/app/controllers/steps/closure/check_answers_controller.rb
@@ -1,14 +1,24 @@
 module Steps::Closure
   class CheckAnswersController < Steps::ClosureStepController
-    respond_to :html, :pdf
+    before_action :authenticate_user!, only: [:resume]
 
     def show
-      @presenter = CheckAnswers::ClosureAnswersPresenter.new(current_tribunal_case, format: request.format.symbol)
+      @presenter = closure_presenter
 
       respond_to do |format|
         format.html
         format.pdf { render @presenter.pdf_params }
       end
+    end
+
+    def resume
+      @presenter = closure_presenter
+    end
+
+    private
+
+    def closure_presenter
+      CheckAnswers::ClosureAnswersPresenter.new(current_tribunal_case, format: request.format.symbol)
     end
   end
 end

--- a/app/controllers/steps/details/check_answers_controller.rb
+++ b/app/controllers/steps/details/check_answers_controller.rb
@@ -1,14 +1,24 @@
 module Steps::Details
   class CheckAnswersController < Steps::DetailsStepController
-    respond_to :html, :pdf
+    before_action :authenticate_user!, only: [:resume]
 
     def show
-      @presenter = CheckAnswers::AppealAnswersPresenter.new(current_tribunal_case, format: request.format.symbol)
+      @presenter = appeal_presenter
 
       respond_to do |format|
         format.html
         format.pdf { render @presenter.pdf_params }
       end
+    end
+
+    def resume
+      @presenter = appeal_presenter
+    end
+
+    private
+
+    def appeal_presenter
+      CheckAnswers::AppealAnswersPresenter.new(current_tribunal_case, format: request.format.symbol)
     end
   end
 end

--- a/app/controllers/users/cases_controller.rb
+++ b/app/controllers/users/cases_controller.rb
@@ -3,38 +3,40 @@ module Users
     before_action :authenticate_user!
 
     def index
-      @tribunal_cases = current_user.pending_tribunal_cases
+      @tribunal_cases = pending_user_cases
     end
 
     def edit
-      @tribunal_case = current_user.pending_tribunal_cases.find(params[:id])
+      @tribunal_case = pending_user_cases.find(params[:id])
     end
 
     def update
-      @tribunal_case = current_user.pending_tribunal_cases.find(params[:id])
+      @tribunal_case = pending_user_cases.find(params[:id])
       @tribunal_case.update(user_case_reference: permitted_params[:user_case_reference])
 
       redirect_to users_cases_path
     end
 
     def resume
-      tribunal_case = current_user.pending_tribunal_cases.find(params[:case_id])
+      tribunal_case = pending_user_cases.find(params[:case_id])
       session[:tribunal_case_id] = tribunal_case.id
 
-      redirect_to resume_check_answers_path_for(tribunal_case)
+      redirect_to resume_check_answers_path_for(tribunal_case.intent)
     end
 
     def destroy
-      tribunal_case = current_user.tribunal_cases.find(params[:id])
-      tribunal_case.destroy
-
+      pending_user_cases.find(params[:id]).destroy
       redirect_to users_cases_path
     end
 
     private
 
-    def resume_check_answers_path_for(tribunal_case)
-      if tribunal_case.intent.eql?(Intent::TAX_APPEAL)
+    def pending_user_cases
+      current_user.pending_tribunal_cases
+    end
+
+    def resume_check_answers_path_for(intent)
+      if intent.eql?(Intent::TAX_APPEAL)
         resume_steps_details_check_answers_path
       else
         resume_steps_closure_check_answers_path

--- a/app/controllers/users/cases_controller.rb
+++ b/app/controllers/users/cases_controller.rb
@@ -21,7 +21,7 @@ module Users
       tribunal_case = current_user.pending_tribunal_cases.find(params[:case_id])
       session[:tribunal_case_id] = tribunal_case.id
 
-      redirect_to check_your_answers_path_for(tribunal_case)
+      redirect_to resume_check_answers_path_for(tribunal_case)
     end
 
     def destroy
@@ -33,11 +33,11 @@ module Users
 
     private
 
-    def check_your_answers_path_for(tribunal_case)
+    def resume_check_answers_path_for(tribunal_case)
       if tribunal_case.intent.eql?(Intent::TAX_APPEAL)
-        steps_details_check_answers_path
+        resume_steps_details_check_answers_path
       else
-        steps_closure_check_answers_path
+        resume_steps_closure_check_answers_path
       end
     end
 

--- a/app/presenters/check_answers/appeal_section_presenter.rb
+++ b/app/presenters/check_answers/appeal_section_presenter.rb
@@ -35,7 +35,7 @@ module CheckAnswers
     end
 
     def challenged_decision_answer
-      if tribunal_case.case_type.direct_tax?
+      if tribunal_case.case_type&.direct_tax?
         Answer.new(:challenged_decision_direct, tribunal_case.challenged_decision, change_path: edit_steps_challenge_decision_path)
       else
         Answer.new(:challenged_decision_indirect, tribunal_case.challenged_decision, change_path: edit_steps_challenge_decision_path)

--- a/app/presenters/check_answers/contact_details_answer.rb
+++ b/app/presenters/check_answers/contact_details_answer.rb
@@ -8,7 +8,7 @@ module CheckAnswers
     end
 
     def show?
-      true
+      display_name.strip.present?
     end
 
     # Used by Rails to determine which partial to render

--- a/app/presenters/check_answers/section_presenter.rb
+++ b/app/presenters/check_answers/section_presenter.rb
@@ -13,9 +13,17 @@ module CheckAnswers
       'section'
     end
 
-    # May be overridden in subclasses to hide if appropriate
+    # May be overridden in subclasses to hide/show if appropriate
     def show?
-      true
+      answers.any?
     end
+
+    protected
+
+    # :nocov:
+    def answers
+      raise 'must be implemented in subclasses'
+    end
+    # :nocov:
   end
 end

--- a/app/presenters/check_answers/taxpayer_section_presenter.rb
+++ b/app/presenters/check_answers/taxpayer_section_presenter.rb
@@ -47,8 +47,11 @@ module CheckAnswers
           organisation_registration_number: tribunal_case.representative_organisation_registration_number,
           change_path: edit_steps_details_representative_type_path
         )
-      else
+      elsif tribunal_case.has_representative == HasRepresentative::NO
         Answer.new(:representative_details, :no_representative, change_path: edit_steps_details_has_representative_path)
+      else
+        # `nil` because this question has not been answered yet and should not be shown when resuming a case
+        Answer.new(:representative_details, nil)
       end
     end
   end

--- a/app/views/application/_resume_check_answers_footer.html.erb
+++ b/app/views/application/_resume_check_answers_footer.html.erb
@@ -1,0 +1,4 @@
+<!-- TODO: implement the `Resume` button -->
+<p>
+  <%# button_to translate_with_appeal_or_application('check_answers.footer..resume'), '#', class: 'button js-debounce' %>
+</p>

--- a/app/views/steps/closure/check_answers/resume.html.erb
+++ b/app/views/steps/closure/check_answers/resume.html.erb
@@ -1,0 +1,7 @@
+<%= step_header %>
+
+<h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
+
+<%= render @presenter.sections %>
+
+<%= render partial: 'resume_check_answers_footer' %>

--- a/app/views/steps/details/check_answers/resume.html.erb
+++ b/app/views/steps/details/check_answers/resume.html.erb
@@ -1,0 +1,7 @@
+<%= step_header %>
+
+<h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
+
+<%= render @presenter.sections %>
+
+<%= render partial: 'resume_check_answers_footer' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,8 @@ en:
       check_answers:
         show:
           heading: Check your answers
+        resume:
+          heading: Resume your %{appeal_or_application}
       confirmation:
         show:
           case_submitted: Case submitted
@@ -800,6 +802,7 @@ en:
         against me. I understand that if I have given false information or I do not provide further evidence if
         requested, my %{appeal_or_application} may be rejected.
       submit_and_continue: Submit
+      resume: Resume %{appeal_or_application}
     pdf:
       header:
         tax_chamber: First-tier Tribunal (Tax Chamber)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,12 @@ class ActionDispatch::Routing::Mapper
              only:       [:show],
              controller: name
   end
+
+  def collection_step(name, action)
+    resources name, only: [] do
+      get action, on: :collection
+    end
+  end
 end
 
 Rails.application.routes.draw do
@@ -64,6 +70,7 @@ Rails.application.routes.draw do
       edit_step :additional_info
       edit_step :support_documents
       show_step :check_answers
+      collection_step :check_answers, :resume
       show_step :confirmation
     end
 
@@ -79,6 +86,7 @@ Rails.application.routes.draw do
       edit_step :documents_checklist
       show_step :documents_upload_problems
       show_step :check_answers
+      collection_step :check_answers, :resume
       show_step :confirmation
       edit_step :user_type
       edit_step :representative_approval

--- a/spec/controllers/steps/closure/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/closure/check_answers_controller_spec.rb
@@ -30,4 +30,26 @@ RSpec.describe Steps::Closure::CheckAnswersController, type: :controller do
       expect(response.headers['Content-Disposition']).to eq('inline; filename="check_answers.pdf"')
     end
   end
+
+  describe '#resume' do
+    let(:user) { User.new }
+
+    context 'when user is signed in' do
+      before do
+        sign_in(user)
+      end
+
+      it 'renders the expected page' do
+        get :resume, session: { tribunal_case_id: tribunal_case.id }
+        expect(response).to render_template(:resume)
+      end
+    end
+
+    context 'when user is not signed in' do
+      it 'redirects to the sign-in page' do
+        get :resume, session: { tribunal_case_id: tribunal_case.id }
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+  end
 end

--- a/spec/controllers/steps/details/check_answers_controller_spec.rb
+++ b/spec/controllers/steps/details/check_answers_controller_spec.rb
@@ -30,4 +30,26 @@ RSpec.describe Steps::Details::CheckAnswersController, type: :controller do
       expect(response.headers['Content-Disposition']).to eq('inline; filename="check_answers.pdf"')
     end
   end
+
+  describe '#resume' do
+    let(:user) { User.new }
+
+    context 'when user is signed in' do
+      before do
+        sign_in(user)
+      end
+
+      it 'renders the expected page' do
+        get :resume, session: { tribunal_case_id: tribunal_case.id }
+        expect(response).to render_template(:resume)
+      end
+    end
+
+    context 'when user is not signed in' do
+      it 'redirects to the sign-in page' do
+        get :resume, session: { tribunal_case_id: tribunal_case.id }
+        expect(response).to redirect_to(user_session_path)
+      end
+    end
+  end
 end

--- a/spec/controllers/users/cases_controller_spec.rb
+++ b/spec/controllers/users/cases_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Users::CasesController, type: :controller do
 
       context 'when tribunal case exists' do
         before do
-          expect(user).to receive(:tribunal_cases).and_return(scoped_result)
+          expect(user).to receive(:pending_tribunal_cases).and_return(scoped_result)
           expect(scoped_result).to receive(:find).with(tribunal_case.id).and_return(tribunal_case)
         end
 

--- a/spec/controllers/users/cases_controller_spec.rb
+++ b/spec/controllers/users/cases_controller_spec.rb
@@ -138,19 +138,19 @@ RSpec.describe Users::CasesController, type: :controller do
           expect(session[:tribunal_case_id]).to eq(tribunal_case.id)
         end
 
-        context 'redirects to the corresponding `check your answers` page' do
+        context 'redirects to the corresponding `check your answers` resume page' do
           before do
             get :resume, params: {case_id: tribunal_case.id}
           end
 
           context 'for an appeal case' do
             let(:intent) { Intent::TAX_APPEAL }
-            it { expect(response).to redirect_to(steps_details_check_answers_path) }
+            it { expect(response).to redirect_to(resume_steps_details_check_answers_path) }
           end
 
           context 'for a closure case' do
             let(:intent) { Intent::CLOSE_ENQUIRY }
-            it { expect(response).to redirect_to(steps_closure_check_answers_path) }
+            it { expect(response).to redirect_to(resume_steps_closure_check_answers_path) }
           end
         end
       end

--- a/spec/presenters/check_answers/contact_details_answer_spec.rb
+++ b/spec/presenters/check_answers/contact_details_answer_spec.rb
@@ -8,8 +8,21 @@ module CheckAnswers
     subject { described_class.new(question, attributes) }
 
     describe '#show?' do
-      it 'returns true' do
-        expect(subject.show?).to eq(true)
+      context 'when contact details have been entered' do
+        let(:attributes) { {
+          individual_first_name: 'Hans',
+          individual_last_name: 'Muller'
+        } }
+
+        it 'returns true' do
+          expect(subject.show?).to eq(true)
+        end
+      end
+
+      context 'when no contact details have been entered yet' do
+        it 'returns false' do
+          expect(subject.show?).to eq(false)
+        end
       end
     end
 

--- a/spec/presenters/check_answers/section_presenter_spec.rb
+++ b/spec/presenters/check_answers/section_presenter_spec.rb
@@ -12,8 +12,24 @@ module CheckAnswers
     end
 
     describe '#show?' do
-      it 'returns true' do
-        expect(subject.show?).to eq(true)
+      context 'for an empty answers collection' do
+        before do
+          expect(subject).to receive(:answers).and_return([])
+        end
+
+        it 'returns false' do
+          expect(subject.show?).to eq(false)
+        end
+      end
+
+      context 'for a not empty answers collection' do
+        before do
+          expect(subject).to receive(:answers).and_return(['blah'])
+        end
+
+        it 'returns true' do
+          expect(subject.show?).to eq(true)
+        end
       end
     end
   end

--- a/spec/presenters/check_answers/taxpayer_section_presenter_spec.rb
+++ b/spec/presenters/check_answers/taxpayer_section_presenter_spec.rb
@@ -24,6 +24,25 @@ module CheckAnswers
       end
     end
 
+    describe '#show?' do
+      context 'when the representative question have been answered' do
+        it 'returns true' do
+          expect(subject.show?).to eq(true)
+        end
+      end
+
+      context 'when the representative question have not been answered' do
+        let(:has_representative) { nil }
+        let(:contact_details_answer) { instance_double(ContactDetailsAnswer, show?: false) }
+        let(:file_or_text_answer) { instance_double(FileOrTextAnswer, show?: false) }
+        let(:answer) { instance_double(Answer, show?: false) }
+
+        it 'returns false' do
+          expect(subject.show?).to eq(false)
+        end
+      end
+    end
+
     describe '#answers' do
       context 'when there is a rep' do
         let(:has_representative) { HasRepresentative::YES }


### PR DESCRIPTION
This PR ensures we only show in the check your answers page those sections
that have at least an answer and avoid having missing translation exceptions.

Also it renders a different template for the `resume` action so we can get rid of
the declaration, modify the title and also we will have (WIP) a button to
resume the case, which will redirect the user to the last answered step.