### PR TITLE
Fix broken logging in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.logstash.type = :stdout
   config.log_level = :info
 
   config.cache_classes = true


### PR DESCRIPTION
I was under the mistaken impression that the 12 factor gem would
automatically handle chaning the production logging over to STDOUT.
However, it did not take precedence over the default configuration of
the logstash-logger gem, which is to use UDP.  The default config requires that
the UDP port is explicitly set, which is wasn't.