### PR TITLE
DRY survey in kickout pages

### DIFF
--- a/app/views/steps/challenge/must_ask_for_review/show.html.erb
+++ b/app/views/steps/challenge/must_ask_for_review/show.html.erb
@@ -16,9 +16,6 @@
 
     <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
 
-    <p>
-    <a href="https://docs.google.com/a/digital.justice.gov.uk/forms/d/e/1FAIpQLSeO4vNB4prDWw_PtnsNnwAOt_MWkfSHUg28xAokJSYJi7YBCA/viewform"><%=t '.kick_out_must_review' %></a>
-    </p>
-
+    <%= render partial: 'steps/shared/kickout_survey' %>
   </div>
 </div>

--- a/app/views/steps/challenge/must_challenge_hmrc/show.html.erb
+++ b/app/views/steps/challenge/must_challenge_hmrc/show.html.erb
@@ -19,9 +19,6 @@
       <a href="https://www.gov.uk/contact-hmrc" class="button"><%=t '.contact_hmrc_button' %></a>
     </p>
 
-    <p>
-    <a href="https://docs.google.com/a/digital.justice.gov.uk/forms/d/e/1FAIpQLSeO4vNB4prDWw_PtnsNnwAOt_MWkfSHUg28xAokJSYJi7YBCA/viewform"><%=t '.kick_out_survey' %></a>
-    </p>
-
+    <%= render partial: 'steps/shared/kickout_survey' %>
   </div>
 </div>

--- a/app/views/steps/challenge/must_wait_for_challenge_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_challenge_decision/show.html.erb
@@ -11,9 +11,6 @@
 
     <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
 
-	<p>
-    <a href="https://docs.google.com/a/digital.justice.gov.uk/forms/d/e/1FAIpQLSeO4vNB4prDWw_PtnsNnwAOt_MWkfSHUg28xAokJSYJi7YBCA/viewform"><%=t '.kick_out_challenge_wait' %></a>
-    </p>
-
+    <%= render partial: 'steps/shared/kickout_survey' %>
   </div>
 </div>

--- a/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
@@ -12,9 +12,6 @@
 
     <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
 
-    <p>
-    <a href="https://docs.google.com/a/digital.justice.gov.uk/forms/d/e/1FAIpQLSeO4vNB4prDWw_PtnsNnwAOt_MWkfSHUg28xAokJSYJi7YBCA/viewform"><%=t '.kick_out_review' %></a>
-    </p>
-
+    <%= render partial: 'steps/shared/kickout_survey' %>
   </div>
 </div>

--- a/app/views/steps/shared/_kickout_survey.html.erb
+++ b/app/views/steps/shared/_kickout_survey.html.erb
@@ -1,0 +1,3 @@
+<p>
+  <%= link_to t('steps.shared.kickout_feedback'), Rails.configuration.kickout_survey_link %>
+</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module TaxTribunalsDatacapture
     config.active_record.primary_key = :uuid
 
     config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
+    config.kickout_survey_link = 'https://goo.gl/forms/Ccx0sJcOs5cSVYks2'
+
     config.feedback_email = 'taxtribunals_helpdesk@digital.justice.gov.uk'
     config.tax_tribunal_email = 'taxappeals@hmcts.gsi.gov.uk'
     config.tax_tribunal_phone = '0300 123 1024'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,6 @@ en:
               <li><a href="https://www.gov.uk/tax-appeals" target="_blank" rel="noopener">challenging a tax decision with HM Revenue &amp; Customs (HMRC)<span class="visuallyhidden"> (opens in new window)</span></a></li>
               <li><a href="https://www.gov.uk/customs-seizures/overview" target="_blank" rel="noopener">options when UK Border Force (UKBF) seizes your things<span class="visuallyhidden"> (opens in new window)</span></a></li>
             </ul>
-          kick_out_must_review: Give your feedback. Help improve this service
           page_title: Must ask for review
       must_wait_for_review_decision:
         show:
@@ -159,7 +158,6 @@ en:
               <li>received a review conclusion letter</li>
               <li>waited 45 days and not received a letter</li>
             </ul>
-          kick_out_review: Give your feedback. Help improve this service
           page_title: Must wait for review
       must_challenge_hmrc:
         show:
@@ -171,7 +169,6 @@ en:
           free_to_challenge_hmrc_guidance_html: <p>You should appeal even if you think
             you are late. HMRC will decide whether to accept your appeal or explain
             what you can do next. </p> 
-          kick_out_survey: Give your feedback. Help improve this service
           contact_hmrc_button: Contact HMRC
           <<: *START_FINISH
           page_title: Must challenge HMRC
@@ -183,7 +180,6 @@ en:
               <li>received a review conclusion letter</li>
               <li>waited 45 days and not received a letter</li>
             </ul>
-          kick_out_challenge_wait: Give your feedback. Help improve this service
           page_title: Must wait for decision
     closure:
       case_type:
@@ -227,6 +223,7 @@ en:
             </ul>
           <p>You can use a representative if you feel you need help or advice. A representative is able to receive correspondence from the tax tribunal and go to any hearings for you.</p>
           <p>If your representative is not a legal professional, you’ll need to authorise them to act for you by completing an <a href="%{approval_form_href}" target="_blank" rel="noopener">authorisation form (%{approval_form_format_and_size})<span class="visuallyhidden"> (opens in new window)</span></a>.</p>
+      kickout_feedback: Give your feedback. Help improve this service
     details:
       user_type:
         edit:


### PR DESCRIPTION
A bit of DRY and using the shortened google forms link to be consistent with
the other survey link.