### PR TITLE
Revert dev and test envs to standard Rails logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'govuk_frontend_toolkit', '< 6.0.0'
 gem 'govuk_notify_rails', '~> 2.0.0'
 gem 'govuk_template'
 gem 'jquery-rails'
-gem 'logstash-logger'
 gem 'mojfile-uploader-api-client', '~> 0.8'
 gem 'pg', '~> 0.18'
 gem 'pry-rails'
@@ -27,6 +26,10 @@ gem 'virtus'
 # PDF generation
 gem 'wicked_pdf', '~> 1.1.0'
 gem 'wkhtmltopdf-binary'
+
+group :production do
+  gem 'logstash-logger'
+end
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     logstash-event (1.2.02)
-    logstash-logger (0.20.0)
+    logstash-logger (0.24.1)
       logstash-event (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,6 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "logstash-logger"
 
 # Ensure that when running the application through Rake the RAILS_ENV doesn't incorrectly
 # get replaced with 'development' when running the specs.
@@ -18,24 +17,6 @@ if defined?(Rake.application) &&
     Rake.application.top_level_tasks.grep(/^(default$|spec(:|$))/).any?
   ENV["RAILS_ENV"] ||= "test"
 end
-
-LogStashLogger.configure do |config|
-  config.customize_event do |event|
-    event['app'] = 'tt-datacapture'
-  end
-end
-
-module LogStashPrettyLogger
-  module Formatter
-    class PrettyJson < LogStashLogger::Formatter::Base
-      def call(severity, time, progname, message)
-        message&.gsub!(/\e\[(\d+)m/, '')&.strip! if message.is_a?(String)
-        super
-        "#{JSON.pretty_generate(@event)}\n"
-      end
-    end
-  end
-end
 # :nocov:
 
 Bundler.require(*Rails.groups)
@@ -43,8 +24,6 @@ Bundler.require(*Rails.groups)
 module TaxTribunalsDatacapture
   class Application < Rails::Application
     ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
-    config.logstash.formatter = LogStashPrettyLogger::Formatter::PrettyJson
-
 
     # This automatically adds id: :uuid to create_table in all future migrations
     config.active_record.primary_key = :uuid

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,4 @@
 Rails.application.configure do
-  config.logstash.type = :file
-
   config.cache_classes = false
 
   config.eager_load = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,25 @@
+require "logstash-logger"
+
+LogStashLogger.configure do |config|
+  config.customize_event do |event|
+    event['app'] = 'tt-datacapture'
+  end
+end
+
+module LogStashPrettyLogger
+  module Formatter
+    class PrettyJson < LogStashLogger::Formatter::Base
+      def call(severity, time, progname, message)
+        message&.gsub!(/\e\[(\d+)m/, '')&.strip! if message.is_a?(String)
+        super
+        "#{JSON.pretty_generate(@event)}\n"
+      end
+    end
+  end
+end
+
 Rails.application.configure do
+  config.logstash.formatter = LogStashPrettyLogger::Formatter::PrettyJson
   config.logstash.type = :stdout
   config.log_level = :info
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -3,8 +3,6 @@ Rails.application.config.before_configuration do
 end
 
 Rails.application.configure do
-  config.logstash.type = :file
-
   config.cache_classes = true
 
   config.eager_load = false


### PR DESCRIPTION
Leave `LogStashLogger` only in production env.