### PR TITLE
Using gov.uk done page for the survey

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,8 +28,8 @@ module TaxTribunalsDatacapture
     # This automatically adds id: :uuid to create_table in all future migrations
     config.active_record.primary_key = :uuid
 
-    config.survey_link = 'https://goo.gl/forms/5MeKnK5kGJH99Fsn2'
-    config.kickout_survey_link = 'https://goo.gl/forms/Ccx0sJcOs5cSVYks2'
+    config.survey_link = 'https://www.gov.uk/done/tax-tribunal'.freeze
+    config.kickout_survey_link = 'https://goo.gl/forms/Ccx0sJcOs5cSVYks2'.freeze
 
     # This is the GDS-hosted homepage for our service, and the one with a `start` button
     config.gds_service_homepage_url = 'https://www.gov.uk/tax-tribunal'.freeze

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SessionsController, type: :controller do
 
         it 'redirects to the survey page' do
           get :destroy, params: {survey: true}
-          expect(response.location).to match(/goo\.gl\/forms/)
+          expect(response.location).to match(/done\/tax-tribunal/)
         end
       end
 


### PR DESCRIPTION
NOTE: to be merged and deployed to prod once the 'done' page goes live.

This will only apply to submissions. Kick-out journeys will still use
our google forms feedback form, unless we decide otherwise.

https://www.pivotaltracker.com/story/show/147035307