### PR TITLE
Enable non-JS users to reach post-service survey

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,16 +3,14 @@ class SessionsController < ApplicationController
     head(:no_content)
   end
 
-  def destroy
-    # When redirecting to the survey, we want to logout the user. But when only taking the users to the home,
-    # we don't want to log them out but instead only reset the current case in session.
-    show_survey = params[:survey] == 'true'
-    show_survey ? reset_session : reset_tribunal_case_session
+  # The 'method: :delete' on the finish button only works if JS is enabled, so the controller needs to implement both
+  # show and destroy, for users without JS.
+  def show
+    redirect_to_survey_or_home_page
+  end
 
-    respond_to do |format|
-      format.html { redirect_to show_survey ? Rails.configuration.survey_link : root_path }
-      format.json { render json: {} }
-    end
+  def destroy
+    redirect_to_survey_or_home_page
   end
 
   def create_and_fill_appeal
@@ -45,6 +43,18 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def redirect_to_survey_or_home_page
+    # When redirecting to the survey, we want to logout the user. But when only taking the users to the home,
+    # we don't want to log them out but instead only reset the current case in session.
+    show_survey = params[:survey] == 'true'
+    show_survey ? reset_session : reset_tribunal_case_session
+
+    respond_to do |format|
+      format.html { redirect_to show_survey ? Rails.configuration.survey_link : root_path }
+      format.json { render json: {} }
+    end
+  end
 
   # :nocov:
   def fake_appeal_data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,7 @@ Rails.application.routes.draw do
 
   resources :appeal_cases, :closure_cases, only: [:create]
 
-  resource :session, only: [:destroy] do
+  resource :session, only: [:destroy, :show] do
     member do
       get :ping
       post :create_and_fill_appeal

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -8,54 +8,61 @@ RSpec.describe SessionsController, type: :controller do
     end
   end
 
-  describe '#destroy' do
-    context 'when survey param is not provided' do
-      it 'resets the tribunal case session' do
-        expect(subject).to receive(:reset_tribunal_case_session)
-        get :destroy
-      end
+  RSpec.shared_examples 'logs out and redirects to survey' do |options|
+    let(:method) { options.fetch(:method) }
 
-      it 'redirects to the home page' do
-        get :destroy
-        expect(subject).to redirect_to(root_path)
-      end
-    end
-
-    context 'when survey param is provided' do
-      context 'for a `true` value' do
-        it 'resets the session' do
-          expect(subject).to receive(:reset_session)
-          get :destroy, params: {survey: true}
-        end
-
-        it 'redirects to the survey page' do
-          get :destroy, params: {survey: true}
-          expect(response.location).to match(/goo\.gl\/forms/)
-        end
-      end
-
-      context 'for a `false` value' do
+    describe '#destroy' do
+      context 'when survey param is not provided' do
         it 'resets the tribunal case session' do
           expect(subject).to receive(:reset_tribunal_case_session)
-          get :destroy, params: {survey: false}
+          get method
         end
 
         it 'redirects to the home page' do
-          get :destroy, params: {survey: false}
+          get method
           expect(subject).to redirect_to(root_path)
         end
       end
-    end
 
-    context 'when a JSON request is made' do
-      before { request.accept = "application/json" }
+      context 'when survey param is provided' do
+        context 'for a `true` value' do
+          it 'resets the session' do
+            expect(subject).to receive(:reset_session)
+            get method, params: {survey: true}
+          end
 
-      it 'returns empty JSON and does not redirect' do
-        expect(response.body).to be_empty
-        expect(response.location).to be_nil
+          it 'redirects to the survey page' do
+            get method, params: {survey: true}
+            expect(response.location).to match(/goo\.gl\/forms/)
+          end
+        end
+
+        context 'for a `false` value' do
+          it 'resets the tribunal case session' do
+            expect(subject).to receive(:reset_tribunal_case_session)
+            get method, params: {survey: false}
+          end
+
+          it 'redirects to the home page' do
+            get method, params: {survey: false}
+            expect(subject).to redirect_to(root_path)
+          end
+        end
+      end
+
+      context 'when a JSON request is made' do
+        before { request.accept = "application/json" }
+
+        it 'returns empty JSON and does not redirect' do
+          expect(response.body).to be_empty
+          expect(response.location).to be_nil
+        end
       end
     end
   end
+
+  include_examples 'logs out and redirects to survey', method: :destroy
+  include_examples 'logs out and redirects to survey', method: :show
 
   [
     'create_and_fill_appeal',


### PR DESCRIPTION
This commit gets around a problem where IE8, for which we disable
javascript, does not get redirected to our survey, because the
'Finish' button uses javascript to send a DELETE request when the
button is clicked. This commit makes the sessions controller
handle GET and DELETE requests in the same way.