### PR TITLE
Convert link_to to button_to when method is delete

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,6 +47,7 @@
 @import 'local/lists';
 @import 'local/inputs';
 @import 'local/buttons';
+@import 'local/forms';
 @import 'local/typography';
 @import 'local/header';
 @import 'local/panels';

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -1,0 +1,26 @@
+form.button_to {
+  padding-bottom: 0;
+
+  #proposition-links & {
+    input[type="submit"] {
+      background: transparent;
+      border: none;
+      outline: none;
+      color: $white;
+      padding: 0;
+      font-weight: bold;
+      cursor: pointer;
+      text-decoration-skip: ink;
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      &:focus {
+        color: $black;
+        background-color: $yellow;
+        outline: 3px solid $yellow;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/local/forms.scss
+++ b/app/assets/stylesheets/local/forms.scss
@@ -8,6 +8,7 @@ form.button_to {
       outline: none;
       color: $white;
       padding: 0;
+      margin: 0;
       font-weight: bold;
       cursor: pointer;
       text-decoration-skip: ink;

--- a/app/views/layouts/_current_user_menu.html.erb
+++ b/app/views/layouts/_current_user_menu.html.erb
@@ -2,5 +2,5 @@
   <li><%= link_to t('.your_cases'), users_cases_path %></li>
   <li><%= link_to t('.change_password'), edit_user_registration_path %></li>
   <li><%= current_user.email %></li>
-  <li><%= link_to t('.logout'), destroy_user_session_path, method: :delete %></li>
+  <li><%= button_to t('.logout'), destroy_user_session_path, method: :delete %></li>
 </ul>

--- a/app/views/steps/shared/_finish_button.html.erb
+++ b/app/views/steps/shared/_finish_button.html.erb
@@ -1,3 +1,3 @@
 <div class="form-group">
-  <%= link_to name, session_path(survey: local_assigns.fetch(:show_survey, true)), method: :delete, class: 'button' %>
+  <%= button_to name, session_path(survey: local_assigns.fetch(:show_survey, true)), method: :delete, class: 'button' %>
 </div>


### PR DESCRIPTION
When JS is disabled, `link_to` with method `delete` will trigger a GET
instead of a POST. In order to fix this, we need to replace any instance
of `link_to` to `button_to`.

Some styling fixes will be required in the header logout link.

https://www.pivotaltracker.com/story/show/146151511

<img width="609" alt="screen shot 2017-05-30 at 09 50 10" src="https://cloud.githubusercontent.com/assets/687910/26575657/05d30224-451e-11e7-842d-5798d864ef22.png">
