### PR TITLE
Add Help link to footer links

### DIFF
--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -1,5 +1,8 @@
 <ul>
   <li>
+    <%= link_to t('.help'), 'http://www.gov.uk/help' %>
+  </li>
+  <li>
     <%= link_to t('.contact'), contact_page_path %>
   </li>
   <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1188,6 +1188,7 @@ en:
       page_title: Not found
   layouts:
     footer_links:
+      help: Help
       contact: Contact
       cookies: Cookies
       terms_and_conditions: Terms and Conditions


### PR DESCRIPTION
[This Pivotal ticket](https://www.pivotaltracker.com/story/show/146362757) was to add an accessibility statement. On examining a couple of previous services – Accelerated Claims and Help With Fees – I found that they had dealt with this issue by simply including a 'Help' link in their footer which links to www.gov.uk/help

This implements that until/unless we have a better idea.