### PR TITLE
Signed in saved case confirmation email.

### DIFF
--- a/app/controllers/concerns/starting_point_step.rb
+++ b/app/controllers/concerns/starting_point_step.rb
@@ -1,12 +1,16 @@
 module StartingPointStep
   extend ActiveSupport::Concern
 
+  included do
+    before_action :save_case_for_later, if: :user_signed_in?
+  end
+
   private
 
   def current_tribunal_case
     # Only the step including this concern should create a tribunal case
     # if there isn't one in the session - because it's the first
-    super || initialize_tribunal_case(intent: intent, user: current_user)
+    super || initialize_tribunal_case(intent: intent)
   end
 
   def update_navigation_stack
@@ -14,5 +18,9 @@ module StartingPointStep
     # before re-initialising it in StepController#update_navigation_stack
     current_tribunal_case.navigation_stack = []
     super
+  end
+
+  def save_case_for_later
+    SaveCaseForLater.new(current_tribunal_case, current_user).save
   end
 end


### PR DESCRIPTION
Previously, when a user is already signed in, any case they create was being
assigned to the user without triggering a 'saved case' confirmation email.

With this change we ensure the assigning of the user is also triggering the
confirmation email, making use of the service object `SaveCaseForLater`.

Only one email will be sent as once the case is assigned to the signed in user,
no more emails are sent.

https://www.pivotaltracker.com/story/show/144695107