### PR TITLE
Correct the log file format in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,10 +46,6 @@ group :development, :test do
   gem 'rspec-rails'
 end
 
-group :production do
-  gem 'rails_12factor'
-end
-
 group :test do
   gem 'brakeman'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,11 +260,6 @@ GEM
       nokogiri (~> 1.6.0)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.0.1)
       actionpack (= 5.0.0.1)
       activesupport (= 5.0.0.1)
@@ -418,7 +413,6 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0)
   rails-controller-testing
-  rails_12factor
   responders
   rspec-rails
   rubocop

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,13 +22,6 @@ Rails.application.configure do
 
   config.active_support.deprecation = :notify
 
-  config.log_formatter = ::Logger::Formatter.new
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   config.active_record.dump_schema_after_migration = false
 
   # NB: Because of the way the form builder works, and hence the


### PR DESCRIPTION
The 12 factor gem was preventing the logs from being output in the
logstash format.  Not only were we not using its functionality, it has
been included in Rails 5 directly.  I have remove the gem and the
suggested Rails 5 log configuration and logging now formats as expected.