### PR TITLE
Fix the save & return smoke tests

### DIFF
--- a/smoke_tests/happypath/income_tax.feature
+++ b/smoke_tests/happypath/income_tax.feature
@@ -26,7 +26,7 @@ Feature: Income Tax Happy Paths
     Then I should see "Your case has been saved"
     Given I click the "Sign in" link
     And I fill in my email address
-    And I fill in "Choose password" with "ABCD1234"
+    And I fill in "Enter password" with "ABCD1234"
     When I click the "Sign in" button
     Then I should see "Your saved cases"
     Given I click the "Resume" link


### PR DESCRIPTION
We used to have 'Choose password' as the prompt for both the
sign-up and sign-in pages. This was changed, recently, so this
commit fixes the smoke tests to look for 'Choose password' on
the sign-up page, and 'Enter password' on the sign-in page.