### PR TITLE
Fix dropzone keyboard access in IE

### DIFF
--- a/app/assets/javascripts/modules/doc-upload.js
+++ b/app/assets/javascripts/modules/doc-upload.js
@@ -69,7 +69,7 @@ moj.Modules.docUpload = {
     });
 
     $(document).on('keydown', 'a.faux-link, .dz-clickable', function(e) {
-      if([13, 32].includes(e.keyCode)) { // pressed RETURN or SPACE
+      if(e.keyCode === 13 || e.keyCode === 32) { // pressed RETURN or SPACE
         e.preventDefault();
         self.$form.trigger('click');
       }

--- a/app/assets/stylesheets/local/dropzone.scss
+++ b/app/assets/stylesheets/local/dropzone.scss
@@ -1,3 +1,6 @@
+.dz-preview {
+  display: none;
+}
 
 .dropzone {
   border: 2px dashed $grey-1;
@@ -37,6 +40,7 @@
   }
 
   .dz-preview {
+    display: block;
     width: 100%;
     min-height: 50px;
     margin: 0 0 1em;


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/145288459)

Doh. `array.includes()` doesn't work in IE. Of course it doesn't.

Also non dropzone friendly browsers (like IE9-) were showing DZ related elements which had no business being there.