### PR TITLE
Tweaks to the challenge status options

### DIFF
--- a/app/forms/steps/challenge/decision_status_form.rb
+++ b/app/forms/steps/challenge/decision_status_form.rb
@@ -19,7 +19,6 @@ module Steps::Challenge
           ChallengedDecisionStatus::RECEIVED,
           ChallengedDecisionStatus::PENDING,
           ChallengedDecisionStatus::OVERDUE,
-          ChallengedDecisionStatus::REFUSED,
           ChallengedDecisionStatus::REVIEW_LATE_REJECTION
         ]
       else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,8 +42,8 @@ en:
       pending: I have been waiting less than 45 days for a review to finish
       overdue: I have been waiting for 45 days or more for a review to finish
       refused: I was refused a review as I was outside the time limit
-      appeal_late_rejection: My appeal was rejected for being late
-      review_late_rejection: My review was rejected for being late
+      appeal_late_rejection: I missed the deadline. I am applying to get a late appeal accepted
+      review_late_rejection: I missed the deadline. I am applying to get a late review accepted
       appealing_directly: No response. I want to appeal directly to the tribunal
       not_required: I was offered a review but didn’t accept
 

--- a/spec/forms/steps/challenge/decision_status_form_spec.rb
+++ b/spec/forms/steps/challenge/decision_status_form_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Steps::Challenge::DecisionStatusForm do
           received
           pending
           overdue
-          refused
           review_late_rejection
         ))
       end


### PR DESCRIPTION
* Restoration > challenge status only needs to have one rejection for
lateness response. Remove the extra option.

* Copy changes to `appeal_late_rejection` and `review_late_rejection`

https://www.pivotaltracker.com/story/show/147833699