### PR TITLE
Parameterize hardcoded draft case expire days

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -20,6 +20,7 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       appeal_or_application: mail_presenter.appeal_or_application,
+      draft_expire_in_days: mail_presenter.draft_expire_in_days,
       show_deadline_warning: mail_presenter.show_deadline_warning?,
       resume_case_link: resume_users_case_url(tribunal_case)
     )

--- a/app/presenters/case_mail_presenter.rb
+++ b/app/presenters/case_mail_presenter.rb
@@ -51,6 +51,10 @@ class CaseMailPresenter < SimpleDelegator
     Rails.configuration.survey_link
   end
 
+  def draft_expire_in_days
+    Rails.configuration.x.cases.expire_in_days
+  end
+
   private
 
   def representative_contact_name

--- a/app/views/errors/case_not_found.html.erb
+++ b/app/views/errors/case_not_found.html.erb
@@ -6,7 +6,7 @@
 
     <p class="lede"><%=t '.lead_text', session_timeout: Rails.configuration.x.session.expires_in_minutes %></p>
 
-    <p class="lede"><%=t '.more_text' %></p>
+    <p class="lede"><%= t('.more_text', expire_in_days: Rails.configuration.x.cases.expire_in_days) %></p>
 
     <div class="form-group">
       <%= link_to t('.start_again'), start_path, class: 'button' %>

--- a/app/views/users/logins/logged_out.html.erb
+++ b/app/views/users/logins/logged_out.html.erb
@@ -6,7 +6,7 @@
 
     <p class="lede"><%=t '.lead_text' %></p>
 
-    <p class="lede"><%=t '.more_text_html' %></p>
+    <p class="lede"><%= t('.more_text_html', expire_in_days: Rails.configuration.x.cases.expire_in_days) %></p>
 
     <%= render partial: 'steps/shared/finish_button', locals: {name: t('shared.start_again'), show_survey: false} %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1159,7 +1159,7 @@ en:
       heading: Sorry, this case can't be found
       <<: *START_FINISH
       lead_text: If you copied a web address, please check it’s correct.
-      more_text: "Please note: a draft case expires 14 days after it was created or when you submit it to the tax tribunal."
+      more_text: "Please note: a draft case expires %{expire_in_days} days after it was created or when you submit it to the tax tribunal."
       page_title: Case not found
     case_submitted:
       heading: You have already submitted this case
@@ -1311,7 +1311,7 @@ en:
       logged_out:
         heading: You have signed out
         lead_text: You can return to a saved case using the link sent in the email or by returning to the start of the service.
-        more_text_html: A draft case expires 14 days after it was created or when you submit it to the tax tribunal.
+        more_text_html: A draft case expires %{expire_in_days} days after it was created or when you submit it to the tax tribunal.
         page_title: Signed out
       save_confirmation:
         heading: Your case has been saved

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe NotifyMailer, type: :mailer do
     it 'has the right keys' do
       expect(mail.govuk_notify_personalisation).to eq({
         appeal_or_application: :appeal,
+        draft_expire_in_days: 14,
         show_deadline_warning: 'yes',
         resume_case_link: 'https://tax.justice.uk/users/cases/4a362e1c-48eb-40e3-9458-a31ead3f30a4/resume'
       })

--- a/spec/presenters/case_mail_presenter_spec.rb
+++ b/spec/presenters/case_mail_presenter_spec.rb
@@ -194,4 +194,11 @@ RSpec.describe CaseMailPresenter do
       subject.survey_link
     end
   end
+
+  describe '#draft_expire_in_days' do
+    it 'should retrieve it from the Rails config' do
+      expect(Rails).to receive_message_chain(:configuration, :x, :cases, :expire_in_days)
+      subject.draft_expire_in_days
+    end
+  end
 end


### PR DESCRIPTION
We had some instances where the number of days a draft case is keep was
hardcoded. This changes it to use the configuration value.

https://www.pivotaltracker.com/story/show/144699259