### PR TITLE
Fix `TypeError: can't quote CaseStatus` error on reminders.

### DIFF
--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -1,12 +1,8 @@
 task :daily_tasks do
   puts "#{Time.now} Starting daily tasks"
 
-  # TODO: remove this test when save & return is enabled
-  # in all environments
-  if ENV['SAVE_AND_RETURN_ENABLED']
-    Rake::Task['case_reminders:first_email'].invoke
-    Rake::Task['case_reminders:last_email'].invoke
-  end
+  Rake::Task['case_reminders:first_email'].invoke
+  Rake::Task['case_reminders:last_email'].invoke
 
   puts "#{Time.now} tribunal_case:purge"
   Rake::Task['tribunal_case:purge'].invoke
@@ -16,11 +12,17 @@ end
 
 namespace :case_reminders do
   task :first_email => :environment do
-    CaseReminders.new(rule_set: ReminderRuleSet.first_reminder).run
+    rule_set = ReminderRuleSet.first_reminder
+
+    puts "#{Time.now} case_reminders:first_email - Count: #{rule_set.count}"
+    CaseReminders.new(rule_set: rule_set).run
   end
 
   task :last_email => :environment do
-    CaseReminders.new(rule_set: ReminderRuleSet.last_reminder).run
+    rule_set = ReminderRuleSet.last_reminder
+
+    puts "#{Time.now} case_reminders:last_email  - Count: #{rule_set.count}"
+    CaseReminders.new(rule_set: rule_set).run
   end
 end
 

--- a/spec/services/reminder_rule_set_spec.rb
+++ b/spec/services/reminder_rule_set_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ReminderRuleSet do
       it { expect(subject.created_days_ago).to eq(8) }
     end
 
-    context '#status_in' do
-      it { expect(subject.status_in).to match_array([nil]) }
+    context '#status' do
+      it { expect(subject.status).to eq(nil) }
     end
 
     context '#status_transition_to' do
@@ -33,8 +33,8 @@ RSpec.describe ReminderRuleSet do
       it { expect(subject.created_days_ago).to eq(10) }
     end
 
-    context '#status_in' do
-      it { expect(subject.status_in).to match_array([CaseStatus::FIRST_REMINDER_SENT]) }
+    context '#status' do
+      it { expect(subject.status).to eq(CaseStatus::FIRST_REMINDER_SENT) }
     end
 
     context '#status_transition_to' do
@@ -50,7 +50,7 @@ RSpec.describe ReminderRuleSet do
     let(:dummy_config) do
       {
         created_days_ago: 3,
-        status_in: ['status'],
+        status: 'status',
         status_transition_to: 'another_status',
         email_template_id: 'test-template'
       }
@@ -65,7 +65,7 @@ RSpec.describe ReminderRuleSet do
 
     it 'filters the cases' do
       expect(TribunalCase).to receive(:with_owner).and_return(finder_double)
-      expect(finder_double).to receive(:where).with(case_status: ['status']).and_return(finder_double)
+      expect(finder_double).to receive(:where).with(case_status: 'status').and_return(finder_double)
       expect(finder_double).to receive(:where).with('created_at <= ?', 3.days.ago).and_return(finder_double)
       subject.find_each
     end


### PR DESCRIPTION
Instead of using `map(&:to_s)` we just get rid of the array as it is not necessary
for our current requirements.

Also, added a bit of extra logging in the rake tasks.