### PR TITLE
Create a management report that emails stats daily

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -94,6 +94,12 @@ class NotifyMailer < GovukNotifyRails::Mailer
     mail(to: mail_presenter.account_user_email)
   end
 
+  def statistics_report(title, data)
+    set_template(ENV.fetch('NOTIFY_STATISTICS_REPORT_TEMPLATE_ID'))
+    set_personalisation(title: title, data: data)
+    mail(to: ENV.fetch('STATISTICS_REPORT_EMAIL_ADDRESS'))
+  end
+
   private
 
   def log_errors(exception)

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -6,7 +6,8 @@ class NotifyMailer < GovukNotifyRails::Mailer
   PERSONALISATION_ERROR_FILTER = [
     :recipient_name,
     :company_name,
-    :documents_url
+    :documents_url,
+    :reset_url
   ].freeze
 
   # Define methods as usual, and set the template and personalisation, if needed,

--- a/app/services/tax_tribs.rb
+++ b/app/services/tax_tribs.rb
@@ -1,0 +1,4 @@
+module TaxTribs
+  # This namespace only exists so that we can get mutant
+  # to test all our service classes
+end

--- a/app/services/tax_tribs/statistics_report.rb
+++ b/app/services/tax_tribs/statistics_report.rb
@@ -1,0 +1,32 @@
+class TaxTribs::StatisticsReport
+  def self.cases_by_date_csv
+    results = TribunalCase.connection.execute <<~SQL
+      SELECT
+        date(created_at) AS created_on,
+        case_status,
+        count(*) AS number
+      FROM #{TribunalCase.table_name}
+      GROUP BY date(created_at), case_status
+    SQL
+
+    dates = results.inject({}) do |hash, row|
+      d = row.fetch('created_on')
+
+      data = hash.fetch(d, { 'started' => 0, 'submitted' => 0 })
+
+      started = data.fetch('started')
+      started += row.fetch('number')
+
+      submitted = data.fetch('submitted')
+      submitted += row.fetch('number') if row.fetch('case_status').eql?(CaseStatus::SUBMITTED.to_s)
+
+      hash[d] = { 'started' => started, 'submitted' => submitted }
+
+      hash
+    end
+
+    dates.inject(["Date, Started, Submitted"]) do |arr, (date, data)|
+      arr.push [date, data.fetch('started'), data.fetch('submitted')].join(', ')
+    end.join("\n")
+  end
+end

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -10,6 +10,9 @@ task :daily_tasks do
   puts "#{Time.now} users:purge"
   Rake::Task['users:purge'].invoke
 
+  puts "#{Time.now} reports:cases_by_date_csv"
+  Rake::Task['reports:cases_by_date_csv'].invoke
+
   puts "#{Time.now} Finished daily tasks"
 end
 
@@ -46,5 +49,15 @@ namespace :users do
     puts "Purging users who have not logged in for #{expire_after} days."
     purged = User.purge!(expire_after.days.ago)
     puts "Purged #{purged.size} users."
+  end
+end
+
+namespace :reports do
+  desc "Email CSV of cases created/submitted by date"
+  task cases_by_date_csv: :environment do
+    if ENV['STATISTICS_REPORT_EMAIL_ADDRESS']
+      csv = TaxTribs::StatisticsReport.cases_by_date_csv
+      NotifyMailer.statistics_report("Cases by Date", csv).deliver_later
+    end
   end
 end

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -1,10 +1,19 @@
 task :mutant => :environment do
+  vars = 'NOCOVERAGE=true'
+  flags = '--use rspec --fail-fast'
+
+  # TODO: Remove this once all our classes are migrated to the
+  # TaxTribs namespace
   classes_to_mutate.each do |klass|
-    vars = 'NOCOVERAGE=true'
-    flags = '--use rspec --fail-fast'
     unless system("#{vars} mutant #{flags} #{klass}")
       raise 'Mutation testing failed'
     end
+  end
+
+  # TODO: migrate all service classes into the TaxTribs namespace, so
+  # that mutant will test them
+  unless system("#{vars} mutant #{flags} TaxTribs*")
+    raise 'Mutation testing failed'
   end
 end
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe NotifyMailer, type: :mailer do
     allow(ENV).to receive(:fetch).with('NOTIFY_RESET_PASSWORD_TEMPLATE_ID').and_return('reset-password-template')
     allow(ENV).to receive(:fetch).with('NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID').and_return('change-password-template')
     allow(ENV).to receive(:fetch).with('NOTIFY_NEW_CASE_SAVED_TEMPLATE_ID').and_return('new-case-saved-template')
+    allow(ENV).to receive(:fetch).with('NOTIFY_STATISTICS_REPORT_TEMPLATE_ID').and_return('statistics-report')
+  end
+
+  describe '#statistics_report' do
+    before do
+      allow(ENV).to receive(:fetch).with('STATISTICS_REPORT_EMAIL_ADDRESS').and_return('reporting@tax-tribunals.org')
+    end
+
+    let(:mail) { described_class.statistics_report('My Title', "foo\nbar\nbaz") }
+    it_behaves_like 'a Notify mail', template_id: 'statistics-report'
+    it 'has the right keys' do
+      expect(mail.govuk_notify_personalisation).to eq({
+        title: 'My Title',
+        data: "foo\nbar\nbaz"
+      })
+    end
   end
 
   describe '#new_case_saved_confirmation' do

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -37,11 +37,22 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     let(:mail) { described_class.statistics_report('My Title', "foo\nbar\nbaz") }
     it_behaves_like 'a Notify mail', template_id: 'statistics-report'
