### PR TITLE
Refactor the landing page step for appeal and closure.

### DIFF
--- a/app/controllers/appeal_home_controller.rb
+++ b/app/controllers/appeal_home_controller.rb
@@ -1,0 +1,4 @@
+class AppealHomeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/closure_home_controller.rb
+++ b/app/controllers/closure_home_controller.rb
@@ -1,0 +1,4 @@
+class ClosureHomeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/concerns/starting_point_step.rb
+++ b/app/controllers/concerns/starting_point_step.rb
@@ -2,7 +2,7 @@ module StartingPointStep
   extend ActiveSupport::Concern
 
   included do
-    before_action :save_case_for_later, if: :user_signed_in?
+    before_action :save_case_for_later, if: :user_signed_in?, only: [:update]
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -21,8 +21,8 @@ class HomeController < ApplicationController
   # [task name (used for i18n), estimated minutes to complete this task, path/url to the task]
   def link_sections
     [
-      [:appeal, 30, steps_appeal_start_path],
-      [:close, 15, steps_closure_start_path]
+      [:appeal, 30, appeal_path],
+      [:close, 15, closure_path]
     ]
   end
 end

--- a/app/controllers/steps/appeal/case_type_controller.rb
+++ b/app/controllers/steps/appeal/case_type_controller.rb
@@ -1,5 +1,7 @@
 module Steps::Appeal
   class CaseTypeController < Steps::AppealStepController
