### PR TITLE
Revert back to run smoke tests in DEV environment

### DIFF
--- a/Dockerfile.smoketests
+++ b/Dockerfile.smoketests
@@ -2,7 +2,7 @@ FROM ruby:2.3.3-onbuild
 
 RUN touch /etc/inittab
 
-ENV DATACAPTURE_URI https://tax-tribunals-datacapture-staging.dsd.io
+ENV DATACAPTURE_URI https://tax-tribunals-datacapture-dev.dsd.io
 RUN apt-get update && apt-get install -y && apt-get install libcurl4-gnutls-dev -y
 
 CMD bundle exec cucumber

--- a/smoke_tests/README.md
+++ b/smoke_tests/README.md
@@ -11,7 +11,7 @@ generally NOT be run against the production enviroment.**
 ## Running
 
 ```
-export DATACAPTURE_URI=https://tax-tribunals-datacapture-staging.dsd.io
+export DATACAPTURE_URI=https://tax-tribunals-datacapture-dev.dsd.io
 bundle exec cucumber
 ```
 
@@ -27,7 +27,7 @@ set -euo pipefail
 docker build -f Dockerfile.smoketests -t smoketests .
 docker run smoketests
 ```
-The default target environment is staging.  You can change this at run
+The default target environment is dev.  You can change this at run
 time by overriding the DATACAPTURE_URI environment variable:
 
 ```bash
@@ -36,7 +36,7 @@ time by overriding the DATACAPTURE_URI environment variable:
 set -euo pipefail
 
 docker build -f Dockerfile.smoketests -t smoketests .
-docker run -e "DATACAPTURE_URI=https://tax-tribunals-datacapture-dev.dsd.io" smoketests
+docker run -e "DATACAPTURE_URI=https://tax-tribunals-datacapture-staging.dsd.io" smoketests
 ```
 
 ### Containerisation Rationale/Why not docker-compose?


### PR DESCRIPTION
We recently changed the smoke tests to run on `staging` as we were
planning for decommissioning the `dev` environment, but sustaining
team decided to maintain both envs for the time being.

Given any new features and fixes get merged to DEV before Staging,
it makes sense to revert back to run the smoke tests also on DEV.