+
     it 'has the right keys' do
       expect(mail.govuk_notify_personalisation).to eq({
         title: 'My Title',
         data: "foo\nbar\nbaz"
       })
+    end
+
+    it "gets the template id from an env var" do
+      expect(ENV).to receive(:fetch).with('NOTIFY_STATISTICS_REPORT_TEMPLATE_ID')
+      mail.body
+    end
+
+    it "gets the recipient from an env var" do
+      expect(ENV).to receive(:fetch).with('STATISTICS_REPORT_EMAIL_ADDRESS')
+      mail.body
     end
   end
 
@@ -62,6 +73,11 @@ RSpec.describe NotifyMailer, type: :mailer do
         resume_case_link: 'https://tax.justice.uk/users/cases/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume'
       })
     end
+
+    it "gets the template id from an env var" do
+      expect(ENV).to receive(:fetch).with('NOTIFY_NEW_CASE_SAVED_TEMPLATE_ID')
+      mail.body
+    end
   end
 
   describe '#reset_password_instructions' do
@@ -76,6 +92,11 @@ RSpec.describe NotifyMailer, type: :mailer do
         reset_url: 'https://tax.justice.uk/users/password/edit?reset_password_token=0xDEADBEEF'
       })
     end
+
+    it "gets the template id from an env var" do
+      expect(ENV).to receive(:fetch).with('NOTIFY_RESET_PASSWORD_TEMPLATE_ID')
+      mail.body
+    end
   end
 
   describe '#password_change' do
@@ -89,12 +110,22 @@ RSpec.describe NotifyMailer, type: :mailer do
         portfolio_url: 'https://tax.justice.uk/users/cases'
       })
     end
+
+    it "gets the template id from an env var" do
+      expect(ENV).to receive(:fetch).with('NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID')
+      mail.body
+    end
   end
 
   describe 'taxpayer_case_confirmation' do
     let(:mail) { described_class.taxpayer_case_confirmation(tribunal_case) }
 
     it_behaves_like 'a Notify mail', template_id: 'confirmation-template'
+
+    it "gets the template id from an env var" do
+      expect(ENV).to receive(:fetch).with('NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID')
+      mail.body
+    end
 
     context 'personalisation' do
       it 'sets the personalisation' do
@@ -160,6 +191,11 @@ RSpec.describe NotifyMailer, type: :mailer do
           mail.govuk_notify_personalisation.keys
         ).to eq([:recipient_name, :company_name, :show_company_name, :documents_url])
       end
+    end
+
+    it "gets the template id from an env var" do
+      expect(ENV).to receive(:fetch).with('NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID')
+      mail.body
     end
   end
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -169,4 +169,9 @@ RSpec.describe NotifyMailer, type: :mailer do
       end
     end
   end
+
+  describe 'personalisation logging filter' do
+    let(:filter) { described_class::PERSONALISATION_ERROR_FILTER }
+    it { expect(filter).to match_array([:recipient_name, :company_name, :documents_url, :reset_url]) }
+  end
 end

--- a/spec/services/tax_tribs/statistics_report_spec.rb
+++ b/spec/services/tax_tribs/statistics_report_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe TaxTribs::StatisticsReport do
+  describe '#cases_by_date_csv' do
+    let(:header) { "Date, Started, Submitted" }
+
+    context 'when there are no TribunalCase records' do
+      specify { expect(described_class.cases_by_date_csv).to eq(header) }
+    end
+
+    context 'when there are some TribunalCase records' do
+      before do
+        travel_to Time.at(0) do
+          TribunalCase.create({})
+          TribunalCase.create({})
+          TribunalCase.create({ case_status: CaseStatus.new(:submitted) })
+        end
+
+        travel_to(Time.parse('2017-05-08 06:30:00')) do
+          TribunalCase.create({ case_status: CaseStatus.new(:first_reminder_sent) })
+        end
+      end
+
+      it "generates a csv report" do
+        report = [
+          header,
+          "1970-01-01, 3, 1",
+          "2017-05-08, 1, 0"
+        ].join("\n")
+        expect(described_class.cases_by_date_csv).to eq(report)
+      end
+
+    end
+  end
+end
+

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -74,6 +74,12 @@ RSpec.shared_examples 'a starting point step controller' do |options|
   let(:intent) { options.fetch(:intent) }
 
   describe '#edit' do
+    before do
+      # This should not be necessary, but without it David S. was getting
+      # consistent errors when running the tests
+      TribunalCase.delete_all
+    end
+
     context 'when no case exists in the session yet' do
       it 'creates a new case' do
         expect { get :edit }.to change { TribunalCase.count }.by(1)


### PR DESCRIPTION
This is a quick and dirty solution which simply emails every day's stats
every day. We can refine this later.

This commit also introduces a TaxTribs namespace, and mutation tests any
class within it. This gives us a framework for incrementally adding
mutation testing to the classes which are currently not being tested.