### PR TITLE
Copy amendments to document upload step

### DIFF
--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -10,6 +10,8 @@
 
     <p><%=t 'shared.file_upload.technical_info' %></p>
 
+    <%= render partial: 'steps/shared/file_upload_requirements' %>
+
     <%= form_tag documents_url(document_key: :supporting_documents), multipart: true, class: 'no-js-only' do %>
       <%= file_field_tag :document %>
       <%= submit_tag 'Upload', class: 'button' %>

--- a/app/views/steps/details/documents_checklist/edit.html.erb
+++ b/app/views/steps/details/documents_checklist/edit.html.erb
@@ -10,6 +10,8 @@
 
     <p><%=t 'shared.file_upload.technical_info' %></p>
 
+    <%= render partial: 'steps/shared/file_upload_requirements' %>
+
     <div id="supplied_letters_placeholder"></div>
 
     <%= form_tag documents_url(document_key: :supporting_documents), multipart: true, class: 'no-js-only' do %>
@@ -21,6 +23,8 @@
 
     <%= step_form @form_object, html: { class: 'cf' } do |f| %>
       <div class="form-group supplied_letters_checkboxes">
+        <%=t '.letters_heading_html' %>
+
         <%= f.label :original_notice_provided, class: 'block-label selection-button-checkbox' do %>
           <%= f.check_box :original_notice_provided, form: 'new_steps_details_documents_checklist_form' %>
           <%= t '.original_notice_provided_html' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   dictionary:
     default_service_title: &default_service_title "Appeal to the tax tribunal - GOV.UK"
+    tax_tribunal_independent: &tax_tribunal_independent "The tax tribunal is independent and doesn't have access to files from HMRC."
     attach_reasons_document: &attach_reasons_document "<strong>Attach reasons as a document</strong>"
     attach_reasons_blank_error: &attach_reasons_blank_error "You must enter reasons or attach a document"
     blank_uploading_problems: &blank_uploading_problems "Please describe the problem"
@@ -200,8 +201,7 @@ en:
       support_documents:
         edit:
           heading: Add documents to support your application (optional)
-          lead_text: The tax tribunal is independent and doesn't have access to any
-            information you may have sent to HMRC.
+          lead_text: *tax_tribunal_independent
           having_problems_uploading_html: I am having trouble uploading my documents
           page_title: Documents upload
       <<: *CYA_CONFIRMATION
@@ -336,10 +336,8 @@ en:
       documents_checklist:
         edit:
           heading: Upload your letter(s)
-          lead_text: The tax tribunal is independent and doesn't have access to files
-            from HMRC.
-          documents_check_heading: 'You must upload the following (select the items
-            you have uploaded):'
+          lead_text: *tax_tribunal_independent
+          letters_heading_html: "<p><strong>Upload at least one letter</strong></p>"
           original_notice_provided_html: "<strong>Original notice letter</strong><br>including
             the explanation for any decision(s)"
           review_conclusion_provided_html: "<strong>Review conclusion letter</strong><br>you
@@ -1103,9 +1101,7 @@ en:
         </ul>
       footer: You can’t upload executable (.exe), zip or other archive files due to
         virus risks.
-      technical_info: We accept scanned images or good quality pictures, for example
-        via a smartphone. You can upload Word, Excel, PDF, JPG, GIF or PNG formats. Maximum file
-        size of 20MB.
+      technical_info: We accept scanned images or good quality pictures, for example via a smartphone.
       dropzone_message_html: Drag and drop files here<br> <strong>or</strong><br><span
         class="faux-link" tabindex="-1">click to choose a file</span>
       uploaded_files_header: Uploaded files


### PR DESCRIPTION
Some minor changes to the document uploader (appeal and closure) to introduce the
expandable `File upload requirements` element, as it was missing from these steps,
and to add a header to the letter checkboxes to clarify at least one is needed.

https://www.pivotaltracker.com/story/show/147530773

https://www.pivotaltracker.com/story/show/147531309

<img width="632" alt="document-upload-improvements" src="https://user-images.githubusercontent.com/687910/27393659-c8c76844-56a1-11e7-9497-e322dd74fbcd.png">
