### PR TITLE
Add local copy of selection-buttons.js

### DIFF
--- a/app/assets/javascripts/govuk/selection-buttons.js
+++ b/app/assets/javascripts/govuk/selection-buttons.js
@@ -1,0 +1,125 @@
+// DEPRECATED
+// This isn’t needed if you’re using GOV.UK Elements 3.0.0 or above
+
+;(function (global) {
+  'use strict'
+
+  // Warning commented out in local version. Project reaching end of dev
+  // cycle, and it is unlikely that Elements will be upgraded to v3.x.x
+  // in dev time remaining.
+  // This local copy supercedes the version incorporated by govuk_toolkit, so
+  // console warning is suppressed but all functionality remains
+
+  // if (window.console && window.console.warn) {
+  //   window.console.warn('Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.')
+  // }
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+
+  var SelectionButtons = function (elmsOrSelector, opts) {
+    this.selectedClass = 'selected'
+    this.focusedClass = 'focused'
+    this.radioClass = 'selection-button-radio'
+    this.checkboxClass = 'selection-button-checkbox'
+    if (opts !== undefined) {
+      $.each(opts, function (optionName, optionObj) {
+        this[optionName] = optionObj
+      }.bind(this))
+    }
+    if (typeof elmsOrSelector === 'string') {
+      this.selector = elmsOrSelector
+      this.setInitialState($(this.selector))
+    } else if (elmsOrSelector !== undefined) {
+      this.$elms = elmsOrSelector
+      this.setInitialState(this.$elms)
+    }
+    this.addEvents()
+  }
+  SelectionButtons.prototype.addEvents = function () {
+    if (typeof this.$elms !== 'undefined') {
+      this.addElementLevelEvents()
+    } else {
+      this.addDocumentLevelEvents()
+    }
+  }
+  SelectionButtons.prototype.setInitialState = function ($elms) {
+    $elms.each(function (idx, elm) {
+      var $elm = $(elm)
+
+      var labelClass = $elm.attr('type') === 'radio' ? this.radioClass : this.checkboxClass
+      $elm.parent('label').addClass(labelClass)
+      if ($elm.is(':checked')) {
+        this.markSelected($elm)
+      }
+    }.bind(this))
+  }
+  SelectionButtons.prototype.markFocused = function ($elm, state) {
+    if (state === 'focused') {
+      $elm.parent('label').addClass(this.focusedClass)
+    } else {
+      $elm.parent('label').removeClass(this.focusedClass)
+    }
+  }
+  SelectionButtons.prototype.markSelected = function ($elm) {
+    var radioName
+
+    if ($elm.attr('type') === 'radio') {
+      radioName = $elm.attr('name')
+      $($elm[0].form).find('input[name="' + radioName + '"]')
+        .parent('label')
+        .removeClass(this.selectedClass)
+      $elm.parent('label').addClass(this.selectedClass)
+    } else { // checkbox
+      if ($elm.is(':checked')) {
+        $elm.parent('label').addClass(this.selectedClass)
+      } else {
+        $elm.parent('label').removeClass(this.selectedClass)
+      }
+    }
+  }
+  SelectionButtons.prototype.addElementLevelEvents = function () {
+    this.clickHandler = this.getClickHandler()
+    this.focusHandler = this.getFocusHandler({ 'level': 'element' })
+
+    this.$elms
+      .on('click', this.clickHandler)
+      .on('focus blur', this.focusHandler)
+  }
+  SelectionButtons.prototype.addDocumentLevelEvents = function () {
+    this.clickHandler = this.getClickHandler()
+    this.focusHandler = this.getFocusHandler({ 'level': 'document' })
+
+    $(document)
+      .on('click', this.selector, this.clickHandler)
+      .on('focus blur', this.selector, this.focusHandler)
+  }
+  SelectionButtons.prototype.getClickHandler = function () {
+    return function (e) {
+      this.markSelected($(e.target))
+    }.bind(this)
+  }
+  SelectionButtons.prototype.getFocusHandler = function (opts) {
+    var focusEvent = (opts.level === 'document') ? 'focusin' : 'focus'
+
+    return function (e) {
+      var state = (e.type === focusEvent) ? 'focused' : 'blurred'
+
+      this.markFocused($(e.target), state)
+    }.bind(this)
+  }
+  SelectionButtons.prototype.destroy = function () {
+    if (typeof this.selector !== 'undefined') {
+      $(document)
+        .off('click', this.selector, this.clickHandler)
+        .off('focus blur', this.selector, this.focusHandler)
+    } else {
+      this.$elms
+        .off('click', this.clickHandler)
+        .off('focus blur', this.focusHandler)
+    }
+  }
+
+  GOVUK.SelectionButtons = SelectionButtons
+  global.GOVUK = GOVUK
+})(window);


### PR DESCRIPTION
When including `govuk_toolkit` in `application.js`, the latest version of `selection-buttons.js` is pulled into the application. This includes a console warning that the JS is no longer required if the project is using Elements >=3.0.0. We are not, and it is unlikely that we will upgrade in the remaining time left on the project, so the warning would be present and visible to users when we go live.

![screen shot 2017-06-05 at 15 02 09](https://cloud.githubusercontent.com/assets/988436/26786915/0a7203ac-4a00-11e7-9dc4-06070f9c9bea.png)


Including a local copy of `selection-buttons.js` in which the warning is commented out retains all existing functionality, but suppresses the noisy console warning.