### PR TITLE
Enable tracing of docker container serving request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   # See the various lograge configurations in `production.rb`.
   def append_info_to_payload(payload)
     super
-    payload[:host] = request&.host
     payload[:referrer] = request&.referrer
     payload[:session_id] = request&.session&.id
     payload[:user_agent] = request&.user_agent


### PR DESCRIPTION
Prior to this, the `host` attribute was populated with a hash that
identified the specific docker container responding to the request. This
is far more useful than the service URL as it enables us to connect the
sentry error reports to the log file entries.

This commit returns us to using the docker container hash.