### PR TITLE
Correct 'cases by date' report wrt. save & return

### DIFF
--- a/app/services/tax_tribs/statistics_report.rb
+++ b/app/services/tax_tribs/statistics_report.rb
@@ -1,32 +1,28 @@
 class TaxTribs::StatisticsReport
   def self.cases_by_date_csv
-    results = TribunalCase.connection.execute <<~SQL
-      SELECT
-        date(created_at) AS created_on,
-        case_status,
-        count(*) AS number
-      FROM #{TribunalCase.table_name}
-      GROUP BY date(created_at), case_status
-      ORDER BY date(created_at)
-    SQL
+    started_cases = TribunalCase.select("date(created_at) as date, count(*) as number")
+                      .group("date(created_at)")
+                      .map {|c| [c.date.strftime, c.number]}
 
-    dates = results.inject({}) do |hash, row|
-      d = row.fetch('created_on')
-
-      data = hash.fetch(d, { 'started' => 0, 'submitted' => 0 })
-
-      started = data.fetch('started')
-      started += row.fetch('number')
-
-      submitted = data.fetch('submitted')
-      submitted += row.fetch('number') if row.fetch('case_status').eql?(CaseStatus::SUBMITTED.to_s)
-
-      hash[d] = { 'started' => started, 'submitted' => submitted }
-
+    started_dates = started_cases.inject({})  do |hash, row|
+      date, number = row
+      hash[date] = { 'started' => number, 'submitted' => 0 }
       hash
     end
 
-    dates.inject(["Date, Started, Submitted"]) do |arr, (date, data)|
+    submitted_cases = TribunalCase.select("date(updated_at) as date, count(*) as number")
+                        .where(case_status: 'submitted')
+                        .group("date(updated_at)")
+                        .map {|c| [c.date.strftime, c.number]}
+
+    combined_dates = submitted_cases.each_with_object(started_dates) do |row, hash|
+      date, number = row
+      hash[date] ||= { 'started' => 0 }
+      hash[date]['submitted'] = number
+    end
+
+    combined_dates.keys.sort.each_with_object(['Date, Started, Submitted']) do |date, arr|
+      data = combined_dates.fetch(date)
       arr.push [date, data.fetch('started'), data.fetch('submitted')].join(', ')
     end.join("\n")
   end

--- a/spec/services/tax_tribs/statistics_report_spec.rb
+++ b/spec/services/tax_tribs/statistics_report_spec.rb
@@ -4,6 +4,29 @@ RSpec.describe TaxTribs::StatisticsReport do
   describe '#cases_by_date_csv' do
     let(:header) { "Date, Started, Submitted" }
 
+    context 'when case is submitted days after creation' do
+      before do
+        tribunal_case = nil
+
+        travel_to(Time.parse('2017-05-08 06:30:00')) do
+          tribunal_case = TribunalCase.create({ case_status: CaseStatus.new(:first_reminder_sent) })
+        end
+
+        travel_to(Time.parse('2017-05-10 06:30:00')) do
+          tribunal_case.update(case_status: CaseStatus.new(:submitted))
+        end
+      end
+
+      it 'reports started and submitted on separate dates' do
+        report = [
+          header,
+          '2017-05-08, 1, 0',
+          '2017-05-10, 0, 1'
+        ].join("\n")
+        expect(described_class.cases_by_date_csv).to eq(report)
+      end
+    end
+
     context 'when there are no TribunalCase records' do
       specify { expect(described_class.cases_by_date_csv).to eq(header) }
     end
@@ -25,16 +48,15 @@ RSpec.describe TaxTribs::StatisticsReport do
         end
       end
 
-      it "generates a csv report" do
+      it 'generates a csv report' do
         report = [
           header,
-          "1970-01-01, 3, 1",
-          "2017-04-08, 1, 0",
-          "2017-05-08, 1, 0"
+          '1970-01-01, 3, 1',
+          '2017-04-08, 1, 0',
+          '2017-05-08, 1, 0'
         ].join("\n")
         expect(described_class.cases_by_date_csv).to eq(report)
       end
-
     end
   end
 end


### PR DESCRIPTION
The report was counting cases as submitted on the date they
were created, but with save and return, that's not always
the case. This commit fixes that, counting start and
submission dates separately.