### PR TITLE
Include case type as SKU in transaction details

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,6 +70,7 @@ module ApplicationHelper
 
     content_for :transaction_data, {
       id: current_tribunal_case.id,
+      sku: current_tribunal_case.intent_case_type.to_s,
       quantity: '1',
     }.merge(attributes).to_json.html_safe
   end

--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -78,11 +78,15 @@ class TribunalCase < ApplicationRecord
     user_type.eql?(UserType::REPRESENTATIVE)
   end
 
+  def intent_case_type
+    intent.eql?(Intent::TAX_APPEAL) ? case_type : closure_case_type
+  end
+
   # With our current implementation, we consider a case as `blank` if
   # case_type (appeals) nor closure_case_type (closure) have been set,
   # as this is the first question the user is asked.
   def blank?
-    case_type.nil? && closure_case_type.nil?
+    intent_case_type.nil?
   end
 
   private

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe ApplicationHelper do
     let(:tribunal_case) { instance_double(TribunalCase, id: '12345') }
 
     before do
+      allow(tribunal_case).to receive(:intent_case_type).and_return(CaseType::INCOME_TAX)
       allow(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
     end
 
@@ -212,7 +213,7 @@ RSpec.describe ApplicationHelper do
 
       expect(
         helper.content_for(:transaction_data)
-      ).to eq("{\"id\":\"12345\",\"quantity\":\"1\",\"name\":\"whatever\"}")
+      ).to eq("{\"id\":\"12345\",\"sku\":\"income_tax\",\"quantity\":\"1\",\"name\":\"whatever\"}")
     end
   end
 end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -166,22 +166,39 @@ RSpec.describe TribunalCase, type: :model do
   end
 
   describe '#blank?' do
-    let(:attributes) { { case_type: case_type, closure_case_type: closure_case_type } }
-    let(:case_type) { nil }
-    let(:closure_case_type) { nil}
-
-    context 'both `case_type` and `closure_case_type` are not set' do
-      it { expect(subject.blank?).to eq(true) }
+    it 'calls `#intent_case_type`' do
+      expect(subject).to receive(:intent_case_type)
+      subject.blank?
     end
 
-    context '`case_type` is set' do
-      let(:case_type) { CaseType.new(:anything) }
-      it { expect(subject.blank?).to eq(false) }
+    it 'returns true if no case type is set' do
+      expect(subject).to receive(:intent_case_type).and_return(nil)
+      expect(subject.blank?).to eq(true)
     end
 
-    context '`closure_case_type` is set' do
-      let(:closure_case_type) { ClosureCaseType.new(:anything) }
-      it { expect(subject.blank?).to eq(false) }
+    it 'returns false if a case type is set' do
+      expect(subject).to receive(:intent_case_type).and_return(CaseType::INCOME_TAX)
+      expect(subject.blank?).to eq(false)
+    end
+  end
+
+  describe '#intent_case_type' do
+    context 'for an appeal intent' do
+      let(:attributes) { { intent: Intent.new(:tax_appeal) } }
+
+      it 'retrieves the `case_type`' do
+        expect(subject).to receive(:case_type)
+        subject.intent_case_type
+      end
+    end
+
+    context 'for a closure intent' do
+      let(:attributes) { { intent: Intent.new(:close_enquiry) } }
+
+      it 'retrieves the `closure_case_type`' do
+        expect(subject).to receive(:closure_case_type)
+        subject.intent_case_type
+      end
     end
   end
 end


### PR DESCRIPTION
Further to the previous PR to track transactions, we can extend the details
of each of those tracked events by adding a SKU or item code, and this is
perfect to track the `case type` for each of these transactions.

So for example, case submissions can be analyzed by case type (VAT, income tax
and so on) and grouped together to enable better insights.