### PR TITLE
Refactor the 'case not found' error into 2 separate errors.

### DIFF
--- a/app/assets/javascripts/modules/session-timeout.js
+++ b/app/assets/javascripts/modules/session-timeout.js
@@ -13,7 +13,7 @@ moj.Modules.sessionTimeout = {
     // URLs
     pingUrl: '/session/ping',
     destroySessionUrl: '/session',
-    expiredUrl: '/errors/case_not_found',
+    expiredUrl: '/errors/invalid_session',
     abortedUrl: '/',
     // i18n for minutes/seconds/expired
     inString: "in",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,9 @@ class ApplicationController < ActionController::Base
 
   rescue_from Exception do |exception|
     case exception
-    when Errors::CaseNotFound, ActionController::InvalidAuthenticityToken
+    when Errors::InvalidSession, ActionController::InvalidAuthenticityToken
+      redirect_to invalid_session_errors_path
+    when Errors::CaseNotFound
       redirect_to case_not_found_errors_path
     when Errors::CaseSubmitted
       redirect_to case_submitted_errors_path
@@ -38,7 +40,7 @@ class ApplicationController < ActionController::Base
   end
 
   def check_tribunal_case_presence
-    raise Errors::CaseNotFound unless current_tribunal_case
+    raise Errors::InvalidSession unless current_tribunal_case
   end
 
   def check_tribunal_case_status

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -12,6 +12,10 @@ class ErrorsController < ApplicationController
     respond_with_status(:not_found)
   end
 
+  def invalid_session
+    respond_with_status(:not_found)
+  end
+
   def unhandled
     respond_with_status(:internal_server_error)
   end

--- a/app/controllers/users/cases_controller.rb
+++ b/app/controllers/users/cases_controller.rb
@@ -7,25 +7,25 @@ module Users
     end
 
     def edit
-      @tribunal_case = pending_user_cases.find(params[:id])
+      @tribunal_case = pending_case_from_params
     end
 
     def update
-      @tribunal_case = pending_user_cases.find(params[:id])
+      @tribunal_case = pending_case_from_params
       @tribunal_case.update(user_case_reference: permitted_params[:user_case_reference])
 
       redirect_to users_cases_path
     end
 
     def resume
-      tribunal_case = pending_user_cases.find(params[:id])
+      tribunal_case = pending_case_from_params
       session[:tribunal_case_id] = tribunal_case.id
 
       redirect_to continue_path_for(tribunal_case.freeze)
     end
 
     def destroy
-      pending_user_cases.find(params[:id]).destroy
+      pending_case_from_params.destroy
       redirect_to users_cases_path
     end
 
@@ -33,6 +33,10 @@ module Users
 
     def pending_user_cases
       current_user.pending_tribunal_cases
+    end
+
+    def pending_case_from_params
+      pending_user_cases.find_by(id: params[:id]) || (raise Errors::CaseNotFound)
     end
 
     # If tribunal_case is blank, there is little point taking the users to the `check your answers` page as

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
     # We are allowing to create new accounts only as part of saving a case in progress
-    before_action :ensure_tribunal_case, only: [:new, :create]
+    before_action :check_tribunal_case_presence, only: [:new, :create]
 
     def save_confirmation
       @email_address = session[:confirmation_email_address]
@@ -34,12 +34,6 @@ module Users
 
     def after_update_path_for(_)
       users_registration_update_confirmation_path
-    end
-
-    private
-
-    def ensure_tribunal_case
-      redirect_to case_not_found_errors_path unless current_tribunal_case
     end
   end
 end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,4 +1,5 @@
 module Errors
+  class InvalidSession < StandardError; end
   class CaseNotFound < StandardError; end
   class CaseSubmitted < StandardError; end
 end

--- a/app/views/errors/invalid_session.html.erb
+++ b/app/views/errors/invalid_session.html.erb
@@ -1,0 +1,13 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large"><%= t '.heading' %></h1>
+
+    <p class="lede"><%=t '.lead_text', session_timeout: Rails.configuration.x.session.expires_in_minutes %></p>
+
+    <p class="lede"><%=t '.more_text' %></p>
+
+    <div class="form-group">
+      <%= link_to t('.start_again'), start_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1027,12 +1027,16 @@ en:
     error_summary:
       heading: There's a problem. You need to fix this error.
       text: ''
-    case_not_found:
+    invalid_session:
       heading: Sorry, you'll have to start again
       <<: *START_FINISH
-      lead_text: Your session automatically ends if you don't use the service for
-        %{session_timeout} minutes.
+      lead_text: Your session automatically ends if you don't use the service for %{session_timeout} minutes.
       more_text: We do this for your security. Any unsaved details will be deleted.
+    case_not_found:
+      heading: Sorry, this case can't be found
+      <<: *START_FINISH
+      lead_text: The case you are looking for couldn't be found.
+      more_text: If you followed an email link, the case might have expired or was already submitted.
     case_submitted:
       heading: You have already submitted this case
       lead_text_html: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
   resources :status, only: [:index]
 
   resource :errors, only: [] do
+    get :invalid_session
     get :case_not_found
     get :case_submitted
     get :unhandled

--- a/spec/controllers/users/cases_controller_spec.rb
+++ b/spec/controllers/users/cases_controller_spec.rb
@@ -41,11 +41,18 @@ RSpec.describe Users::CasesController, type: :controller do
 
     it 'renders the edit page' do
       expect(user).to receive(:pending_tribunal_cases).and_return(tribunal_cases)
-      expect(tribunal_cases).to receive(:find).with('124').and_return(double)
+      expect(tribunal_cases).to receive(:find_by).with(id: '124').and_return(double)
 
       get :edit, params: { id: 124 }
       expect(assigns[:tribunal_case]).not_to be_nil
       expect(response).to render_template(:edit)
+    end
+
+    context 'when tribunal case does not exist' do
+      it 'redirects to the case not found error page' do
+        get :edit, params: { id: 123 }
+        expect(response).to redirect_to(case_not_found_errors_path)
+      end
     end
   end
 
@@ -59,11 +66,18 @@ RSpec.describe Users::CasesController, type: :controller do
 
     it 'updates the tribunal case' do
       expect(user).to receive(:pending_tribunal_cases).and_return(tribunal_cases)
-      expect(tribunal_cases).to receive(:find).with('124').and_return(tribunal_case)
+      expect(tribunal_cases).to receive(:find_by).with(id: '124').and_return(tribunal_case)
       expect(tribunal_case).to receive(:update).with(user_case_reference: 'lolz')
 
       patch :update, params: { id: 124, tribunal_case: { user_case_reference: 'lolz' } }
       expect(response).to redirect_to(users_cases_path)
+    end
+
+    context 'when tribunal case does not exist' do
+      it 'redirects to the case not found error page' do
+        patch :update, params: { id: 123 }
+        expect(response).to redirect_to(case_not_found_errors_path)
+      end
     end
   end
 
@@ -83,16 +97,17 @@ RSpec.describe Users::CasesController, type: :controller do
         sign_in(user)
       end
 
-      it 'raises an exception if case is not found' do
-        expect {
+      context 'when tribunal case does not exist' do
+        it 'redirects to the case not found error page' do
           delete :destroy, params: {id: '123'}
-        }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(response).to redirect_to(case_not_found_errors_path)
+        end
       end
 
       context 'when tribunal case exists' do
         before do
           expect(user).to receive(:pending_tribunal_cases).and_return(scoped_result)
-          expect(scoped_result).to receive(:find).with(tribunal_case.id).and_return(tribunal_case)
+          expect(scoped_result).to receive(:find_by).with(id: tribunal_case.id).and_return(tribunal_case)
         end
 
         it 'deletes the tribunal case by ID' do
@@ -129,16 +144,17 @@ RSpec.describe Users::CasesController, type: :controller do
         sign_in(user)
       end
 
-      it 'raises an exception if case is not found' do
-        expect {
+      context 'when tribunal case does not exist' do
+        it 'redirects to the case not found error page' do
           get :resume, params: {id: '123'}
-        }.to raise_error(ActiveRecord::RecordNotFound)
+          expect(response).to redirect_to(case_not_found_errors_path)
+        end
       end
 
       context 'when tribunal case exists' do
         before do
           expect(user).to receive(:pending_tribunal_cases).and_return(scoped_result)
-          expect(scoped_result).to receive(:find).with(tribunal_case.id).and_return(tribunal_case)
+          expect(scoped_result).to receive(:find_by).with(id: tribunal_case.id).and_return(tribunal_case)
         end
 
         it 'assigns the chosen tribunal case to the current session' do

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Users::RegistrationsController do
     context 'when there is no tribunal case in the session' do
       let(:tribunal_case) { nil }
 
-      it 'redirects to case not found error' do
+      it 'redirects to the invalid session error page' do
         get :new
-        expect(response).to redirect_to(case_not_found_errors_path)
+        expect(response).to redirect_to(invalid_session_errors_path)
       end
     end
 
@@ -30,9 +30,9 @@ RSpec.describe Users::RegistrationsController do
     context 'when there is no tribunal case in the session' do
       let(:tribunal_case) { nil }
 
-      it 'redirects to case not found error' do
+      it 'redirects to the invalid session error page' do
         post :create, params: { doesnt: 'matter' }
-        expect(response).to redirect_to(case_not_found_errors_path)
+        expect(response).to redirect_to(invalid_session_errors_path)
       end
     end
 

--- a/spec/support/current_tribunal_case_shared_examples.rb
+++ b/spec/support/current_tribunal_case_shared_examples.rb
@@ -4,8 +4,8 @@ RSpec.shared_examples 'checks the validity of the current tribunal case' do
   context 'when there is no case in the session' do
     let(:current_tribunal_case) { nil }
 
-    it 'redirects to the case not found error page' do
-      expect(response).to redirect_to(case_not_found_errors_path)
+    it 'redirects to the invalid session error page' do
+      expect(response).to redirect_to(invalid_session_errors_path)
     end
   end
 

--- a/spec/support/endpoint_shared_examples.rb
+++ b/spec/support/endpoint_shared_examples.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 RSpec.shared_examples 'an end point step controller' do
   describe '#show' do
     context 'when no case exists in the session' do
-      it 'redirects to the case not found error page' do
+      it 'redirects to the invalid session error page' do
         get :show
-        expect(response).to redirect_to(case_not_found_errors_path)
+        expect(response).to redirect_to(invalid_session_errors_path)
       end
     end
 

--- a/spec/support/step_controller_shared_examples.rb
+++ b/spec/support/step_controller_shared_examples.rb
@@ -13,9 +13,9 @@ RSpec.shared_examples 'a generic step controller' do |form_class, decision_tree_
         allow(controller).to receive(:current_tribunal_case).and_return(nil)
       end
 
-      it 'redirects to the case not found error page' do
+      it 'redirects to the invalid session error page' do
         put :update, params: expected_params
-        expect(response).to redirect_to(case_not_found_errors_path)
+        expect(response).to redirect_to(invalid_session_errors_path)
       end
     end
 
@@ -181,9 +181,9 @@ RSpec.shared_examples 'an intermediate step controller' do |form_class, decision
         allow(controller).to receive(:current_tribunal_case).and_return(nil)
       end
 
-      it 'redirects to the case not found error page' do
+      it 'redirects to the invalid session error page' do
         get :edit
-        expect(response).to redirect_to(case_not_found_errors_path)
+        expect(response).to redirect_to(invalid_session_errors_path)
       end
     end
 


### PR DESCRIPTION
This PR introduces a small refactor to separate into 2 different errors the
`case not found` error, as we now need to show a more accurate message when
the case doesn't exist in the database as opossed to the session.

The `case not found` error is now raised on the cases controller when the
record does not exist, and the `invalid session` error is raised in any other
place where a valid tribunal case is needed to be in the session.

https://www.pivotaltracker.com/story/show/145025665