### PR TITLE
Remove late review case type

### DIFF
--- a/app/services/mapping_code_determiner.rb
+++ b/app/services/mapping_code_determiner.rb
@@ -50,8 +50,6 @@ module MappingCodeDeterminer
   def case_type_mapping_code
     # TODO: Add further when-branches once we have additional case types
     case case_type
-    when CaseType::REQUEST_LATE_REVIEW
-      MappingCode::APPN_LATE
     when CaseType::OTHER
       MappingCode::APPEAL_OTHER
     else

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -58,7 +58,6 @@ class CaseType < ValueObject
     PETROLEUM_REVENUE_TAX        = new(:petroleum_revenue_tax,        direct_tax_properties),
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),
     REMOTE_GAMING_DUTY           = new(:remote_gaming_duty,           indirect_tax_properties),
-    REQUEST_LATE_REVIEW          = new(:request_late_review,          direct_tax: true, appeal_or_application: :application),
     RESTORATION_CASE             = new(:restoration_case,             direct_tax: false, ask_challenged: true, appeal_or_application: :application),
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -679,9 +679,6 @@ en:
           petroleum_revenue_tax_html: "<strong>Petroleum Revenue Tax</strong>"
           pool_betting_duty_html: "<strong>Pool Betting Duty</strong>"
           remote_gaming_duty_html: "<strong>Remote Gaming Duty</strong>"
-          request_late_review_html: "<strong>Request permission for a late review</strong><br>apply
-            to get a late review accepted by HMRC, UK Border Force (UKBF) or National
-            Crime Authority (NCA)"
           restoration_case_html: "<strong>Restoration case</strong><br>apply for the
             return of seized goods"
           stamp_duties_html: "<strong>Stamp duties</strong><br>includes Stamp Duty
@@ -938,7 +935,6 @@ en:
         petroleum_revenue_tax: Petroleum Revenue Tax
         pool_betting_duty: Pool Betting Duty
         remote_gaming_duty: Remote Gaming Duty
-        request_late_review: Request permission for a late review
         restoration_case: Restoration case
         stamp_duties: Stamp duties
         statutory_payments: Statutory payments

--- a/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
         petroleum_revenue_tax
         pool_betting_duty
         remote_gaming_duty
-        request_late_review
         restoration_case
         stamp_duties
         statutory_payments

--- a/spec/services/mapping_code_determiner_spec.rb
+++ b/spec/services/mapping_code_determiner_spec.rb
@@ -111,12 +111,6 @@ RSpec.describe MappingCodeDeterminer do
     it { is_expected.to have_mapping_code(:appeal_other) }
   end
 
-  context 'when the case type is to request permission for a late review' do
-    let(:case_type) { CaseType::REQUEST_LATE_REVIEW }
-
-    it { is_expected.to have_mapping_code(:appn_late) }
-  end
-
   context 'when there is a case type but it is an unhandled value' do
     let(:case_type) { CaseType.new(:anything_else) }
 


### PR DESCRIPTION
This was clarified with the judges, and we don't need this option anymore.

https://www.pivotaltracker.com/story/show/145936639