### PR TITLE
bigger text on confirmation for colour contrast win

### DIFF
--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -97,3 +97,9 @@ address {
   text-decoration: underline;
   margin-bottom: 0;
 }
+
+.govuk-box-highlight {
+  p {
+    @include core-24;
+  }
+}


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/145267087)

Make the second line of text in the green box on 'Case submitted' bigger to achieve required colour contrast.

