### PR TITLE
Using the value of intent_case_type method

### DIFF
--- a/app/views/admin/upload_problems_report/index.html.erb
+++ b/app/views/admin/upload_problems_report/index.html.erb
@@ -22,7 +22,7 @@
     <% @cases_with_upload_problems.each do |tribunal_case| %>
       <tr>
         <td><%= l(tribunal_case.updated_at, format: :long) %></td>
-        <td><%= tribunal_case.case_type.to_s %></td>
+        <td><%= tribunal_case.intent_case_type.to_s %></td>
         <td><%= tribunal_case.having_problems_uploading_explanation %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
For closure cases, the attribute where the case type is stored is
different to appeal cases. Using `intent_case_type` ensures we get
the correct case type value.