### PR TITLE
update visual email confirmation on more events

### DIFF
--- a/app/assets/javascripts/modules/check-email-address.js
+++ b/app/assets/javascripts/modules/check-email-address.js
@@ -18,7 +18,7 @@ moj.Modules.checkEmail = {
   bindEvents: function() {
     var self = this;
 
-    self.$emailField.on('keyup', function() {
+    self.$emailField.on('keyup change focus blur', function() {
       self.checkValue();
     });
   },


### PR DESCRIPTION
As reported by Alejandra, when using a browser's own autocomplete to fill in a known email address, the `keyup` event doesn't fire if the user uses the mouse. Since there's no harm in the visual update function firing multiple times, I've just added more event type to the listener to fix that.