### PR TITLE
Mutant coverage in ZendeskSender service object

### DIFF
--- a/app/forms/surveys/feedback_form.rb
+++ b/app/forms/surveys/feedback_form.rb
@@ -21,7 +21,7 @@ module Surveys
     private
 
     def persist!
-      ZendeskSender.new(self).send!
+      TaxTribs::ZendeskSender.new(self).send!
     end
   end
 end

--- a/app/services/tax_tribs/zendesk_sender.rb
+++ b/app/services/tax_tribs/zendesk_sender.rb
@@ -1,4 +1,4 @@
-class ZendeskSender
+class TaxTribs::ZendeskSender
   attr_accessor :form_object
 
   # This needs to match the value in the `Service` ticket field.
@@ -34,11 +34,15 @@ class ZendeskSender
   private
 
   def requester_details
-    {name: requester_name, email: form_object.email} if requester_name
+    {name: requester_name, email: requester_email} if requester_email.present?
+  end
+
+  def requester_email
+    form_object.email
   end
 
   # We are not asking for a name, so we default to the first part of the user email
   def requester_name
-    form_object.email.to_s.split('@').first
+    requester_email.split('@').first
   end
 end

--- a/lib/tasks/mutant.rake
+++ b/lib/tasks/mutant.rake
@@ -1,20 +1,21 @@
+# TODO: migrate all service classes into the `TaxTribs` namespace, so
+# that mutant will test them. Remove `ApplicationRecord.descendants`
+# once all our classes are migrated to the `TaxTribs` namespace.
+#
+# Pass a match expression as an optional argument to only run mutant
+# on classes that match. Example: `rake mutant TaxTribs::ZendeskSender`
+
 task :mutant => :environment do
   vars = 'NOCOVERAGE=true'
   flags = '--use rspec --fail-fast'
 
-  # TODO: Remove this once all our classes are migrated to the
-  # TaxTribs namespace
   classes_to_mutate.each do |klass|
     unless system("#{vars} mutant #{flags} #{klass}")
       raise 'Mutation testing failed'
     end
   end
 
-  # TODO: migrate all service classes into the TaxTribs namespace, so
-  # that mutant will test them
-  unless system("#{vars} mutant #{flags} TaxTribs*")
-    raise 'Mutation testing failed'
-  end
+  exit
 end
 
 task(:default).prerequisites << task(:mutant)
@@ -23,5 +24,5 @@ private
 
 def classes_to_mutate
   Rails.application.eager_load!
-  ApplicationRecord.descendants.map(&:name)
+  Array(ARGV[1]).presence || ApplicationRecord.descendants.map(&:name) + ['TaxTribs*']
 end

--- a/spec/forms/surveys/feedback_form_spec.rb
+++ b/spec/forms/surveys/feedback_form_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Surveys::FeedbackForm do
       let(:zendesk_sender_double) { double('zendesk_sender_double') }
 
       it 'creates the ticket' do
-        expect(ZendeskSender).to receive(:new).with(subject).and_return(zendesk_sender_double)
+        expect(TaxTribs::ZendeskSender).to receive(:new).with(subject).and_return(zendesk_sender_double)
         expect(zendesk_sender_double).to receive(:send!).and_return(true)
         expect(subject.save).to be(true)
       end

--- a/spec/services/zendesk_sender_spec.rb
+++ b/spec/services/zendesk_sender_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ZendeskSender do
+RSpec.describe TaxTribs::ZendeskSender do
   let(:form_object) {
     Surveys::FeedbackForm.new(
       rating: 5, comment: 'very nice service', email: email, referrer: '/whatever', user_agent: 'Safari'


### PR DESCRIPTION
* Add mutant coverage to the ZendeskSender service object.

* Small refactor of the mutant rake task to make it simpler to only run
specific classes, passing a matching expression as an optional argument.