### PR TITLE
Amendments to closure enquiry types

### DIFF
--- a/app/value_objects/closure_case_type.rb
+++ b/app/value_objects/closure_case_type.rb
@@ -4,12 +4,11 @@ class ClosureCaseType < ValueObject
     COMPANY_RETURN                 = new(:company_return),
     PARTNERSHIP_RETURN             = new(:partnership_return),
     TRUSTEE_RETURN                 = new(:trustee_return),
-    CLAIM_OR_AMENDMENT             = new(:claim_or_amendment),
     ENTERPRISE_MGMT_INCENTIVES     = new(:enterprise_mgmt_incentives),
     NON_RESIDENT_CAPITAL_GAINS_TAX = new(:non_resident_capital_gains_tax),
     STAMP_DUTY_LAND_TAX_RETURN     = new(:stamp_duty_land_tax_return),
-    STAMP_DUTY_LAND_TAX_CLAIM      = new(:stamp_duty_land_tax_claim),
     TRANSACTIONS_IN_SECURITIES     = new(:transactions_in_securities),
+    CLAIM_OR_AMENDMENT             = new(:claim_or_amendment),
   ].freeze
 
   def self.values

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -732,8 +732,6 @@ en:
             return
           stamp_duty_land_tax_return_html: 'Stamp Duty Land Tax (SDLT): land transaction
             return'
-          stamp_duty_land_tax_claim_html: 'Stamp Duty Land Tax (SDLT): claim or amendment
-            of a claim'
           transactions_in_securities_html: 'Transactions in securities: issue of counteraction
             or no-counteraction notice'
       steps_closure_enquiry_details_form:
@@ -1062,8 +1060,6 @@ en:
         non_resident_capital_gains_tax: Non-resident Capital Gains Tax (NRCGT) return
         stamp_duty_land_tax_return: 'Stamp Duty Land Tax (SDLT): land transaction
           return'
-        stamp_duty_land_tax_claim: 'Stamp Duty Land Tax (SDLT): claim or amendment
-          of a claim'
         transactions_in_securities: 'Transactions in securities: issue of counteraction
           or no-counteraction notice'
     closure_hmrc_reference:

--- a/smoke_tests/happypath/income_tax.feature
+++ b/smoke_tests/happypath/income_tax.feature
@@ -79,7 +79,7 @@ Feature: Income Tax Happy Paths
     And I click the "Back" link
     Then I should see "Previously attached document: grounds_for_appeal.docx"
     And I click the "Save and continue" button
-    Then I should see "Briefly say what outcome you'd like"
+    Then I should see "Briefly say what outcome you would like"
 
     Given I fill in "Clearly explain in 2-3 sentences" with "Drive my enemies before me, hear the lament of their women"
     And I click the "Save and continue" button

--- a/spec/forms/steps/closure/case_type_form_spec.rb
+++ b/spec/forms/steps/closure/case_type_form_spec.rb
@@ -17,12 +17,11 @@ RSpec.describe Steps::Closure::CaseTypeForm do
         company_return
         partnership_return
         trustee_return
-        claim_or_amendment
         enterprise_mgmt_incentives
         non_resident_capital_gains_tax
         stamp_duty_land_tax_return
-        stamp_duty_land_tax_claim
         transactions_in_securities
+        claim_or_amendment
       ))
     end
   end


### PR DESCRIPTION
Move `Claim or amendment of a claim` to be last in the list, and remove
`Stamp Duty Land Tax (SDLT): claim or amendment of a claim`

Also fixed a smoke test due to a previous copy change.

https://www.pivotaltracker.com/story/show/143171261