### PR TITLE
Changes to feedback form and header link

### DIFF
--- a/app/controllers/surveys/survey_base_controller.rb
+++ b/app/controllers/surveys/survey_base_controller.rb
@@ -41,7 +41,7 @@ module Surveys
       params_key = form_object_class.name.underscore.tr('/'.freeze, '_'.freeze)
 
       params.require(params_key).permit(
-        :rating, :comment, :referrer
+        :rating, :comment, :email, :referrer
       ).to_h
     end
   end

--- a/app/forms/surveys/feedback_form.rb
+++ b/app/forms/surveys/feedback_form.rb
@@ -2,15 +2,12 @@ module Surveys
   class FeedbackForm < BaseForm
     attribute :rating, Integer
     attribute :comment, String
+    attribute :email, NormalisedEmail
     attribute :referrer, String
     attribute :user_agent, String
 
-    def self.rating_choices
-      (1..5)
-    end
-
-    validates_inclusion_of :rating, in: rating_choices
-    validates_presence_of  :comment
+    validates :email, email: true, allow_blank: true
+    validates_presence_of :comment
 
     # TODO: once we have at least 2 of these feedback forms, we can extract
     # the duplicated code to a superclass as all of them will have at least

--- a/app/services/zendesk_sender.rb
+++ b/app/services/zendesk_sender.rb
@@ -2,16 +2,14 @@ class ZendeskSender
   attr_accessor :form_object
 
   # This needs to match the value in the `Service` ticket field.
-  SERVICE_NAME = 'tax_tribunal'.freeze
+  SERVICE_NAME = 'datacapture_app'.freeze
 
   # The following `custom_fields` are created in the Zendesk admin panel,
-  # `Manage` section, `Ticket Fields` sub-section. Please note all created
-  # fields will show in other service tickets too, so use wisely.
-  #
-  SERVICE_TICKET_FIELD_ID  = '23757677'.freeze
-  BROWSER_TICKET_FIELD_ID  = '23791776'.freeze
-  REFERRER_TICKET_FIELD_ID = '26047167'.freeze
-  RATING_TICKET_FIELD_ID   = '114094159771'.freeze
+  # `Manage` section, `Ticket Fields` sub-section.
+  SERVICE_FIELD_ID    = '79094767'.freeze
+  USER_AGENT_FIELD_ID = '79531628'.freeze
+  REFERRER_FIELD_ID   = '79094927'.freeze
+  RATING_FIELD_ID     = '79096207'.freeze
 
 
   def initialize(form_object)
@@ -21,14 +19,26 @@ class ZendeskSender
   def send!
     ZendeskAPI::Ticket.create!(
       ZENDESK_CLIENT,
+      requester: requester_details,
       subject: form_object.subject,
       comment: { body: form_object.comment },
       custom_fields: [
-        { id: SERVICE_TICKET_FIELD_ID,  value: SERVICE_NAME },
-        { id: BROWSER_TICKET_FIELD_ID,  value: form_object.user_agent },
-        { id: REFERRER_TICKET_FIELD_ID, value: form_object.referrer },
-        { id: RATING_TICKET_FIELD_ID,   value: form_object.rating }
+        { id: SERVICE_FIELD_ID,    value: SERVICE_NAME },
+        { id: USER_AGENT_FIELD_ID, value: form_object.user_agent },
+        { id: REFERRER_FIELD_ID,   value: form_object.referrer },
+        { id: RATING_FIELD_ID,     value: form_object.rating }
       ]
     )
+  end
+
+  private
+
+  def requester_details
+    {name: requester_name, email: form_object.email} if requester_name
+  end
+
+  # We are not asking for a name, so we default to the first part of the user email
+  def requester_name
+    form_object.email.to_s.split('@').first
   end
 end

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -12,7 +12,7 @@
 <div class="phase-banner-beta">
   <p>
     <strong class="phase-tag">beta</strong>
-    <span><%= t('.phase_info_html', feedback_email: Rails.configuration.feedback_email) %></span>
+    <span><%= t('.phase_info_html', feedback_url: new_surveys_feedback_path) %></span>
   </p>
 </div>
 <% end %>

