### PR TITLE
Add new challenge radio option for direct tax and restoration

### DIFF
--- a/app/forms/steps/challenge/decision_status_form.rb
+++ b/app/forms/steps/challenge/decision_status_form.rb
@@ -11,7 +11,16 @@ module Steps::Challenge
           ChallengedDecisionStatus::PENDING,
           ChallengedDecisionStatus::OVERDUE,
           ChallengedDecisionStatus::NOT_REQUIRED,
+          ChallengedDecisionStatus::APPEAL_LATE_REJECTION,
           ChallengedDecisionStatus::APPEALING_DIRECTLY
+        ]
+      elsif restoration_case?
+        [
+          ChallengedDecisionStatus::RECEIVED,
+          ChallengedDecisionStatus::PENDING,
+          ChallengedDecisionStatus::OVERDUE,
+          ChallengedDecisionStatus::REFUSED,
+          ChallengedDecisionStatus::REVIEW_LATE_REJECTION
         ]
       else
         [
@@ -24,6 +33,10 @@ module Steps::Challenge
     end
 
     private
+
+    def restoration_case?
+      tribunal_case.case_type.eql?(CaseType::RESTORATION_CASE)
+    end
 
     def challenged_decision_status_value
       ChallengedDecisionStatus.new(challenged_decision_status)

--- a/app/value_objects/challenged_decision_status.rb
+++ b/app/value_objects/challenged_decision_status.rb
@@ -1,11 +1,13 @@
 class ChallengedDecisionStatus < ValueObject
   VALUES = [
-    RECEIVED           = new(:received),
-    PENDING            = new(:pending),
-    OVERDUE            = new(:overdue),
-    REFUSED            = new(:refused),
-    NOT_REQUIRED       = new(:not_required),
-    APPEALING_DIRECTLY = new(:appealing_directly)
+    RECEIVED              = new(:received),
+    PENDING               = new(:pending),
+    OVERDUE               = new(:overdue),
+    REFUSED               = new(:refused),
+    NOT_REQUIRED          = new(:not_required),
+    APPEALING_DIRECTLY    = new(:appealing_directly),
+    APPEAL_LATE_REJECTION = new(:appeal_late_rejection),
+    REVIEW_LATE_REJECTION = new(:review_late_rejection),
   ].freeze
 
   def self.values

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,16 @@ en:
       heading: What is your appeal about?
       lead_text: Check the original notice letter or review conclusion letter.
 
+    CHALLENGE_STATUS: &CHALLENGE_STATUS
+      received: I have a review conclusion letter
+      pending: I have been waiting less than 45 days for a review to finish
+      overdue: I have been waiting for 45 days or more for a review to finish
+      refused: I was refused a review as I was outside the time limit
+      appeal_late_rejection: My appeal was rejected for being late
+      review_late_rejection: My review was rejected for being late
+      appealing_directly: No response. I want to appeal directly to the tribunal
+      not_required: I was offered a review but didn’t accept
+
     START_FINISH: &START_FINISH
       start_again: Start again
       finish: Finish
@@ -707,12 +717,7 @@ en:
           <<: *YESNO
       steps_challenge_decision_status_form:
         challenged_decision_status:
-          received: I have a review conclusion letter
-          pending: I have been waiting less than 45 days for a review to finish
-          overdue: I have been waiting for 45 days or more for a review to finish
-          refused: I was refused a review as I was outside the time limit
-          appealing_directly: No response. I want to appeal directly to the tribunal
-          not_required: I was offered a review but didn’t accept
+          <<: *CHALLENGE_STATUS
       steps_closure_case_type_form:
         closure_case_type:
           personal_return_html: Personal return
@@ -932,12 +937,7 @@ en:
       question: What response did you receive?
       accessible_change_text: what response you received
       answers:
-        received: I have a review conclusion letter
-        pending: I have been waiting less than 45 days for a review to finish
-        overdue: I have been waiting for 45 days or more for a review to finish
-        refused: I was refused a review as I was outside the time limit
-        appealing_directly: No response. I want to appeal directly to the tribunal
-        not_required: I was offered a review but didn’t accept
+        <<: *CHALLENGE_STATUS
     dispute_type:
       question: What is your dispute about?
       accessible_change_text: what your dispute is about

--- a/spec/forms/steps/challenge/decision_status_form_spec.rb
+++ b/spec/forms/steps/challenge/decision_status_form_spec.rb
@@ -21,12 +21,27 @@ RSpec.describe Steps::Challenge::DecisionStatusForm do
           pending
           overdue
           not_required
+          appeal_late_rejection
           appealing_directly
         ))
       end
     end
 
-    context 'when the case type is not a direct tax' do
+    context 'when the case type is restoration case' do
+      let(:case_type) { CaseType::RESTORATION_CASE }
+
+      it 'shows only the relevant choices' do
+        expect(subject.choices).to eq(%w(
+          received
+          pending
+          overdue
+          refused
+          review_late_rejection
+        ))
+      end
+    end
+
+    context 'when the case type is any other' do
       let(:case_type) { CaseType::VAT }
 
       it 'shows only the relevant choices' do

--- a/spec/value_objects/challenged_decision_status_spec.rb
+++ b/spec/value_objects/challenged_decision_status_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ChallengedDecisionStatus do
         refused
         not_required
         appealing_directly
+        appeal_late_rejection
+        review_late_rejection
       ))
     end
   end


### PR DESCRIPTION
As a user (direct tax or restoration) I want to inform the tribunal that I have
appealed to HRMC but was refused due to appealing late.

Selecting this option the user proceeds as normal.

Two separate values have been added to the ChallengedDecisionStatus value object
so the copy can be different depending on the case type being direct tax or a
restoration case (this was required by Josh).

https://www.pivotaltracker.com/story/show/145026639