### PR TITLE
Improve the logging format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem 'wicked_pdf', '~> 1.1.0'
 gem 'wkhtmltopdf-binary'
 
 group :production do
-  gem 'logstash-logger'
+  gem 'lograge'
+  gem 'logstash-event'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,9 +193,11 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     logstash-event (1.2.02)
-    logstash-logger (0.25.0)
-      logstash-event (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.5)
@@ -458,7 +460,8 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (~> 3.0.5)
-  logstash-logger
+  lograge
+  logstash-event
   ministryofjustice-danger
   mojfile-uploader-api-client (~> 0.8)
   mutant-rspec

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  # This is required to get request attributes in to the production logs.
+  # See the various lograge configurations in `production.rb`.
+  def append_info_to_payload(payload)
+    super
+    payload[:host] = request&.host
+    payload[:referrer] = request&.referrer
+    payload[:session_id] = request&.session&.id
+    payload[:user_agent] = request&.user_agent
+  end
+
   rescue_from Exception do |exception|
     case exception
     when Errors::InvalidSession, ActionController::InvalidAuthenticityToken


### PR DESCRIPTION
I had previously skipped lograge because I had trouble elsewhere getting
kibana to correctly ingest its `key=value` format. Reviewing it again
after reading the recommendation to use it in the `logstash-logger`
repo, I decided to give it a try.  This implementation provides much
cleaner output than bare logstash.  I've also included a number of
request object attributes that I had not been able to add previously.