### PR TITLE
Temporarily use email for the header feedback

### DIFF
--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -12,7 +12,10 @@
 <div class="phase-banner-beta">
   <p>
     <strong class="phase-tag">beta</strong>
-    <span><%= t('.phase_info_html', feedback_url: new_surveys_feedback_path) %></span>
+    <span>
+      <%# t('.phase_info_html', feedback_url: new_surveys_feedback_path) %>
+      <%= t('.phase_info_email_html') %>
+    </span>
   </p>
 </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1188,6 +1188,8 @@ en:
     phase_banner:
       phase_info_html: |
         This is a new service. <a href="%{feedback_url}" target="_blank" rel="noopener">Report a problem</a> and help improve it for others.
+      phase_info_email_html: |
+        This is a new service. <a href="mailto:taxtribunals_helpdesk@digital.justice.gov.uk?subject=Feedback">Report a problem</a> and help improve it for others.
     current_user_menu:
       logout: Sign out
       change_password: Change password


### PR DESCRIPTION
Do not use Zendesk, as our account has expired. We will enable it again
once it has been re-activated.