### PR TITLE
Heading structure

### DIFF
--- a/app/views/appeal_home/index.html.erb
+++ b/app/views/appeal_home/index.html.erb
@@ -16,9 +16,9 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <h1 class="heading-large">
+    <h2 class="heading-large">
       <%=t '.heading' %>
-    </h1>
+    </h2>
 
     <p class="lede">
       <%=t '.lead_text_html' %>

--- a/app/views/application/_check_answers_footer.html.erb
+++ b/app/views/application/_check_answers_footer.html.erb
@@ -4,7 +4,7 @@
 
 <p class="notice util_mt-large">
   <i class="icon icon-important">
-    <span class="visuallyhidden"><%= t 'check_answers.footer..warning' %></span>
+    <h2 class="visuallyhidden"><%= t 'check_answers.footer..warning' %></h2>
   </i>
   <strong class="bold-small">
     <%= t 'check_answers.footer..warning_message' %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -22,7 +22,7 @@
 
       <p class="notice util_mt-large">
         <i class="icon icon-important">
-          <span class="visuallyhidden">Warning</span>
+          <h2 class="visuallyhidden">Warning</h2>
         </i>
         <strong class="bold-small">
           You can't save details so get everything ready before you start

--- a/app/views/shared/_confirmation_case_reference.html.erb
+++ b/app/views/shared/_confirmation_case_reference.html.erb
@@ -1,17 +1,17 @@
 <% if tribunal_case&.case_reference.present? %>
 
-  <h1 class="heading-large">
+  <h2 class="heading-large">
     <span class="heading-secondary"><%= t '.case_reference' %></span>
     <span><%= tribunal_case.case_reference %></span>
-  </h1>
+  </h2>
 
   <p><%= t '.note_number' %></p>
 
 <% else %>
 
-  <h1 class="heading-large">
+  <h2 class="heading-large">
     <span class="heading-secondary"><%= t '.case_submitted_successfully' %></span>
-  </h1>
+  </h2>
 
   <p><%= t '.case_reference_pending' %></p>
 


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/145265153)

We had multiple `<h1>` tags on some pages, which makes understanding the page structure harder for users of assistive tech.

Additionally, one analyst advised making the hidden 'Warning' text which accompanies our ! icons into a heading tag to surface these to screenreaders.