### PR TITLE
Route out of time requests direct to lateness

### DIFF
--- a/app/services/challenge_decision_tree.rb
+++ b/app/services/challenge_decision_tree.rb
@@ -51,6 +51,8 @@ class ChallengeDecisionTree < TaxTribs::DecisionTree
       show(:must_wait_for_challenge_decision)
     elsif pending_challenge_indirect_tax?
       show(:must_wait_for_review_decision)
+    elsif tribunal_case.challenged_decision_status.late_rejection?
+      edit('/steps/lateness/in_time')
     else
       dispute_or_penalties_decision
     end

--- a/app/value_objects/challenged_decision_status.rb
+++ b/app/value_objects/challenged_decision_status.rb
@@ -17,4 +17,8 @@ class ChallengedDecisionStatus < ValueObject
   def pending?
     self == PENDING
   end
+
+  def late_rejection?
+    [APPEAL_LATE_REJECTION, REVIEW_LATE_REJECTION].include?(self)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,9 +42,9 @@ en:
       pending: I have been waiting less than 45 days for a review to finish
       overdue: I have been waiting for 45 days or more for a review to finish
       refused: I was refused a review as I was outside the time limit
-      appeal_late_rejection: I missed the deadline. I am applying to get a late appeal accepted
-      review_late_rejection: I missed the deadline. I am applying to get a late review accepted
-      appealing_directly: No response. I want to appeal directly to the tribunal
+      appeal_late_rejection: My appeal to HMRC was late. I am applying to be allowed to make a late appeal to HMRC
+      review_late_rejection: My request was late. I am applying to be able to request a late review
+      appealing_directly: I am appealing direct to the tribunal before receiving a response from HMRC
       not_required: I was offered a review but didn’t accept
 
     START_FINISH: &START_FINISH

--- a/spec/services/challenge_decision_tree/challenged_decision_status_spec.rb
+++ b/spec/services/challenge_decision_tree/challenged_decision_status_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe ChallengeDecisionTree, '#destination' do
   subject { described_class.new(tribunal_case: tribunal_case, step_params: step_params, next_step: next_step) }
 
   context 'when the step is `challenged_decision_status`' do
+    context 'and the status is a late appeal/review' do
+      let(:case_type) {CaseType.new(:anything)}
+
+      context '`appeal_late_rejection`' do
+        let(:challenged_decision_status) {ChallengedDecisionStatus::APPEAL_LATE_REJECTION}
+        it {is_expected.to have_destination('/steps/lateness/in_time', :edit)}
+      end
+
+      context '`review_late_rejection`' do
+        let(:challenged_decision_status) {ChallengedDecisionStatus::REVIEW_LATE_REJECTION}
+        it {is_expected.to have_destination('/steps/lateness/in_time', :edit)}
+      end
+    end
+
     context 'and the status is `pending`' do
       let(:challenged_decision_status) { ChallengedDecisionStatus::PENDING }
 


### PR DESCRIPTION
Late appeal and late review answers in the challenge decision question
should both be routed direct to the lateness step, as we don't need to
capture dispute details for these.

Also, copy changes to reword these options.

https://www.pivotaltracker.com/story/show/148008695