### PR TITLE
Tailor declaration of truth for close enquiry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,11 +266,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.2)
       actionpack (= 5.0.2)
       activesupport (= 5.0.2)

--- a/app/views/application/_check_answers_footer.html.erb
+++ b/app/views/application/_check_answers_footer.html.erb
@@ -1,7 +1,3 @@
-<h2 class="heading-medium"><%= t 'check_answers.footer..declaration_of_truth' %></h2>
-
-<p><%= translate_with_appeal_or_application 'check_answers.footer..declaration_of_truth_message' %></p>
-
 <h2 class="notice util_mt-large">
   <i class="icon icon-important">
     <span class="visuallyhidden"><%= t 'check_answers.footer..warning' %></span>

--- a/app/views/steps/closure/check_answers/show.html.erb
+++ b/app/views/steps/closure/check_answers/show.html.erb
@@ -6,4 +6,8 @@
 
 <%= render @presenter.sections %>
 
+<h2 class="heading-medium"><%=t 'check_answers.footer.closure.declaration_of_truth' %></h2>
+
+<p><%=t 'check_answers.footer.closure.declaration_of_truth_message' %></p>
+
 <%= render partial: 'check_answers_footer', locals: { submit_link: closure_cases_path }  %>

--- a/app/views/steps/details/check_answers/show.html.erb
+++ b/app/views/steps/details/check_answers/show.html.erb
@@ -6,4 +6,8 @@
 
 <%= render @presenter.sections %>
 
+<h2 class="heading-medium"><%=t 'check_answers.footer.appeal.declaration_of_truth' %></h2>
+
+<p><%= translate_with_appeal_or_application 'check_answers.footer.appeal.declaration_of_truth_message' %></p>
+
 <%= render partial: 'check_answers_footer', locals: { submit_link: appeal_cases_path }  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -868,13 +868,22 @@ en:
     footer:
       warning: Warning
       warning_message: Once you click 'Submit', you cannot change your answers
-      declaration_of_truth: Declaration and statement of truth
-      declaration_of_truth_message: |
-        By completing this Notice of Appeal to the First-tier Tribunal (Tax Chamber) and clicking the ‘Submit’
-        button, I believe the information I have given in this form is true to the best of my knowledge. If I am
-        found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought
-        against me. I understand that if I have given false information or I do not provide further evidence if
-        requested, my %{appeal_or_application} may be rejected.
+      appeal:
+        declaration_of_truth: Declaration and statement of truth
+        declaration_of_truth_message: |
+          By completing this Notice of Appeal to the First-tier Tribunal (Tax Chamber) and clicking the ‘Submit’
+          button, I believe the information I have given in this form is true to the best of my knowledge. If I am
+          found to have been deliberately untruthful or dishonest, criminal proceedings for fraud can be brought
+          against me. I understand that if I have given false information or I do not provide further evidence if
+          requested, my %{appeal_or_application} may be rejected.
+      closure:
+        declaration_of_truth: Declaration and statement of truth
+        declaration_of_truth_message: |
+          By completing this Application to Close an Enquiry and clicking the ‘Submit’ button, I believe the
+          information I have given in this form is true to the best of my knowledge. If I am found to have been
+          deliberately untruthful or dishonest, criminal proceedings for fraud can be brought against me. I
+          understand that if I have given false information or I do not provide further evidence if requested, my
+          application may be rejected.
       submit_and_continue: Submit
       submitting: Submitting...
       resume: Resume %{appeal_or_application}


### PR DESCRIPTION
Appeal and close enquiry had the same declaration of truth copy. This PR tailor it
as closure requires a slighly different copy.

Note: some removals in the Gemfile.lock probably a leftover of a previous PR.

https://www.pivotaltracker.com/story/show/145278077