### PR TITLE
Add personalisation variable to case saved confirmation email.

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -19,6 +19,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       appeal_or_application: mail_presenter.appeal_or_application,
+      show_deadline_warning: mail_presenter.show_deadline_warning?,
       resume_case_link: resume_users_case_url(tribunal_case)
     )
 

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -38,6 +38,10 @@ class CaseMailPresenter < SimpleDelegator
     (started_by_representative? ? representative_organisation_name : taxpayer_organisation_name).to_s
   end
 
+  def show_deadline_warning?
+    intent.equal?(Intent::TAX_APPEAL) ? 'yes' : 'no'
+  end
+
   # Email address to use for `GLiMR is down` notifications
   def ftt_recipient_email
     ENV.fetch('TAX_TRIBUNAL_EMAIL')

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe NotifyMailer, type: :mailer do
     it 'has the right keys' do
       expect(mail.govuk_notify_personalisation).to eq({
         appeal_or_application: :appeal,
+        show_deadline_warning: 'yes',
         resume_case_link: 'https://tax.justice.uk/users/cases/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume'
       })
     end

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe CaseMailPresenter do
   let(:tribunal_case) { TribunalCase.new(tribunal_case_attributes) }
   let(:tribunal_case_attributes) {
     {
+      intent: intent,
       user_type: user_type,
       taxpayer_type: taxpayer_type,
       representative_type: representative_type,
@@ -18,6 +19,8 @@ RSpec.describe CaseMailPresenter do
       representative_individual_last_name: 'Quinten'
     }.merge(additional_attributes)
   }
+
+  let(:intent) { Intent::TAX_APPEAL }
   let(:user_type) { nil }
   let(:taxpayer_type) { nil }
   let(:representative_type) { nil }
@@ -163,6 +166,18 @@ RSpec.describe CaseMailPresenter do
       end
 
       it { expect(subject.show_company_name?).to eq('no') }
+    end
+  end
+
+  describe '#show_deadline_warning?' do
+    context 'for a tax appeal case' do
+      let(:intent) { Intent::TAX_APPEAL }
+      it { expect(subject.show_deadline_warning?).to eq('yes') }
+    end
+
+    context 'for a closure case' do
+      let(:intent) { Intent::CLOSE_ENQUIRY }
+      it { expect(subject.show_deadline_warning?).to eq('no') }
     end
   end
 


### PR DESCRIPTION
As per @joshlow request, in order to customise further the email based on the case intent.