### PR TITLE
Add the error summary box to the user forms.

### DIFF
--- a/app/views/users/logins/new.html.erb
+++ b/app/views/users/logins/new.html.erb
@@ -3,8 +3,6 @@
     <h2 class="heading-large"><%=t '.heading' %></h2>
 
     <%= form_for(resource, as: resource_name, url: user_session_path) do |f| %>
-      <%= devise_error_messages! %>
-
       <%= f.email_field :email, autofocus: true %>
       <%= f.password_field :password, class: 'js-toggleable-password', autocomplete: 'off' %>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= error_summary(resource) %>
+
     <h2 class="heading-large"><%=t '.heading' %></h2>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :patch }) do |f| %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= error_summary(resource) %>
+
     <h2 class="heading-large"><%=t '.heading' %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :patch }) do |f| %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,12 +1,18 @@
-<h2 class="heading-xlarge"><%= translate_with_appeal_or_application '.heading' %></h2>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= error_summary(resource) %>
 
-<%=t '.account_warning_html' %>
+    <h2 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h2>
 
-<p><%= link_to t('.existing_account'), user_session_path %></p>
+    <%= t '.account_warning_html' %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.email_field :email, autofocus: true %>
-  <%= f.password_field :password, class: 'js-toggleable-password', autocomplete: "off" %>
+    <p><%= link_to t('.existing_account'), user_session_path %></p>
 
-  <%= f.submit t('helpers.submit.create_account'), class: 'button' %>
-<% end %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= f.email_field :email, autofocus: true %>
+      <%= f.password_field :password, class: 'js-toggleable-password', autocomplete: "off" %>
+
+      <%= f.submit t('helpers.submit.create_account'), class: 'button' %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
As they were not part of the steps flow, they didn't make use of the step_header and
thus were missing the error summary in the top of the page.

https://www.pivotaltracker.com/story/show/144359839

<img width="545" alt="screen shot 2017-05-04 at 11 07 15" src="https://cloud.githubusercontent.com/assets/687910/25699143/df9c6960-30b9-11e7-9736-08ac98baf1e1.png">
