### PR TITLE
Validate blank email addresses on reset password.

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,9 +1,20 @@
 module Users
   class PasswordsController < Devise::PasswordsController
+    # Intercept the creation of the reset token given an email address, and check this
+    # value as otherwise Devise will not error if the email address is left blank.
+    # This will not error on malformed email addresses as we are in Paranoid mode and Devise
+    # will consider any input as valid, but at least we cover the blank scenario.
+    def create
+      super do |user|
+        if user.errors.added?(:email, :blank)
+          respond_with(user) and return
+        end
+      end
+    end
 
-    # Intercept the errors and if there is an 'invalid token' error, redirect back to the
-    # reset password page. Otherwise, Devise will not show the error in the edit page,
-    # because the error belongs to a hidden field.
+    # Intercept the errors and if there is any on the reset_password_token field, redirect back
+    # to the reset password page. Otherwise, Devise will not show the error in the edit page,
+    # because it belongs to a hidden field.
     def update
       super do |user|
         if user.errors.include?(:reset_password_token)

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,5 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
+    <%= error_summary(resource) %>
+
     <h2 class="heading-large"><%=t '.heading' %></h2>
 
     <p><%= t '.lead_text' %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,7 +481,7 @@ en:
         user:
           attributes:
             email:
-              blank: Please enter an email address
+              blank: Please enter your email address
               invalid: Please enter a valid email address
               taken: You already have cases saved with this email address. Try signing in.
             password:
@@ -1234,13 +1234,13 @@ en:
         heading: Forgot your password
         sign_in: Go back and sign in
         lead_text: Enter your email address and we'll send you a link to reset your password.
-        account_text: Remember, if you haven't signed in for 30 days we delete your email address for security reasons.
+        account_text: Remember, if you haven't signed in for 30 days we delete your account for security reasons.
       edit:
         heading: Change your password
       reset_sent:
         heading: Please check your email
         lead_text: We have sent you an email with a link to reset your password. Please check your inbox and spam folder.
-        deleted_account: If you haven't signed in for 30 days we delete your email address for security reasons. You'll need to start again and save an appeal or application.
+        deleted_account: If you haven't signed in for 30 days we delete your account for security reasons. You'll need to start again and save an appeal or application.
       reset_confirmation:
         heading: Your password has been changed
         lead_text: You have set a new password successfully.

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -15,13 +15,26 @@ RSpec.describe Users::PasswordsController do
   describe '#create' do
     def do_post
       post :create, params: {'user' => {
-        email: 'foo@bar.com'
+        email: email
       }}
     end
 
-    it 'redirects to the confirmation path' do
-      do_post
-      expect(response).to redirect_to(users_password_reset_sent_path)
+    context 'when email field is not left empty' do
+      let(:email) { 'foo@bar.com' }
+
+      it 'redirects to the confirmation path' do
+        do_post
+        expect(response).to redirect_to(users_password_reset_sent_path)
+      end
+    end
+
+    context 'when email field is left empty' do
+      let(:email) { '' }
+
+      it 're-renders the page' do
+        do_post
+        expect(subject).to render_template(:new)
+      end
     end
   end
 


### PR DESCRIPTION
Devise Paranoid mode means it considers any email (even blank ones) as valid and
will not disclose any information regarding if it is valid, exists or not.
This is cool, but at least blank emails should be shown as errors to the user.

This PR intercept the errors and if a :blank email error is set, we re-render the
view in order to show the errors, otherwise normal flow happens.
This will however not show errors for malformed email addresses as Devise will use
this code also when the email doesn't exists, which means we would be disclosing
valid, existing accounts.

If we wanted to validate the email address some extra monkey patching might be needed.

https://www.pivotaltracker.com/story/show/144345627