+    include StartingPointStep
+
     def edit
       @form_object = CaseTypeForm.new(
         tribunal_case: current_tribunal_case,

--- a/app/controllers/steps/appeal/start_controller.rb
+++ b/app/controllers/steps/appeal/start_controller.rb
@@ -1,8 +1,0 @@
-module Steps::Appeal
-  class StartController < Steps::AppealStepController
-    include StartingPointStep
-
-    def show
-    end
-  end
-end

--- a/app/controllers/steps/closure/case_type_controller.rb
+++ b/app/controllers/steps/closure/case_type_controller.rb
@@ -1,5 +1,7 @@
 module Steps::Closure
   class CaseTypeController < Steps::ClosureStepController
+    include StartingPointStep
+
     def edit
       @form_object = CaseTypeForm.new(
         tribunal_case: current_tribunal_case,

--- a/app/controllers/steps/closure/start_controller.rb
+++ b/app/controllers/steps/closure/start_controller.rb
@@ -1,8 +1,0 @@
-module Steps::Closure
-  class StartController < Steps::ClosureStepController
-    include StartingPointStep
-
-    def show
-    end
-  end
-end

--- a/app/views/appeal_home/index.html.erb
+++ b/app/views/appeal_home/index.html.erb
@@ -1,0 +1,35 @@
+<header class="homepage-top">
+  <div class="homepage-top-inner">
+    <div class="welcome-block">
+      <div class="inner-block floated-children">
+        <div class="welcome-text">
+          <div class="floated-inner-block">
+            <h1><%= t '.impartial_decision' %></h1>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">
+      <%=t '.heading' %>
+    </h1>
+
+    <p class="lede">
+      <%=t '.lead_text_html' %>
+    </p>
+
+    <%= t('.description_html',
+          approval_form_href: asset_path('proforma.pdf'),
+          approval_form_format_and_size: 'PDF, 241KB'
+        )
+    %>
+
+    <p>
+      <%= link_to t('.continue'), edit_steps_appeal_case_type_path, class: 'button button-start', role: 'button' %>
+    </p>
+  </div>
+</div>

--- a/app/views/closure_home/index.html.erb
+++ b/app/views/closure_home/index.html.erb
@@ -1,0 +1,17 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t('.heading') %></h1>
+
+    <p class="lede"><%= t('.lead_text') %></p>
+
+    <%= t('.description_html',
+          approval_form_href: asset_path('proforma.pdf'),
+          approval_form_format_and_size: 'PDF, 241KB'
+        )
+    %>
+
+    <p>
+      <%= link_to t('.continue'), edit_steps_closure_case_type_path, class: 'button button-start', role: 'button' %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,21 +60,6 @@ en:
 
   steps:
     appeal:
-      start:
-        show:
-          impartial_decision: Get an impartial decision on your dispute
-          heading: Appeal against a tax decision
-          lead_text_html: You have 30 calendar days to appeal. This begins from the
-            date of the original notice or review conclusion letter.
-          description_html: |
-            <p>You may be able to appeal late by giving reasons. The judge will decide if your appeal can go ahead.</p>
-            <h2 class="heading-medium">What you will need</h2>
-            <ul class="list list-bullet">
-              <li><strong>a scan or photo</strong> of the original notice or review conclusion letter</li>
-              <li><strong>reasons for your appeal</strong> to copy and paste or attach as a document</li>
-            </ul>
-            <p>You will also need to complete an <a href="%{approval_form_href}" target="_blank" class="ga-pageLink" data-ga-category="Proforma" data-ga-label="rep auth">authorisation form (%{approval_form_format_and_size})</a> if you want someone to represent you and they are not a legal professional.</p>
-          continue: Continue
       case_type:
         <<: *CASE_TYPE_QUESTION
       case_type_show_more:
@@ -159,18 +144,6 @@ en:
               <li>waited 45 days and not received a letter</li>
             </ul>
     closure:
-      start:
-        show:
-          continue: Continue
-          heading: Apply to close an enquiry
-          lead_text: Ask the judge to end a tax enquiry with a closure, counteraction or no-counteraction notice.
-          description_html: |
-            <h2 class="heading-medium">What you will need</h2>
-            <ul class="list list-bullet">
-              <li><strong>details of the enquiry</strong> including the HMRC reference number and tax years under enquiry</li>
-            </ul>
-            <p>You can also provide further information and supporting documents saying why you think the enquiry should end.</p>
-            <p>You will need to complete an <a href="%{approval_form_href}" target="_blank" class="ga-pageLink" data-ga-category="Proforma" data-ga-label="rep auth">authorisation form (%{approval_form_format_and_size})</a> if you want someone to represent you and they are not a legal professional.</p>
       case_type:
         edit:
           heading: What type of enquiry do you want to close?
@@ -1281,3 +1254,30 @@ en:
         lead_text_html: A confirmation email has been sent to:<br><strong>%{email_address}</strong>
         expire_warning: We will keep a draft of your case for %{expire_in_days} days. Any information will be automatically deleted for your security after this time.
         return_info: You can return to continue entering details at any time. Please check you still meet the tribunal deadline and enter reasons if you think you may be late.
+  appeal_home:
+    index:
+      impartial_decision: Get an impartial decision on your dispute
+      heading: Appeal against a tax decision
+      lead_text_html: You have 30 calendar days to appeal. This begins from the
+        date of the original notice or review conclusion letter.
+      description_html: |
+        <p>You may be able to appeal late by giving reasons. The judge will decide if your appeal can go ahead.</p>
+        <h2 class="heading-medium">What you will need</h2>
+        <ul class="list list-bullet">
+          <li><strong>a scan or photo</strong> of the original notice or review conclusion letter</li>
+          <li><strong>reasons for your appeal</strong> to copy and paste or attach as a document</li>
+        </ul>
+        <p>You will also need to complete an <a href="%{approval_form_href}" target="_blank" class="ga-pageLink" data-ga-category="Proforma" data-ga-label="rep auth">authorisation form (%{approval_form_format_and_size})</a> if you want someone to represent you and they are not a legal professional.</p>
+      continue: Continue
+  closure_home:
+    index:
+      continue: Continue
+      heading: Apply to close an enquiry
+      lead_text: Ask the judge to end a tax enquiry with a closure, counteraction or no-counteraction notice.
+      description_html: |
+        <h2 class="heading-medium">What you will need</h2>
+        <ul class="list list-bullet">
+          <li><strong>details of the enquiry</strong> including the HMRC reference number and tax years under enquiry</li>
+        </ul>
+        <p>You can also provide further information and supporting documents saying why you think the enquiry should end.</p>
+        <p>You will need to complete an <a href="%{approval_form_href}" target="_blank" class="ga-pageLink" data-ga-category="Proforma" data-ga-label="rep auth">authorisation form (%{approval_form_format_and_size})</a> if you want someone to represent you and they are not a legal professional.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,6 @@ Rails.application.routes.draw do
     namespace :appeal do
       root 'case_type#edit'
 
-      show_step :start
       edit_step :case_type
       edit_step :case_type_show_more
       edit_step :dispute_type
@@ -68,7 +67,6 @@ Rails.application.routes.draw do
     namespace :closure do
       root 'case_type#edit'
 
-      show_step :start
       edit_step :case_type
       edit_step :enquiry_details
       edit_step :additional_info
@@ -138,6 +136,9 @@ Rails.application.routes.draw do
 
   root to: 'home#index'
   get :start, to: 'home#start'
+  get :appeal, to: 'appeal_home#index'
+  get :closure, to: 'closure_home#index'
+
   get :contact, to: 'home#contact', as: :contact_page
   get :terms_and_conditions, to: 'home#terms_and_conditions'
   get :example_saved_appeal, to: 'home#example_saved_appeal'

--- a/spec/controllers/appeal_home_controller_spec.rb
+++ b/spec/controllers/appeal_home_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe AppealHomeController do
+  describe '#index' do
+    it 'renders the expected page' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    it 'should not initialise a tribunal case' do
+      get :index
+      expect(controller.current_tribunal_case).to be_nil
+    end
+  end
+end

--- a/spec/controllers/closure_home_controller_spec.rb
+++ b/spec/controllers/closure_home_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ClosureHomeController do
+  describe '#index' do
+    it 'renders the expected page' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+
+    it 'should not initialise a tribunal case' do
+      get :index
+      expect(controller.current_tribunal_case).to be_nil
+    end
+  end
+end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe HomeController do
       name, time, link = assigns[:link_sections][0]
       expect(name).to eq(:appeal)
       expect(time).to eq(30)
-      expect(link).to eq('/steps/appeal/start')
+      expect(link).to eq('/appeal')
 
       name, time, link = assigns[:link_sections][1]
       expect(name).to eq(:close)
       expect(time).to eq(15)
-      expect(link).to eq('/steps/closure/start')
+      expect(link).to eq('/closure')
     end
   end
 

--- a/spec/controllers/steps/appeal/case_type_controller_spec.rb
+++ b/spec/controllers/steps/appeal/case_type_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Appeal::CaseTypeController, type: :controller do
+  it_behaves_like 'a starting point step controller', intent: Intent::TAX_APPEAL
   it_behaves_like 'an intermediate step controller', Steps::Appeal::CaseTypeForm, AppealDecisionTree
 end

--- a/spec/controllers/steps/appeal/start_controller_spec.rb
+++ b/spec/controllers/steps/appeal/start_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Steps::Appeal::StartController, type: :controller do
-  it_behaves_like 'a starting point step controller', intent: Intent::TAX_APPEAL
-end

--- a/spec/controllers/steps/closure/case_type_controller_spec.rb
+++ b/spec/controllers/steps/closure/case_type_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Steps::Closure::CaseTypeController, type: :controller do
+  it_behaves_like 'a starting point step controller', intent: Intent::CLOSE_ENQUIRY
   it_behaves_like 'an intermediate step controller', Steps::Closure::CaseTypeForm, ClosureDecisionTree
 end

--- a/spec/controllers/steps/closure/start_controller_spec.rb
+++ b/spec/controllers/steps/closure/start_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Steps::Closure::StartController, type: :controller do
-  it_behaves_like 'a starting point step controller', intent: Intent::CLOSE_ENQUIRY
-end


### PR DESCRIPTION
This PR takes out of the steps hierarchy the landing pages (start pages) for appeal
and closure in order to mitigate an issue with having to create a tribunal case too
early in the journey, before even the user answer any question at all.

Until now it was not very important, but with save & return we don't want to assign
a tribunal case to a user (and this send a confirmation email) until the user really
advance a bit more in the journey and answer the first question (case type).

Please note, in case it is important for Google Analytics, the following URLs have changed:

* /steps/appeal/start  -> /appeal
* /steps/closure/start -> /closure

This work is related to a previous PR:
https://www.pivotaltracker.com/story/show/144695107