### PR TITLE
Implement 'continue/resume' a previously saved case.

### DIFF
--- a/app/controllers/step_controller.rb
+++ b/app/controllers/step_controller.rb
@@ -8,6 +8,7 @@ class StepController < ApplicationController
     # Second to last element in the array, will be nil for arrays of size 0 or 1
     current_tribunal_case&.navigation_stack&.slice(-2) || root_path
   end
+  helper_method :previous_step_path
 
   private
 

--- a/app/controllers/users/cases_controller.rb
+++ b/app/controllers/users/cases_controller.rb
@@ -21,7 +21,7 @@ module Users
       tribunal_case = pending_user_cases.find(params[:id])
       session[:tribunal_case_id] = tribunal_case.id
 
-      redirect_to resume_path_for(tribunal_case.freeze)
+      redirect_to continue_path_for(tribunal_case.freeze)
     end
 
     def destroy
@@ -35,14 +35,30 @@ module Users
       current_user.pending_tribunal_cases
     end
 
-    # If there is no case_type, there is little point taking the users to the `check your answers` page as
+    # If tribunal_case is blank, there is little point taking the users to the `check your answers` page as
     # technically they didn't answer a single question yet, so in this (bit of an edge case) scenario, we
     # get them directly to the the corresponding step `root path`, which at the moment is the case_type step.
-    def resume_path_for(tribunal_case)
-      if tribunal_case.intent.eql?(Intent::TAX_APPEAL)
-        tribunal_case.case_type ? resume_steps_details_check_answers_path : steps_appeal_root_path
+    def continue_path_for(tribunal_case)
+      if tribunal_case.blank?
+        steps_root_path_for(tribunal_case.intent)
       else
-        tribunal_case.closure_case_type ? resume_steps_closure_check_answers_path : steps_closure_root_path
+        resume_check_answers_path_for(tribunal_case.intent)
+      end
+    end
+
+    def resume_check_answers_path_for(intent)
+      if intent.eql?(Intent::TAX_APPEAL)
+        resume_steps_details_check_answers_path
+      else
+        resume_steps_closure_check_answers_path
+      end
+    end
+
+    def steps_root_path_for(intent)
+      if intent.eql?(Intent::TAX_APPEAL)
+        steps_appeal_root_path
+      else
+        steps_closure_root_path
       end
     end
 

--- a/app/controllers/users/cases_controller.rb
+++ b/app/controllers/users/cases_controller.rb
@@ -18,10 +18,10 @@ module Users
     end
 
     def resume
-      tribunal_case = pending_user_cases.find(params[:case_id])
+      tribunal_case = pending_user_cases.find(params[:id])
       session[:tribunal_case_id] = tribunal_case.id
 
-      redirect_to resume_check_answers_path_for(tribunal_case.intent)
+      redirect_to resume_path_for(tribunal_case.freeze)
     end
 
     def destroy
@@ -35,11 +35,14 @@ module Users
       current_user.pending_tribunal_cases
     end
 
-    def resume_check_answers_path_for(intent)
-      if intent.eql?(Intent::TAX_APPEAL)
-        resume_steps_details_check_answers_path
+    # If there is no case_type, there is little point taking the users to the `check your answers` page as
+    # technically they didn't answer a single question yet, so in this (bit of an edge case) scenario, we
+    # get them directly to the the corresponding step `root path`, which at the moment is the case_type step.
+    def resume_path_for(tribunal_case)
+      if tribunal_case.intent.eql?(Intent::TAX_APPEAL)
+        tribunal_case.case_type ? resume_steps_details_check_answers_path : steps_appeal_root_path
       else
-        resume_steps_closure_check_answers_path
+        tribunal_case.closure_case_type ? resume_steps_closure_check_answers_path : steps_closure_root_path
       end
     end
 

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -19,7 +19,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       appeal_or_application: mail_presenter.appeal_or_application,
-      resume_case_link: users_case_resume_url(tribunal_case)
+      resume_case_link: resume_users_case_url(tribunal_case)
     )
 
     mail(to: tribunal_case.user.email)

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -78,6 +78,13 @@ class TribunalCase < ApplicationRecord
     user_type.eql?(UserType::REPRESENTATIVE)
   end
 
