### PR TITLE
Change DOTAs dispute type options

### DIFF
--- a/app/forms/steps/appeal/dispute_type_form.rb
+++ b/app/forms/steps/appeal/dispute_type_form.rb
@@ -8,6 +8,8 @@ module Steps::Appeal
 
     def choices
       case tribunal_case&.case_type
+      when CaseType::DOTAS_PENALTY
+        dotas_penalty_choices
       when CaseType::INFORMATION_NOTICE
         information_notice_choices
       when CaseType::INCOME_TAX
@@ -20,6 +22,13 @@ module Steps::Appeal
     end
 
     private
+
+    def dotas_penalty_choices
+      [
+        DisputeType::PENALTY,
+        DisputeType::OTHER
+      ]
+    end
 
     def information_notice_choices
       [

--- a/spec/forms/steps/appeal/dispute_type_form_spec.rb
+++ b/spec/forms/steps/appeal/dispute_type_form_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe Steps::Appeal::DisputeTypeForm do
         ))
       end
     end
+
+    context 'when the appeal is `Disclosure Of Tax Avoidance Schemes (DOTAS)`' do
+      let(:case_type) { CaseType::DOTAS_PENALTY }
+
+      it 'shows only the relevant choices' do
+        expect(subject.choices).to eq(%w(
+          penalty
+          other
+        ))
+      end
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
When case type is `Disclosure Of Tax Avoidance Schemes (DOTAS)` we don't need
some of the dispute types, so we are removing them from the list.

https://www.pivotaltracker.com/story/show/145863301