### PR TITLE
Fix an issue where IE8 won't upload a JPG

### DIFF
--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -27,6 +27,7 @@ class DocumentUpload
     text/csv
     image/gif
     image/jpeg
+    image/pjpeg
     image/png
     image/tiff
     image/bmp


### PR DESCRIPTION
IE8 is interpreting JPGs as image type pjpeg. This adds that to the filetype whitelist.

Fixes [this issue in Pivotal](https://www.pivotaltracker.com/story/show/145291345)