### PR TITLE
Customise password label (and remove hint) from signin form

### DIFF
--- a/app/views/users/logins/new.html.erb
+++ b/app/views/users/logins/new.html.erb
@@ -3,10 +3,14 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <h2 class="heading-large"><%=t '.heading' %></h2>
-
-    <%= form_for(resource, as: resource_name, url: user_session_path) do |f| %>
-      <%= f.email_field :email, autofocus: true %>
-      <%= f.password_field :password, class: 'js-toggleable-password', autocomplete: 'off' %>
+    <%#
+      Using `as: 'user_signin'` so we can customise the i18n labels (and password hint),
+      to be different in this form. Because of this, we also need to specify the `name`,
+      otherwise it would become `user_signin[email] and user_signin[password]`
+    %>
+    <%= form_for(resource, as: 'user_signin', url: user_session_path) do |f| %>
+      <%= f.email_field :email, name: 'user[email]', autofocus: true %>
+      <%= f.password_field :password, name: 'user[password]', class: 'js-toggleable-password', autocomplete: 'off' %>
 
       <p><%= link_to t('.forgot_password'), new_user_password_path %></p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -835,6 +835,9 @@ en:
         password: Choose password
         password_confirmation: Confirm password
         current_password: Old password
+      user_signin:
+        email: Your email address
+        password: Enter password
       tribunal_case:
         user_case_reference: Your reference (optional)
     hint:


### PR DESCRIPTION
Because the way active record attributes are translated, the User model will have
their `email` and `password` fields always show the same labels (and hint) in every
form, regardless if it is the sign-in or the sign-up, and this is confusing.

In order to customise these labels and remove the hint **only** for the sign-in form,
we need to override some default values. I've added a comment as this is not very
intuitive on first sight.

https://www.pivotaltracker.com/story/show/145424145