### PR TITLE
Isolate cause of intermittent check answers errors

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,7 +10,9 @@ class Document
   end
 
   def self.all_for_collection(collection_ref)
-    for_collection(collection_ref, document_key: nil).group_by { |f| f.full_name.split('/').first.to_sym }
+    for_collection(collection_ref, document_key: nil).group_by { |f| f.full_name.split('/').first.to_sym }.tap { |docs|
+      Rails.logger.info(docs)
+    }
   end
 
   def self.for_collection(collection_ref, document_key:)


### PR DESCRIPTION
Currently, Check your answers is failing the smoketest intermittently
owing to the fact that `review_conclusion.docx` is not getting shown  in
the listing page.  I am putting this in place to ensure that the file
listing call is returning the correct information.