### PR TITLE
Add title and language to the generated case PDF

### DIFF
--- a/app/views/steps/closure/check_answers/show.pdf.erb
+++ b/app/views/steps/closure/check_answers/show.pdf.erb
@@ -1,7 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
+    <title><%=t 'check_answers.pdf.header.closure_heading' %> <%=t 'shared.language' %></title>
     <%= stylesheet_link_tag wicked_pdf_asset_base64('local/case_details_pdf') -%>
   </head>
 

--- a/app/views/steps/details/check_answers/show.pdf.erb
+++ b/app/views/steps/details/check_answers/show.pdf.erb
@@ -1,7 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8"/>
+    <title><%= translate_with_appeal_or_application('check_answers.pdf.header.appeal_heading') %> <%=t 'shared.language' %></title>
     <%= stylesheet_link_tag wicked_pdf_asset_base64('local/case_details_pdf') -%>
   </head>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1085,6 +1085,7 @@ en:
       appeal: appeal
       application: application
   shared:
+    language: (English)
     confirmation_case_reference:
       case_reference: 'Your case reference number is:'
       case_submitted_successfully: Your case was submitted successfully.


### PR DESCRIPTION
This was raised as an issue in the DAC report. As we can't figure out how to
add a 'language' attribute, we've added in the meantime the language in the
title itself, as we have full control of this attribute.

`Title (English)`

If this is not satisfactory we will figure out any other solution.

This work was related to this ticket and needs to be done also in the pro-forma:
https://www.pivotaltracker.com/story/show/145201729