### PR TITLE
Small visual tweaks to 'generated at' date in PDF.

### DIFF
--- a/app/assets/stylesheets/local/case_details_pdf.scss
+++ b/app/assets/stylesheets/local/case_details_pdf.scss
@@ -18,7 +18,7 @@
     }
   }
 
-  span.generated-at {
+  p.generated-at {
     font-size: 60%;
   }
 

--- a/app/views/application/_check_answers_header.pdf.erb
+++ b/app/views/application/_check_answers_header.pdf.erb
@@ -7,7 +7,7 @@
     <% end %>
   </h1>
 
-  <span class="generated-at">
-    <%= t('check_answers.pdf.header.generated_at', date: l(Date.today, format: :compact)) %>
-  </span>
+  <p class="generated-at">
+    <%= t('check_answers.pdf.header.generated_at', date: l(Date.today, format: :long)) %>
+  </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -993,6 +993,7 @@ en:
   date:
     formats:
       compact: '%d/%m/%Y'
+      long: '%e %B %Y'
   time:
     case_expires_in:
       zero: Today


### PR DESCRIPTION
As per Jason request, long form date and slighly bigger top margin.

<img width="549" alt="screen shot 2017-05-03 at 12 14 11" src="https://cloud.githubusercontent.com/assets/687910/25658357/621e1ade-2ffa-11e7-9b90-3f78a7e1c370.png">
