### PR TITLE
Fix broken log parsing between container/kibana

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,24 +2,11 @@ require "logstash-logger"
 
 LogStashLogger.configure do |config|
   config.customize_event do |event|
-    event['app'] = 'tt-datacapture'
-  end
-end
-
-module LogStashPrettyLogger
-  module Formatter
-    class PrettyJson < LogStashLogger::Formatter::Base
-      def call(severity, time, progname, message)
-        message&.gsub!(/\e\[(\d+)m/, '')&.strip! if message.is_a?(String)
-        super
-        "#{JSON.pretty_generate(@event)}\n"
-      end
-    end
+    event['tags'] << 'taxtribs-datacapture'
   end
 end
 
 Rails.application.configure do
-  config.logstash.formatter = LogStashPrettyLogger::Formatter::PrettyJson
   config.logstash.type = :stdout
   config.log_level = :info
 


### PR DESCRIPTION
TL;DR - Newlines are causing the prettified JSON to span multiple
entries in the files to be ingested. This breaks the process.

The pretty json formatter was causing ingestion problems in production
environments.  To wit:

**From Kibana:**

```
{"log":"
\"e1b619be-7913-4694-8ea9-2acc49eb1c03\"\n","stream":"stdout","tags":["docker","_jsonparsefailure"],"@version":1,"@timestamp":"2017-05-16T09:31:44.590Z","host":"i-037e2da86b35167e7","file":"/var/lib/docker/containers/3438537b7326d17d001ce20bf4d23c06af67bca710dd077906b30858b96c7321/3438537b7326d17d001ce20bf4d23c06af67bca710dd077906b30858b96c7321-json.log","time":"2017-05-16T09:31:44.500285265Z","message":"","type":"docker_json","project":"tax-tribunals-feespayment","enviroment":"prod","@logstash_uuid":"f5ac046c-b1dd-63d0-5552-8bf9dcb27a05"}
```

**Acutal Log file for ingestion:**
```
...
{"log":"{\n","stream":"stdout","time":"2017-05-16T09:09:38.295317972Z"}
{"log":"  \"message\": \"Processing by TaxTribs::StatusController#index
as JSON\",\n","stream":"stdout","time":"2017-05-16T09:09:38.295337277Z"}
{"log":"  \"@timestamp\":
\"2017-05-16T09:09:38.295+00:00\",\n","stream":"stdout","time":"2017-05-16T09:09:38.295347229Z"}
{"log":"  \"@version\":
\"1\",\n","stream":"stdout","time":"2017-05-16T09:09:38.295355659Z"}
{"log":"  \"severity\":
\"INFO\",\n","stream":"stdout","time":"2017-05-16T09:09:38.295363737Z"}
{"log":"  \"host\":
\"3438537b7326\",\n","stream":"stdout","time":"2017-05-16T09:09:38.295371593Z"}
{"log":"  \"tags\":
[\n","stream":"stdout","time":"2017-05-16T09:09:38.295379317Z"}
{"log":"
\"f97233d6-8a52-40bc-9c6b-f0f97be65d9e\"\n","stream":"stdout","time":"2017-05-16T09:09:38.295386866Z"}
{"log":"
],\n","stream":"stdout","time":"2017-05-16T09:09:38.295394351Z"}
...
```