### PR TITLE
Skip forgery protection in Errors controller

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def case_submitted
     @tribunal_case = current_tribunal_case
     respond_with_status(:unprocessable_entity)


### PR DESCRIPTION
This should stop the annoying Sentry errors when bots/crawlers do scans
for non existing javascript files in the service URL.

https://www.pivotaltracker.com/story/show/145503773