### PR TITLE
Try for specific error, fallback to general error

### DIFF
--- a/smoke_tests/happypath/income_tax.feature
+++ b/smoke_tests/happypath/income_tax.feature
@@ -84,16 +84,25 @@ Feature: Income Tax Happy Paths
     Then I should see "Upload your letter(s)"
 
 		Given I drop "original_notice.docx"
-		Then I should see "original_notice.docx"
+    Then I should see "original_notice.docx"
+    And I should not see "format we don't accept"
+    And I should not see "Server responded with 0 code"
+    And I should not see "No files uploaded"
 
 		Given I click the "Remove" link
 		Then I should not see "original_notice.docx"
 
 		Given I drop "original_notice.docx"
 		Then I should see "original_notice.docx"
+    And I should not see "format we don't accept"
+    And I should not see "Server responded with 0 code"
+    And I should not see "No files uploaded"
 
 		Given I drop "review_conclusion.docx"
 		Then I should see "review_conclusion.docx"
+    And I should not see "format we don't accept"
+    And I should not see "Server responded with 0 code"
+    And I should not see "No files uploaded"
 
 		Given I check "Original notice letter"
     And I check "Review conclusion letter"


### PR DESCRIPTION
Locally, I've seen both the format error and the server code error.  I
am uncertain *which* server and whether there might be a range of
possible errors.  To address this, I am taking the double-chekcing
approach on dropping files-look for an error on the drop, and check for
the No files error.

DS and I discussed the possiblity of uploading in another part of the
app.  However, I must point out that it already does this with the
ground for appeal document.  It also checks to ensure the virus scanning
is working.