### PR TITLE
Dynamic app root based on requested domain

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,6 +61,10 @@ module ApplicationHelper
     user_signed_in? ? users_cases_path : user_session_path
   end
 
+  def domain_based_homepage_url
+    request.domain =~ /gov\.uk/ ? Rails.configuration.gds_service_homepage_url : root_path
+  end
+
   def title(page_title)
     content_for :page_title, [page_title.presence, t('generic.page_title')].compact.join(' - ')
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:homepage_url) { "/" } %>
+<% content_for(:homepage_url) { domain_based_homepage_url } %>
 <% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
 
 <% content_for(:head) do %>
@@ -18,7 +18,7 @@
         <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
       <% end %>
       <nav id="proposition-menu">
-        <a href="/" id="proposition-name">Appeal to the tax tribunal</a>
+        <%= link_to 'Appeal to the tax tribunal', yield(:homepage_url), id: 'proposition-name' %>
         <%= render partial: 'layouts/current_user_menu' if user_signed_in? %>
       </nav>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,10 @@ module TaxTribunalsDatacapture
     config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
     config.kickout_survey_link = 'https://goo.gl/forms/Ccx0sJcOs5cSVYks2'
 
+    # TODO: change to the real URL once it is live
+    # This is the GDS-hosted homepage for our service, and the one with a `start` button
+    config.gds_service_homepage_url = 'https://appeal-tax-tribunal.service.gov.uk'.freeze
+
     config.tax_tribunal_email = 'taxappeals@hmcts.gsi.gov.uk'
     config.tax_tribunal_phone = '0300 123 1024'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,15 @@ Rails.application.routes.draw do
     end
   end
 
+  # TODO: remove root branching once the GDS domain is up and running, so we
+  # get rid of our fake start page and move our current `/start` to be `/`
+  constraints domain: 'dsd.io' do
+    get '/', to: 'home#index'
+  end
+  constraints domain: 'gov.uk' do
+    get '/', to: redirect('/start', status: 302)
+  end
+
   root to: 'home#index'
   get :start, to: 'home#start'
   get :appeal, to: 'appeal_home#index'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -155,6 +155,25 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#domain_based_homepage_url' do
+    context 'for dsd.io domains' do
+      before { @request.host = 'tax-tests.dsd.io' }
+
+      it 'returns the app `root_path`' do
+        expect(helper.domain_based_homepage_url).to eq(root_path)
+      end
+    end
+
+    context 'for gov.uk domains' do
+      before { @request.host = 'tax-tests.service.gov.uk' }
+
+      it 'returns the defined `gds_service_homepage_url`' do
+        expect(Rails).to receive_message_chain(:configuration, :gds_service_homepage_url).and_return('http://whatever.com')
+        expect(helper.domain_based_homepage_url).to eq('http://whatever.com')
+      end
+    end
+  end
+
   describe '#title' do
     let(:title) { helper.content_for(:page_title) }
 


### PR DESCRIPTION
As part of the preparations for the going live with a GDS domain, and a
gds-hosted homepage, we need to be able to handle during some time access
to the app through both URLs/domains but there are some small differences:

* If accessing through our current dsd.io domain, everything will continue
as it is now, and the `/` will take to our homepage with a button to `/start`

* If accessing through a gov.uk domain, our `/` will redirect to `/start` as
GDS will be hosting the homepage with the `start` button for us, and thus we
just need to show users coming through this URL the task list.

Temporarily this will be a redirect, but once the GDS domain is live and
working we will be able to move our `/start` to be our `/`.

* Another change will be for the link in the header to direct users to our `/` 
if accessing through a dsd.io domain or to the TBC GDS service homepage
if accessing through a gov.uk domain.

This is a part of a bigger ticket:
https://www.pivotaltracker.com/story/show/146376375