### PR TITLE
Add 'generated at' date to the PDF.

### DIFF
--- a/app/assets/stylesheets/local/case_details_pdf.scss
+++ b/app/assets/stylesheets/local/case_details_pdf.scss
@@ -18,6 +18,10 @@
     }
   }
 
+  span.generated-at {
+    font-size: 60%;
+  }
+
   h2.section-header {
     font-size: 110%;
     font-weight: 700;

--- a/app/views/application/_check_answers_header.pdf.erb
+++ b/app/views/application/_check_answers_header.pdf.erb
@@ -1,0 +1,13 @@
+<div class="pdf-header">
+  <h2><%=t 'check_answers.pdf.header.tax_chamber' %></h2>
+  <h1>
+    <%= translate_with_appeal_or_application("check_answers.pdf.header.#{heading_key}") %>
+    <% if @presenter.case_reference? %>
+      &ndash; <%= @presenter.case_reference %>
+    <% end %>
+  </h1>
+
+  <span class="generated-at">
+    <%= t('check_answers.pdf.header.generated_at', date: l(Date.today, format: :compact)) %>
+  </span>
+</div>

--- a/app/views/steps/closure/check_answers/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/show.pdf.erb
@@ -6,16 +6,7 @@
   </head>
 
   <body id="case-details-pdf">
-    <div class="pdf-header">
-      <h2><%= translate_with_appeal_or_application 'check_answers.pdf.header.tax_chamber' %></h2>
-      <h1>
-        <%= translate_with_appeal_or_application 'check_answers.pdf.header.closure_heading' %>
-        <% if @presenter.case_reference? %>
-          &ndash; <%= @presenter.case_reference %>
-        <% end %>
-      </h1>
-    </div>
-
+    <%= render partial: 'application/check_answers_header', locals: {heading_key: 'closure_heading'} %>
     <%= render @presenter.sections %>
   </body>
 </html>

--- a/app/views/steps/details/check_answers/show.pdf.erb
+++ b/app/views/steps/details/check_answers/show.pdf.erb
@@ -6,16 +6,7 @@
   </head>
 
   <body id="case-details-pdf">
-    <div class="pdf-header">
-      <h2><%= translate_with_appeal_or_application 'check_answers.pdf.header.tax_chamber' %></h2>
-      <h1>
-        <%= translate_with_appeal_or_application 'check_answers.pdf.header.appeal_heading' %>
-        <% if @presenter.case_reference? %>
-          &ndash; <%= @presenter.case_reference %>
-        <% end %>
-      </h1>
-    </div>
-
+    <%= render partial: 'application/check_answers_header', locals: {heading_key: 'appeal_heading'} %>
     <%= render @presenter.sections %>
   </body>
 </html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -811,6 +811,7 @@ en:
         tax_chamber: First-tier Tribunal (Tax Chamber)
         appeal_heading: Notice of %{appeal_or_application}
         closure_heading: Application to close enquiry
+        generated_at: 'Generated: %{date}'
     case_type:
       question: What is your %{appeal_or_application} about?
       accessible_change_text: what your %{appeal_or_application} is about
@@ -989,6 +990,9 @@ en:
       format:
         unit: "£"
         precision: 0
+  date:
+    formats:
+      compact: '%d/%m/%Y'
   time:
     case_expires_in:
       zero: Today


### PR DESCRIPTION
The date of generation has been added to the header of appeal/closure PDF.

https://www.pivotaltracker.com/story/show/144699571

<img width="543" alt="screen shot 2017-05-03 at 10 35 55" src="https://cloud.githubusercontent.com/assets/687910/25655380/90349370-2fec-11e7-9271-8b3ab418744e.png">
