### PR TITLE
add aria role to dropzone

### DIFF
--- a/app/views/steps/shared/_dropzone.html.erb
+++ b/app/views/steps/shared/_dropzone.html.erb
@@ -10,7 +10,7 @@
   <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
 </div>
 
-<div class="dropzone dz-clickable js-only" id="dz_doc_upload" tabindex="0" data-accepted-files="<%= DocumentUpload::ALLOWED_CONTENT_TYPES.join(',') %>" data-max-filesize="<%= DocumentUpload::MAX_FILE_SIZE %>">
+<div class="dropzone dz-clickable js-only" id="dz_doc_upload" tabindex="0" data-accepted-files="<%= DocumentUpload::ALLOWED_CONTENT_TYPES.join(',') %>" data-max-filesize="<%= DocumentUpload::MAX_FILE_SIZE %>" role="button">
   <div class="dz-default dz-message grid-row">
     <div class="column-one-third arrow-icon">
       <p></p>


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/145191647)

The dropzone target is selectable, but did not have an aria-role associated with it.

This adds `role="button"` to the dropzone since it is selectable by any method common to buttons (click, ENTER, SPACE).