--- a/app/views/surveys/feedback/new.html.erb
+++ b/app/views/surveys/feedback/new.html.erb
@@ -10,8 +10,8 @@
 
     <%= form_for(@form_object, url: surveys_feedback_path) do |f| %>
       <%= f.hidden_field :referrer %>
-      <%= f.radio_button_fieldset :rating, inline: true, choices: Surveys::FeedbackForm.rating_choices %>
       <%= f.text_area :comment, size: '40x6', class: 'form-control form-control-3-4' %>
+      <%= f.text_field :email %>
 
       <%= f.submit t('.submit'), class: 'button' %>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,6 @@ module TaxTribunalsDatacapture
     config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
     config.kickout_survey_link = 'https://goo.gl/forms/Ccx0sJcOs5cSVYks2'
 
-    config.feedback_email = 'taxtribunals_helpdesk@digital.justice.gov.uk'
     config.tax_tribunal_email = 'taxappeals@hmcts.gsi.gov.uk'
     config.tax_tribunal_phone = '0300 123 1024'
 

--- a/config/initializers/zendesk.rb
+++ b/config/initializers/zendesk.rb
@@ -1,7 +1,7 @@
 require 'zendesk_api'
 
 ZENDESK_CLIENT = ZendeskAPI::Client.new do |config|
-  config.url = 'https://ministryofjustice.zendesk.com/api/v2'
+  config.url = 'https://tax-tribunals.zendesk.com/api/v2'
   config.username = ENV['ZENDESK_USERNAME']
   config.token = ENV['ZENDESK_TOKEN']
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,10 +579,10 @@ en:
               blank: *attach_reasons_blank_error
         surveys/feedback_form:
           attributes:
-            rating:
-              inclusion: Choose a rating
             comment:
               blank: Please enter some text
+            email:
+              invalid: *invalid_email
   activerecord:
     errors:
       models:
@@ -638,8 +638,6 @@ en:
         hardship_review_status_html: Did HMRC allow you to defer paying because of financial hardship?
       steps_lateness_in_time_form:
         in_time_html: Are you in time to appeal to the tax tribunal?
-      surveys_feedback_form:
-        rating_html: How helpful was this service?
     label:
       steps_appeal_case_type_form:
         case_type:
@@ -847,14 +845,15 @@ en:
       tribunal_case:
         user_case_reference: Your reference (optional)
       surveys_feedback_form:
-        comment: Do you have any ideas for how this service could be improved?
+        comment: Describe any service improvement or problems you are having
+        email: Email (optional)
     hint:
       user:
         password: Must be at least 8 characters
         current_password: We need your current password to confirm your changes
       surveys_feedback_form:
-        rating_html: 1 being not helpful and 5 being very helpful
         comment_html: Don't include any personal or sensitive information
+        email_html: Provide an email if you wish to receive an update on your comment
     submit:
       create: Continue
       update: Continue
@@ -1197,7 +1196,7 @@ en:
     phase_banner:
       phase_info_html: |
         This is a trial service &ndash; your
-        <a href="mailto:%{feedback_email}?subject=Feedback">feedback</a>
+        <a href="%{feedback_url}" target="_blank" rel="noopener">comments</a>
         will help us to improve it.
     current_user_menu:
       logout: Sign out
@@ -1434,7 +1433,7 @@ en:
         page_title: Feedback
         heading: Help us improve this service
         submit: Submit
-        lead_text: Please take this quick survey and help us keep improving (your answers will be anonymous).
+        lead_text: Please tell us how to improve the service or report a problem below (your feedback will be anonymous).
       thanks:
         page_title: Feedback submitted
         heading: Thank you for your feedback

--- a/spec/forms/surveys/feedback_form_spec.rb
+++ b/spec/forms/surveys/feedback_form_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 RSpec.describe Surveys::FeedbackForm do
   let(:arguments) { {
-    rating: rating,
     comment: comment,
+    email: email,
     referrer: referrer,
     user_agent: user_agent
   } }
 
   subject { described_class.new(arguments) }
 
