### PR TITLE
Add the 'show_deadline_warning' variable to the reminders notification

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -88,6 +88,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       appeal_or_application: mail_presenter.appeal_or_application,
+      show_deadline_warning: mail_presenter.show_deadline_warning?,
       resume_case_link: resume_users_case_url(tribunal_case)
     )
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe NotifyMailer, type: :mailer do
       it 'sets the personalisation' do
         expect(
           mail.govuk_notify_personalisation.keys
-        ).to eq([:appeal_or_application, :resume_case_link])
+        ).to eq([:appeal_or_application, :show_deadline_warning, :resume_case_link])
       end
     end
   end


### PR DESCRIPTION
As per Josh request. This variable was already present in the 'case saved' notification.

https://www.pivotaltracker.com/story/show/145046281