### PR TITLE
Stop replacing hyphens with `&dash;` on save

### DIFF
--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -103,7 +103,6 @@ class TribunalCase < ApplicationRecord
     Sanitize.fragment(value).
       gsub('*', '&#42;').
       gsub('=', '&#61;').
-      gsub('-', '&dash;').
       gsub('%', '&#37;').
       gsub(/drop\s+table/i, '').
       gsub(/insert\s+into/i, '')

--- a/spec/forms/steps/details/taxpayer_individual_details_form_spec.rb
+++ b/spec/forms/steps/details/taxpayer_individual_details_form_spec.rb
@@ -45,4 +45,40 @@ RSpec.describe Steps::Details::TaxpayerIndividualDetailsForm do
       end
     end
   end
+
+  # This test is necessary because NormalisedEmailType was working as expected on email fields,
+  # but the TribunalCase#sanitize was reverting back some characters to invalid ones on save
+  context 'NormalisedEmailType integration' do
+    let(:tribunal_case) { TribunalCase.new }
+
+    subject { described_class.new(
+        taxpayer_individual_first_name: 'Bob',
+        taxpayer_individual_last_name: 'Smith',
+        taxpayer_contact_address: 'Address',
+        taxpayer_contact_postcode: 'Postcode',
+        taxpayer_contact_email: taxpayer_contact_email,
+        tribunal_case: tribunal_case
+    ) }
+
+    context 'normalising hyphens' do
+      let(:taxpayer_contact_email) {"email@example\u2010hyphen.com"}
+
+      # Before the fix, TribunalCase#sanitize was converting the normalised hyphen to `&dash;`
+      it 'maintain the replaced hyphen on save' do
+        subject.save
+        expect(tribunal_case.reload.taxpayer_contact_email).to eq('email@example-hyphen.com')
+      end
+    end
+
+    context 'normalising single quotes' do
+      let(:taxpayer_contact_email) {"email\u2019test@example.com"}
+
+      # TribunalCase#sanitize was not affecting normalised single quotes, but this test ensures
+      # we don't introduce a regression in the future
+      it 'maintain the replaced single quote on save' do
+        subject.save
+        expect(tribunal_case.reload.taxpayer_contact_email).to eq("email'test@example.com")
+      end
+    end
+  end
 end

--- a/spec/models/sanitizer_shared_examples.rb
+++ b/spec/models/sanitizer_shared_examples.rb
@@ -18,12 +18,6 @@ RSpec.shared_examples 'sanitizing actions' do
     subject.send(:sanitize)
   end
 
-  specify 'scrub -' do # kills SQL comments
-    allow(Sanitize).to receive(:fragment).and_return(value)
-    expect(value).to receive(:gsub).with('-', '&dash;')
-    subject.send(:sanitize)
-  end
-
   specify 'scrub %' do
     allow(Sanitize).to receive(:fragment).and_return(value)
     expect(value).to receive(:gsub).with('%', '&#37;')


### PR DESCRIPTION
We run into a pesky problem where we thought the NormalisedEmailType was not replacing
properly some unicode hyphens not valid for use in email addresses, or was doing so but
not persisting the replaced (and valid) character to the database.

It turned out the problem was in another different part of the app, the sanitizing of
the database text/string fields `on save`.

The way this bug was reproducing is:

1) The user entered their email address containing an invalid unicode hyphen (for all we
know introducing a valid hyphen would also trigger this bug but for the sake of this
explanation I will go with an invalid hyphen).

2) Our `NormalisedEmailType` would silently replace the invalid hyphen with their valid
equivalent `-` so the user don't get an 'invalid email address' error on validation.

3) On trying to persist this new valid email address to the database, there is a callback
to run TribunalCase#sanitize through the database fields, and sadly enough, the (now valid)
hyphen would get converted back to an html representation of it `&dash;` making the email
address invalid again and persisting this invalid one to database (with char ord code 8208
instead of valid one 45).

4) This email will get all the way to GLiMR (they might run into problems because of this)
but on trying to send the confirmation email to the user, Notify will reject the email as
being not valid (because the invalid hyphen).

5) If the user were to use S&R or go back to the form, they will see a valid email address
as the NormalisedEmailType would replace back the invalid char to a valid one, but on save,
we go back to point (3) and we end up again with an invalid hyphen in the database.

6) All this really happen regardless if the user enters a valid or an invalid hyphen.