### PR TITLE
Remove an obsolete migration causing problems

### DIFF
--- a/db/migrate/20170330130111_rename_having_trouble_uploading_fields.rb
+++ b/db/migrate/20170330130111_rename_having_trouble_uploading_fields.rb
@@ -1,6 +1,0 @@
-class RenameHavingTroubleUploadingFields < ActiveRecord::Migration[5.0]
-  def change
-    rename_column :tribunal_cases, :having_problems_uploading_documents, :having_problems_uploading
-    rename_column :tribunal_cases, :having_problems_uploading_details, :having_problems_uploading_explanation
-  end
-end


### PR DESCRIPTION
This migration is no longer needed and is trying to rename non existing
columns, probably because we did a search and replace in the past and
we changed by mistake the migration itself.