### PR TITLE
Add extra copy around single file uploaders

### DIFF
--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -23,18 +23,5 @@
 
       <%= display_current_document(@form_object.document_key) %>
     </div>
-
-    <details>
-      <summary>
-        <span class="summary">
-          <%= translate_with_appeal_or_application '.details_title' %>
-        </span>
-      </summary>
-      <div class="panel panel-border-narrow">
-        <p>
-          <%= translate_with_appeal_or_application '.details_content' %>
-        </p>
-      </div>
-    </details>
   </div>
 </div>

--- a/app/views/steps/shared/document_upload/_document_upload_field.html.erb
+++ b/app/views/steps/shared/document_upload/_document_upload_field.html.erb
@@ -2,6 +2,10 @@
   <%= form.label(field_name, label_text) %>
 </p>
 
+<p>
+  <%=t '.upload_explanation_html' %>
+</p>
+
 <div class="grid-row uploader-row">
   <div class="column-two-thirds">
     <%= form.file_field(field_name, class: 'single-file-upload', accept: DocumentUpload::ALLOWED_CONTENT_TYPES.join(','), src: 'camera') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,8 @@ en:
       document_upload:
         current_document:
           previous_document_html: "<strong>Previously attached document:</strong><br>%{file_name}"
+        document_upload_field:
+          upload_explanation_html: "Choose a file. Your document will upload when you click 'Continue'."
       representative_explanation:
         heading: What is a representative and what can they do?
         content_html: |
@@ -431,11 +433,6 @@ en:
           lead_text_unsure: To help process your case quickly, you should give reasons
             why your %{appeal_or_application} might be late. The judge will decide
             whether your %{appeal_or_application} can go ahead if it is late.
-          details_title: Help with a late %{appeal_or_application}
-          details_content: You must provide reasonable grounds for submitting your
-            %{appeal_or_application} late. These are usually unforeseen circumstances
-            or events beyond your control which meant you weren't able to meet the
-            tax tribunal deadline.
           attach_document_html: *attach_reasons_document
           page_title: Lateness reason
   activemodel:


### PR DESCRIPTION
In order to minimize the confusion some users experience, where after
selecting a file they were expecting it to upload immediately, we've
added a bit of extra copy to explain the file will upload when they
click 'Continue'.

Also, removed some extra copy in the lateness reasons step as it is
not really necessary.

https://www.pivotaltracker.com/story/show/146507353