### PR TITLE
Increase mutation coverage

### DIFF
--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -1,4 +1,4 @@
-class AppealDecisionTree < DecisionTree
+class AppealDecisionTree < TaxTribs::DecisionTree
   def destination
     return next_step if next_step
 

--- a/app/services/challenge_decision_tree.rb
+++ b/app/services/challenge_decision_tree.rb
@@ -1,4 +1,4 @@
-class ChallengeDecisionTree < DecisionTree
+class ChallengeDecisionTree < TaxTribs::DecisionTree
   def destination
     return next_step if next_step
 

--- a/app/services/closure_decision_tree.rb
+++ b/app/services/closure_decision_tree.rb
@@ -1,4 +1,4 @@
-class ClosureDecisionTree < DecisionTree
+class ClosureDecisionTree < TaxTribs::DecisionTree
   def destination
     return next_step if next_step
 

--- a/app/services/details_decision_tree.rb
+++ b/app/services/details_decision_tree.rb
@@ -1,4 +1,4 @@
-class DetailsDecisionTree < DecisionTree
+class DetailsDecisionTree < TaxTribs::DecisionTree
   def destination
     return next_step if next_step
 

--- a/app/services/hardship_decision_tree.rb
+++ b/app/services/hardship_decision_tree.rb
@@ -1,4 +1,4 @@
-class HardshipDecisionTree < DecisionTree
+class HardshipDecisionTree < TaxTribs::DecisionTree
   def destination
     return next_step if next_step
 

--- a/app/services/lateness_decision_tree.rb
+++ b/app/services/lateness_decision_tree.rb
@@ -1,4 +1,4 @@
-class LatenessDecisionTree < DecisionTree
+class LatenessDecisionTree < TaxTribs::DecisionTree
   def destination
     return next_step if next_step
 

--- a/app/services/tax_tribs/decision_tree.rb
+++ b/app/services/tax_tribs/decision_tree.rb
@@ -1,4 +1,4 @@
-class DecisionTree
+class TaxTribs::DecisionTree
   include ApplicationHelper
 
   attr_reader :tribunal_case, :step_params, :as, :next_step

--- a/lib/generators/step/templates/controller_spec.rb
+++ b/lib/generators/step/templates/controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Controller, type: :controller do
-  it_behaves_like 'an intermediate step controller', Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form, <%= task_name.camelize %>DecisionTree
+  it_behaves_like 'an intermediate step controller', Steps::<%= task_name.camelize %>::<%= step_name.camelize %>Form, <%= task_name.camelize %>TaxTribs::DecisionTree
 end

--- a/spec/services/tax_tribs/decision_tree_spec.rb
+++ b/spec/services/tax_tribs/decision_tree_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+
+RSpec.describe TaxTribs::DecisionTree do
+  let(:tribunal_case) { instance_double(TribunalCase) }
+  let(:step_params) { { one: 'first', two: 'second' } }
+
+  subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params) }
+
+  describe '#new' do
+    subject {
+      described_class.new(
+        tribunal_case: tribunal_case,
+        as: 'lateness',
+        next_step: 'checking'
+      )
+    }
+
+    it 'accepts an "as" attribute' do
+      expect(subject.as).to eq('lateness')
+    end
+
+    it 'accepts a "next_step" attribute' do
+      expect(subject.next_step).to eq('checking')
+    end
+
+    it 'defaults to an empty hash for the "step_params" attribute' do
+      expect(subject.step_params).to eq({})
+    end
+  end
+
+  # I don't like these, but they are the simplest way to achieve mutant kills.
+  describe '.step_name' do
+    context '.as is set' do
+      subject { described_class.new(tribunal_case: tribunal_case, as: 'another_step') }
+
+      it 'takes that value' do
+        expect(subject.send(:step_name)).to eq('another_step')
+      end
+    end
+
+    it 'takes the first key from `.step_params`' do
+      expect(subject.send(:step_name)).to eq(:one)
+    end
+  end
+
+  describe '.answer' do
+    it 'takes the first value from #step_params' do
+      expect(subject.send(:answer)).to eq(:first)
+    end
+  end
+
+  describe '.edit' do
+    specify do
+      expect(subject.send(:edit, 'a_step_controller')).to eq({ controller: 'a_step_controller', action: :edit })
+    end
+  end
+
+  describe '.show' do
+    specify do
+      expect(subject.send(:show, 'a_step_controller')).to eq({ controller: 'a_step_controller', action: :show })
+    end
+  end
+
+  describe '.start_path' do
+    specify do
+      expect(subject.send(:start_path)).to eq({ controller: '/home', action: :start })
+    end
+  end
+
+  describe '.dispute_or_penalties_decision' do
+    let(:case_type) { instance_double(CaseType, ask_dispute_type?: false, ask_penalty?: false) }
+
+    before do
+      allow(tribunal_case).to receive(:case_type).and_return(case_type)
+    end
+
+    context 'ask_dispute_type? == true' do
+      before do
+        allow(case_type).to receive(:ask_dispute_type?).and_return(true)
+      end
+
+      it 'calls /steps/appeal/dispute_type' do
+        expect(subject).to receive(:edit).with('/steps/appeal/dispute_type')
+        subject.send(:dispute_or_penalties_decision)
+      end
+    end
+
+    context 'ask_penalty? == true' do
+      before do
+        allow(case_type).to receive(:ask_penalty?).and_return(true)
+      end
+
+      it 'calls /steps/appeal/penalty_amount' do
+        expect(subject).to receive(:edit).with('/steps/appeal/penalty_amount')
+        subject.send(:dispute_or_penalties_decision)
+      end
+    end
+
+    context 'ask_dispute_type? == false and ask_penalty? == false' do
+      it 'calls /steps/lateness/in_time' do
+        expect(subject).to receive(:edit).with('/steps/lateness/in_time')
+        subject.send(:dispute_or_penalties_decision)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I didn't like having to use `:send` here to get at the private methods.
Ultimately, though, that seemed cleaner than concocting a test class
that then exposed all the methods. This probably would have been
unnecessary if we had started with mutation tests that covered all the
child classes.