### PR TITLE
Tidy production logging

### DIFF
--- a/app/services/uploader.rb
+++ b/app/services/uploader.rb
@@ -14,6 +14,10 @@ class Uploader
   class InfectedFileError < RuntimeError; end
 
   def self.add_file(collection_ref: nil, document_key:, filename:, data:, retry_counter: 0)
+    Rails.logger.tagged('add_file') {
+      Rails.logger.info({filename: filename, collection_ref: collection_ref, folder: document_key.to_s})
+    }
+
     MojFileUploaderApiClient.add_file(
       collection_ref: collection_ref,
       folder: document_key.to_s,
@@ -43,6 +47,10 @@ class Uploader
   end
 
   def self.delete_file(collection_ref:, document_key:, filename:)
+    Rails.logger.tagged('delete_file') {
+      Rails.logger.info({filename: filename, collection_ref: collection_ref, folder: document_key.to_s})
+    }
+
     MojFileUploaderApiClient.delete_file(
       collection_ref: collection_ref,
       folder: document_key.to_s,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,17 @@
 require "logstash-logger"
 
+module LogStashLogger
+  module Formatter
+    class RemoveEscapeSequences < LogStashLogger::Formatter::Base
+      def call(severity, time, progname, message)
+        message&.gsub!(/\e\[(\d+)m/, '')&.strip! if message.is_a?(String)
+        super
+        "#{@event.to_json}\n"
+      end
+    end
+  end
+end
+
 LogStashLogger.configure do |config|
   config.customize_event do |event|
     event['tags'] << 'taxtribs-datacapture'
@@ -8,7 +20,9 @@ end
 
 Rails.application.configure do
   config.logstash.type = :stdout
+  config.logstash.formatter = LogStashLogger::Formatter::RemoveEscapeSequences
   config.log_level = :info
+  config.action_view.logger = nil
 
   config.cache_classes = true
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,2 +1,19 @@
-
-Rails.application.config.filter_parameters += [:password, :confirmation_code]
+Rails.application.config.filter_parameters += [
+  :closure_additional_information,
+  :comment,
+  :confirmation_code,
+  :grounds_for_appeal,
+  :hardship_reason,
+  :having_problems_uploading_explanation,
+  :lateness_reason,
+  :outcome,
+  :password,
+  :representative_contact_address,
+  :representative_contact_email,
+  :representative_contact_phone,
+  :representative_contact_postcode,
+  :taxpayer_contact_address,
+  :taxpayer_contact_email,
+  :taxpayer_contact_phone,
+  :taxpayer_contact_postcode
+]

--- a/spec/services/tax_tribs/statistics_report_spec.rb
+++ b/spec/services/tax_tribs/statistics_report_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe TaxTribs::StatisticsReport do
+
+  before do
+    # On my system, a record from 2017-05-17 gets hung.  I'm uncertain where it
+    # is being created, but it reappears consistently on my system-even after a
+    # test db drop.
+    TribunalCase.destroy_all
+  end
+
   describe '#cases_by_date_csv' do
     let(:header) { "Date, Started, Submitted" }
 


### PR DESCRIPTION
+ Remove active_view timings from production logs
+ Remove bash escape/colorizing sequences from production logs
+ Filter all sensitive parameters