### PR TITLE
Replacing common invalid hyphens and quotes from email user input.

### DIFF
--- a/app/attributes/normalised_email.rb
+++ b/app/attributes/normalised_email.rb
@@ -1,0 +1,5 @@
+class NormalisedEmail < Virtus::Attribute
+  def coerce(value)
+    NormalisedEmailType.new.cast(value)
+  end
+end

--- a/app/attributes/normalised_email_type.rb
+++ b/app/attributes/normalised_email_type.rb
@@ -1,0 +1,21 @@
+class NormalisedEmailType < ActiveRecord::Type::String
+  # https://www.cs.sfu.ca/~ggbaker/reference/characters/#single
+  UNICODE_QUOTES = "\u0060\u2018\u2019\u2032".freeze
+  APOSTROPHE = "'".freeze
+
+  # https://www.cs.sfu.ca/~ggbaker/reference/characters/#dash
+  UNICODE_HYPHENS = "\u2010-\u2015".freeze
+  HYPHEN = "-".freeze
+
+  def cast(value)
+    super(normalise(value))
+  end
+
+  private
+
+  def normalise(value)
+    value.to_s.strip.
+        gsub(/[#{UNICODE_QUOTES}]/,  APOSTROPHE).
+        gsub(/[#{UNICODE_HYPHENS}]/, HYPHEN)
+  end
+end

--- a/app/forms/steps/details/representative_details_form.rb
+++ b/app/forms/steps/details/representative_details_form.rb
@@ -2,7 +2,7 @@ module Steps::Details
   class RepresentativeDetailsForm < BaseForm
     attribute :representative_contact_address, StrippedString
     attribute :representative_contact_postcode, StrippedString
-    attribute :representative_contact_email, StrippedString
+    attribute :representative_contact_email, NormalisedEmail
     attribute :representative_contact_phone, StrippedString
 
     validates_presence_of :representative_contact_address,

--- a/app/forms/steps/details/taxpayer_details_form.rb
+++ b/app/forms/steps/details/taxpayer_details_form.rb
@@ -2,7 +2,7 @@ module Steps::Details
   class TaxpayerDetailsForm < BaseForm
     attribute :taxpayer_contact_address, StrippedString
     attribute :taxpayer_contact_postcode, StrippedString
-    attribute :taxpayer_contact_email, StrippedString
+    attribute :taxpayer_contact_email, NormalisedEmail
     attribute :taxpayer_contact_phone, StrippedString
 
     validates_presence_of :taxpayer_contact_address,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   has_many :tribunal_cases, dependent: :destroy
   has_many :pending_tribunal_cases, -> { not_submitted }, class_name: TribunalCase
 
+  attribute :email, NormalisedEmailType.new
+
   # Devise requires several DB attributes for the `trackable` module, but we are not
   # using all of them. Using virtual attributes so Devise doesn't complain.
   attr_accessor :last_sign_in_ip, :current_sign_in_ip, :sign_in_count

--- a/spec/attributes/normalised_email_type_spec.rb
+++ b/spec/attributes/normalised_email_type_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe NormalisedEmailType do
+  let(:coerced_value) { subject.cast(value) }
+  let(:replacement_char) { coerced_value.split.uniq }
+
+  describe 'normalising hyphens' do
+    let(:value) { "\u2010 \u2011 \u2012 \u2013 \u2014 \u2015" }
+    it { expect(replacement_char).to eq(['-']) }
+  end
+
+  describe 'normalising single quotes' do
+    let(:value) { "\u0060 \u2018 \u2019 \u2032" }
+    it { expect(replacement_char).to eq(["'"]) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,4 +29,18 @@ RSpec.describe User, type: :model do
       described_class.purge!(30.days.ago)
     end
   end
+
+  describe 'email validation' do
+    context 'custom value casting' do
+      #
+      # This is just a quick test to ensure the `NormalisedEmailType` casting is being used.
+      # A more in-deep test of all possible unicode substitutions can be found in:
+      # spec/attributes/normalised_email_type_spec.rb
+      #
+      it 'should replace common unicode equivalent characters' do
+        subject.email = "test\u2032ing@hyphened\u2010domain.com"
+        expect(subject.email).to eq("test\u0027ing@hyphened\u002ddomain.com")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Due to copy&paste or whatever other reason, some users might be entering invalid
characters into the email fields, thus making the validation fail. It is very difficult
to catch some of these characters as they are visually equivalent, so the user will get
frustrated thinking their email address is invalid.

This PR solves (to a certain extent) the problem by replacing silently some of the most
common equivalent characters (for hyphens and single quotes) with the valid ones.

https://www.pivotaltracker.com/story/show/144937767