### PR TITLE
Information notice to follow direct tax logic

### DIFF
--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -48,7 +48,7 @@ class CaseType < ValueObject
     GENERAL_BETTING_DUTY         = new(:general_betting_duty,         indirect_tax_properties),
     HYDROCARBON_OIL_DUTIES       = new(:hydrocarbon_oil_duties,       indirect_tax_properties),
     INCOME_TAX                   = new(:income_tax,                   direct_tax_properties),
-    INFORMATION_NOTICE           = new(:information_notice,           ask_dispute_type: true, ask_penalty: true, appeal_or_application: :appeal),
+    INFORMATION_NOTICE           = new(:information_notice,           direct_tax_properties),
     INHERITANCE_TAX              = new(:inheritance_tax,              direct_tax_properties),
     INSURANCE_PREMIUM_TAX        = new(:insurance_premium_tax,        indirect_tax_properties),
     LANDFILL_TAX                 = new(:landfill_tax,                 indirect_tax_properties),


### PR DESCRIPTION
Following on from our meeting with the tax judges, they informed us that
Information Notice appeals should follow direct tax logic, ie. there is
a kick-out if no appeal.

https://www.pivotaltracker.com/story/show/147187233