### PR TITLE
use 'deliver!' to send email from a rake task

### DIFF
--- a/app/services/tax_tribs/statistics_report.rb
+++ b/app/services/tax_tribs/statistics_report.rb
@@ -7,6 +7,7 @@ class TaxTribs::StatisticsReport
         count(*) AS number
       FROM #{TribunalCase.table_name}
       GROUP BY date(created_at), case_status
+      ORDER BY date(created_at)
     SQL
 
     dates = results.inject({}) do |hash, row|

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -57,7 +57,7 @@ namespace :reports do
   task cases_by_date_csv: :environment do
     if ENV['STATISTICS_REPORT_EMAIL_ADDRESS']
       csv = TaxTribs::StatisticsReport.cases_by_date_csv
-      NotifyMailer.statistics_report("Cases by Date", csv).deliver_later
+      NotifyMailer.statistics_report("Cases by Date", csv).deliver!
     end
   end
 end

--- a/spec/services/tax_tribs/statistics_report_spec.rb
+++ b/spec/services/tax_tribs/statistics_report_spec.rb
@@ -19,12 +19,17 @@ RSpec.describe TaxTribs::StatisticsReport do
         travel_to(Time.parse('2017-05-08 06:30:00')) do
           TribunalCase.create({ case_status: CaseStatus.new(:first_reminder_sent) })
         end
+
+        travel_to(Time.parse('2017-04-08 06:30:00')) do
+          TribunalCase.create({ case_status: CaseStatus.new(:first_reminder_sent) })
+        end
       end
 
       it "generates a csv report" do
         report = [
           header,
           "1970-01-01, 3, 1",
+          "2017-04-08, 1, 0",
           "2017-05-08, 1, 0"
         ].join("\n")
         expect(described_class.cases_by_date_csv).to eq(report)


### PR DESCRIPTION
deliver_later works fine inline in the rails application code,
but it doesn't work for rake tasks, so the daily statistics
email was not being sent. This commit fixes that.