### PR TITLE
Change destination of header links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,3 @@
-<% content_for(:homepage_url) { domain_based_homepage_url } %>
 <% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
 
 <% content_for(:head) do %>
@@ -19,7 +18,7 @@
         <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
       <% end %>
       <nav id="proposition-menu">
-        <%= link_to 'Appeal to the tax tribunal', yield(:homepage_url), id: 'proposition-name' %>
+        <%= link_to 'Appeal to the tax tribunal', domain_based_homepage_url, id: 'proposition-name' %>
         <%= render partial: 'layouts/current_user_menu' if user_signed_in? %>
       </nav>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,9 +31,8 @@ module TaxTribunalsDatacapture
     config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
     config.kickout_survey_link = 'https://goo.gl/forms/Ccx0sJcOs5cSVYks2'
 
-    # TODO: change to the real URL once it is live
     # This is the GDS-hosted homepage for our service, and the one with a `start` button
-    config.gds_service_homepage_url = 'https://appeal-tax-tribunal.service.gov.uk'.freeze
+    config.gds_service_homepage_url = 'https://www.gov.uk/tax-tribunal'.freeze
 
     config.tax_tribunal_email = 'taxappeals@hmcts.gsi.gov.uk'
     config.tax_tribunal_phone = '0300 123 1024'


### PR DESCRIPTION
The GOV.UK logo should go the default destination, www.gov.uk, and
the proposition service name, should go to the GDS homepage if accessing
via gov.uk link, or to the root_path otherwise.

https://www.pivotaltracker.com/story/show/146358417