+  # With our current implementation, we consider a case as `blank` if
+  # case_type (appeals) nor closure_case_type (closure) have been set,
+  # as this is the first question the user is asked.
+  def blank?
+    case_type.nil? && closure_case_type.nil?
+  end
+
   private
 
   def sanitize

--- a/app/views/application/_resume_check_answers_footer.html.erb
+++ b/app/views/application/_resume_check_answers_footer.html.erb
@@ -1,4 +1,4 @@
-<!-- TODO: implement the `Resume` button -->
+<br/>
 <p>
-  <%# button_to translate_with_appeal_or_application('check_answers.footer..resume'), '#', class: 'button js-debounce' %>
+  <%= link_to translate_with_appeal_or_application('check_answers.footer..resume'), previous_step_path, class: 'button' %>
 </p>

--- a/app/views/steps/closure/check_answers/resume.html.erb
+++ b/app/views/steps/closure/check_answers/resume.html.erb
@@ -1,5 +1,3 @@
-<%= step_header %>
-
 <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 
 <%= render @presenter.sections %>

--- a/app/views/steps/details/check_answers/resume.html.erb
+++ b/app/views/steps/details/check_answers/resume.html.erb
@@ -1,5 +1,3 @@
-<%= step_header %>
-
 <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 
 <%= render @presenter.sections %>

--- a/app/views/users/cases/_case_row.html.erb
+++ b/app/views/users/cases/_case_row.html.erb
@@ -19,7 +19,7 @@
   <td class="right">
     <span class="right actions actions-tight">
       <%= button_to t('.delete'), users_case_path(tribunal_case), method: :delete, data: {confirm: t('.delete_confirmation')}, class: 'button button-secondary' %>
-      <%= link_to t('.resume'), users_case_resume_path(tribunal_case), class: 'button' %>
+      <%= link_to t('.resume'), resume_users_case_path(tribunal_case), class: 'button' %>
     </span>
   </td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
 
   namespace :steps do
     namespace :appeal do
+      root 'case_type#edit'
+
       show_step :start
       edit_step :case_type
       edit_step :case_type_show_more
@@ -64,6 +66,8 @@ Rails.application.routes.draw do
     end
 
     namespace :closure do
+      root 'case_type#edit'
+
       show_step :start
       edit_step :case_type
       edit_step :enquiry_details
@@ -104,7 +108,7 @@ Rails.application.routes.draw do
     end
 
     resources :cases, only: [:index, :destroy, :edit, :update] do
-      get :resume
+      get :resume, on: :member
     end
   end
 

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -164,4 +164,24 @@ RSpec.describe TribunalCase, type: :model do
       end
     end
   end
+
+  describe '#blank?' do
+    let(:attributes) { { case_type: case_type, closure_case_type: closure_case_type } }
+    let(:case_type) { nil }
+    let(:closure_case_type) { nil}
+
+    context 'both `case_type` and `closure_case_type` are not set' do
+      it { expect(subject.blank?).to eq(true) }
+    end
+
+    context '`case_type` is set' do
+      let(:case_type) { CaseType.new(:anything) }
+      it { expect(subject.blank?).to eq(false) }
+    end
+
+    context '`closure_case_type` is set' do
+      let(:closure_case_type) { ClosureCaseType.new(:anything) }
+      it { expect(subject.blank?).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
This PR implements the missing functionality to continue a saved case in the point
where the users left. It can be triggered from the resume `check your answers` page,
or in the scenario where the user didn't answer anything yet, we direct them to the
`case_type` step, as at the moment this is the first step.

Two helper routes points to the first step of the appeal or closure flows, so it is
easy to change in the future in case we wanted to redirect the users to a different url.