### PR TITLE
Add a confirmation page after reset the password.

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -12,6 +12,9 @@ module Users
       end
     end
 
+    def reset_confirmation
+    end
+
     def reset_sent
     end
 
@@ -22,7 +25,7 @@ module Users
     end
 
     def after_resetting_password_path_for(_)
-      user_session_path
+      users_password_reset_confirmation_path
     end
 
     def after_sending_reset_password_instructions_path_for(_)

--- a/app/views/users/passwords/reset_confirmation.html.erb
+++ b/app/views/users/passwords/reset_confirmation.html.erb
@@ -1,0 +1,9 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%= link_to t('.sign_in'), user_session_path %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1261,6 +1261,10 @@ en:
         heading: You will get an email
         lead_text: We have sent you an email with a link to reset your password. Please check your inbox and spam folder.
         more_text_html: <a href="https://www.gov.uk/">Go to GOV.UK</a>
+      reset_confirmation:
+        heading: Your password has been reset
+        lead_text: Your new password has been set successfully.
+        sign_in: Sign into your account
     shared:
       case_saved:
         lead_text_html: A confirmation email has been sent to:<br><strong>%{email_address}</strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
     devise_scope :user do
       get 'login/logged_out', to: 'logins#logged_out'
       get 'password/reset_sent', to: 'passwords#reset_sent'
+      get 'password/reset_confirmation', to: 'passwords#reset_confirmation'
       get 'registration/update_confirmation', to: 'registrations#update_confirmation'
       get 'registration/save_confirmation', to: 'registrations#save_confirmation'
       get 'login/save_confirmation', to: 'logins#save_confirmation'

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Users::PasswordsController do
         allow(User).to receive(:reset_password_by_token).and_return(user)
       end
 
-      it 'redirects to the cases portfolio' do
+      it 'redirects to the reset confirmation page' do
         do_update
         expect(response).to redirect_to(users_password_reset_confirmation_path)
       end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe Users::PasswordsController do
         allow(User).to receive(:reset_password_by_token).and_return(user)
       end
 
-      it 'signs the user in and redirects to the cases portfolio' do
+      it 'redirects to the cases portfolio' do
         do_update
-        expect(response).to redirect_to(user_session_path)
+        expect(response).to redirect_to(users_password_reset_confirmation_path)
       end
     end
 
     context 'when the parameters are not valid' do
-      it 'does not sign a user in and re-renders the page' do
+      it 're-renders the page' do
         do_update
         expect(response).to redirect_to(new_user_password_path)
       end
@@ -59,6 +59,13 @@ RSpec.describe Users::PasswordsController do
     it 'renders the expected page' do
       get :reset_sent
       expect(response).to render_template(:reset_sent)
+    end
+  end
+
+  describe '#reset_sent' do
+    it 'renders the expected page' do
+      get :reset_confirmation
+      expect(response).to render_template(:reset_confirmation)
     end
   end
 end


### PR DESCRIPTION
Instead of redirecting the user directly to the sign in page.

https://www.pivotaltracker.com/story/show/144308731