-  let(:rating) { 5 }
   let(:comment) { 'my feedback here' }
+  let(:email) { 'email@example.com' }
   let(:referrer) { '/path' }
   let(:user_agent) { 'Safari' }
 
@@ -20,32 +20,6 @@ RSpec.describe Surveys::FeedbackForm do
   end
 
   describe '#save' do
-    context 'when rating is not given' do
-      let(:rating) { nil }
-
-      it 'returns false' do
-        expect(subject.save).to be(false)
-      end
-
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors[:rating]).to_not be_empty
-      end
-    end
-
-    context 'when rating is not valid' do
-      let(:rating) { 10 }
-
-      it 'returns false' do
-        expect(subject.save).to be(false)
-      end
-
-      it 'has a validation error on the field' do
-        expect(subject).to_not be_valid
-        expect(subject.errors[:rating]).to_not be_empty
-      end
-    end
-
     context 'when comment is not given' do
       let(:comment) { nil }
 
@@ -56,6 +30,27 @@ RSpec.describe Surveys::FeedbackForm do
       it 'has a validation error on the field' do
         expect(subject).to_not be_valid
         expect(subject.errors[:comment]).to_not be_empty
+      end
+    end
+
+    context 'when email is not valid' do
+      let(:email) { 'blah' }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:email]).to_not be_empty
+      end
+    end
+
+    context 'allows blank email' do
+      let(:email) { '' }
+
+      it 'has no validation errors' do
+        expect(subject).to be_valid
       end
     end
 

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -3,32 +3,48 @@ require 'rails_helper'
 RSpec.describe ZendeskSender do
   let(:form_object) {
     Surveys::FeedbackForm.new(
-      rating: 5, comment: 'very nice service', referrer: '/whatever', user_agent: 'Safari'
+      rating: 5, comment: 'very nice service', email: email, referrer: '/whatever', user_agent: 'Safari'
     )
   }
 
   subject { described_class.new(form_object) }
 
   before(:each) do
-    stub_request(:post, %r{\Ahttps://ministryofjustice.zendesk.com/api/v2/tickets\z}).with(
+    stub_request(:post, %r{\Ahttps://tax-tribunals.zendesk.com/api/v2/tickets\z}).with(
       body: {
         ticket: {
+          requester: requester_details,
           subject: 'Feedback',
           comment: { body: 'very nice service' },
           custom_fields: [
-            {id: '23757677', value: 'tax_tribunal'},
-            {id: '23791776', value: 'Safari'},
-            {id: '26047167', value: '/whatever'},
-            {id: '114094159771', value: 5}
+            {id: '79094767', value: 'datacapture_app'},
+            {id: '79531628', value: 'Safari'},
+            {id: '79094927', value: '/whatever'},
+            {id: '79096207', value: 5}
           ]
         }}.to_json
     ).to_return(status: 201, body: '', headers: {})
   end
 
   describe '#send!' do
-    it 'creates a ticket with the details from the form_object' do
-      expect(ZendeskAPI::Ticket).to receive(:create!).and_call_original
-      subject.send!
+    context 'when email is provided' do
+      let(:requester_details) { {name: 'user.name', email: 'user.name@example.com'} }
+      let(:email) { 'user.name@example.com' }
+
+      it 'creates a ticket with the details from the form_object' do
+        expect(ZendeskAPI::Ticket).to receive(:create!).and_call_original
+        subject.send!
+      end
+    end
+
+    context 'when email is not provided' do
+      let(:requester_details) { nil }
+      let(:email) { '' }
+
+      it 'creates a ticket with the details from the form_object' do
+        expect(ZendeskAPI::Ticket).to receive(:create!).and_call_original
+        subject.send!
+      end
     end
   end
 end


### PR DESCRIPTION
Some copy changes to the feedback form, adding an optional email field, and
removing the rating radios, as per Alejandra instructions.

The rating radios will be only in the end of journey surveys.

The form is now accessible through the link in the header but will not work
unless the ENV variables exists.