### PR TITLE
Enable GA ecommerce transaction tracking

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,6 +65,15 @@ module ApplicationHelper
     Rails.configuration.gds_service_homepage_url
   end
 
+  def track_transaction(attributes)
+    return if current_tribunal_case.nil?
+
+    content_for :transaction_data, {
+      id: current_tribunal_case.id,
+      quantity: '1',
+    }.merge(attributes).to_json.html_safe
+  end
+
   def title(page_title)
     content_for :page_title, [page_title.presence, t('generic.page_title')].compact.join(' - ')
   end

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -7,4 +7,10 @@
   ga('create', '<%= analytics_tracking_id %>', 'auto');
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
+
+  <% if content_for?(:transaction_data) %>
+  ga('require', 'ecommerce');
+  ga('ecommerce:addItem', <%= yield(:transaction_data) %>);
+  ga('ecommerce:send');
+  <% end %>
 </script>

--- a/app/views/steps/challenge/must_ask_for_review/show.html.erb
+++ b/app/views/steps/challenge/must_ask_for_review/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'must_ask_for_review', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_challenge_hmrc/show.html.erb
+++ b/app/views/steps/challenge/must_challenge_hmrc/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'must_challenge_hmrc', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_wait_for_challenge_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_challenge_decision/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'must_wait_for_challenge_decision', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'must_wait_for_review_decision', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/closure/check_answers/resume.html.erb
+++ b/app/views/steps/closure/check_answers/resume.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Resume closure case', category: 'Save and Return' %>
 
 <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 

--- a/app/views/steps/closure/confirmation/show.html.erb
+++ b/app/views/steps/closure/confirmation/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Closure case submitted', category: 'Submissions' %>
 
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= t '.case_submitted' %></h1>

--- a/app/views/steps/details/check_answers/resume.html.erb
+++ b/app/views/steps/details/check_answers/resume.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Resume appeal case', category: 'Save and Return' %>
 
 <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 

--- a/app/views/steps/details/confirmation/show.html.erb
+++ b/app/views/steps/details/confirmation/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Appeal case submitted', category: 'Submissions' %>
 
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= t '.case_submitted' %></h1>

--- a/app/views/steps/details/documents_upload_problems/show.html.erb
+++ b/app/views/steps/details/documents_upload_problems/show.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Submit by post', category: 'Postal Submissions' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/users/logins/save_confirmation.html.erb
+++ b/app/views/users/logins/save_confirmation.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Case saved for existing account', category: 'Save and Return' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/users/registrations/save_confirmation.html.erb
+++ b/app/views/users/registrations/save_confirmation.html.erb
@@ -1,4 +1,5 @@
 <% title t('.page_title') %>
+<% track_transaction name: 'Case saved for new account', category: 'Save and Return' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -199,4 +199,20 @@ RSpec.describe ApplicationHelper do
       helper.fallback_title
     end
   end
+
+  describe '#track_transaction' do
+    let(:tribunal_case) { instance_double(TribunalCase, id: '12345') }
+
+    before do
+      allow(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
+    end
+
+    it 'sets the transaction attributes to track' do
+      helper.track_transaction(name: 'whatever')
+
+      expect(
+        helper.content_for(:transaction_data)
+      ).to eq("{\"id\":\"12345\",\"quantity\":\"1\",\"name\":\"whatever\"}")
+    end
+  end
 end


### PR DESCRIPTION
It turned out the way we were tracking submissions and other events (with Goals)
is not the recommended way to track these, as it will only track 1 event per session,
so for example an accountancy firm submitting several cases in one go, will only
track as 1 case submitted, even if they submitted 10.

It is not a mayor issue as we are also tracking most of these events at the database
level and sending reporting emails, but as part of a proof of concept, let's see how
the transaction tracking goes, and even if it helps with tracking other events easily.
I've added a few to start with (most of them what we had as Goals before).

Geckoboard also support transactions/products analytics so it should be easy to start
reporting these.

https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce