### PR TITLE
Add new letter upload step form and controller

### DIFF
--- a/app/controllers/concerns/document_attachable.rb
+++ b/app/controllers/concerns/document_attachable.rb
@@ -25,6 +25,10 @@ module DocumentAttachable
     tribunal_case&.documents(document_key)&.any? || document.present?
   end
 
+  def check_document_presence
+    errors.add(document_attribute, :blank) unless document_provided?
+  end
+
   def valid_uploaded_file
     return true if document.nil? || document.valid?
     retrieve_document_errors

--- a/app/controllers/steps/details/letter_upload_controller.rb
+++ b/app/controllers/steps/details/letter_upload_controller.rb
@@ -1,0 +1,15 @@
+module Steps::Details
+  class LetterUploadController < Steps::DetailsStepController
+    def edit
+      @form_object = LetterUploadForm.new(
+        tribunal_case: current_tribunal_case,
+        having_problems_uploading: current_tribunal_case.having_problems_uploading,
+        having_problems_uploading_explanation: current_tribunal_case.having_problems_uploading_explanation
+      )
+    end
+
+    def update
+      update_and_advance(LetterUploadForm, as: :letter_upload)
+    end
+  end
+end

--- a/app/forms/steps/details/letter_upload_form.rb
+++ b/app/forms/steps/details/letter_upload_form.rb
@@ -1,0 +1,46 @@
+module Steps::Details
+  class LetterUploadForm < BaseForm
+    include DocumentAttachable
+
+    attribute :having_problems_uploading, Boolean
+    attribute :having_problems_uploading_explanation, String
+
+    validate :check_document_presence, unless: :having_problems_uploading
+    validates_presence_of :having_problems_uploading_explanation, if: :having_problems_uploading
+
+    def initialize(*)
+      # We add dynamically the document attribute to the attributes set, as only
+      # at runtime we know the route the user took on the decision tree
+      attribute_set << Virtus::Attribute.build(DocumentUpload, name: document_attribute)
+      super
+    end
+
+    def save
+      # The validation in #documents_uploaded below checks TribunalCase#documents,
+      # which may erroneously return an empty array if the user previously ticked
+      # "I'm having trouble" but then unticked it again.
+      # This ensures having_problems_uploading is the correct value before validation.
+      tribunal_case&.having_problems_uploading = having_problems_uploading
+      super
+    end
+
+    # TODO: the type of letter to be uploaded will depend on challenge question answers
+    def document_key
+      :original_notice_letter
+      # :review_conclusion_letter
+      # :late_review_refusal_letter
+      # :late_appeal_refusal_letter
+    end
+
+    private
+
+    def persist!
+      raise 'No TribunalCase given' unless tribunal_case
+
+      upload_document_if_present && tribunal_case.update(
+        having_problems_uploading: having_problems_uploading,
+        having_problems_uploading_explanation: having_problems_uploading ? having_problems_uploading_explanation : nil
+      )
+    end
+  end
+end

--- a/app/presenters/check_answers/closure_details_section_presenter.rb
+++ b/app/presenters/check_answers/closure_details_section_presenter.rb
@@ -11,7 +11,7 @@ module CheckAnswers
         Answer.new(:closure_hmrc_officer, tribunal_case.closure_hmrc_officer, raw: true),
         FileOrTextAnswer.new(:closure_additional_info, tribunal_case.closure_additional_info, tribunal_case.documents(:closure_additional_info).first, change_path: edit_steps_closure_additional_info_path),
         DocumentsSubmittedAnswer.new(:documents_submitted, tribunal_case.documents(:supporting_documents), change_path: edit_steps_closure_support_documents_path),
-        Answer.new(:problems_uploading_letters, tribunal_case.having_problems_uploading_explanation, raw: true, change_path: edit_steps_closure_support_documents_path)
+        Answer.new(:problems_uploading_documents, tribunal_case.having_problems_uploading_explanation, raw: true, change_path: edit_steps_closure_support_documents_path)
       ].select(&:show?)
     end
   end

--- a/app/presenters/check_answers/details_section_presenter.rb
+++ b/app/presenters/check_answers/details_section_presenter.rb
@@ -9,8 +9,8 @@ module CheckAnswers
         FileOrTextAnswer.new(:grounds_for_appeal, tribunal_case.grounds_for_appeal, tribunal_case.documents(:grounds_for_appeal).first, change_path: edit_steps_details_grounds_for_appeal_path),
         # nil file because there is no file upload field (yet)
         FileOrTextAnswer.new(:outcome, tribunal_case.outcome, nil, change_path: edit_steps_details_outcome_path),
-        DocumentsSubmittedAnswer.new(:documents_submitted, tribunal_case.documents(:supporting_documents), change_path: edit_steps_details_documents_checklist_path),
-        Answer.new(:problems_uploading_documents, tribunal_case.having_problems_uploading_explanation, raw: true, change_path: edit_steps_details_documents_checklist_path)
+        DocumentsSubmittedAnswer.new(:letters_submitted, tribunal_case.documents(:supporting_documents), change_path: edit_steps_details_documents_checklist_path),
+        Answer.new(:problems_uploading_letters, tribunal_case.having_problems_uploading_explanation, raw: true, change_path: edit_steps_details_documents_checklist_path)
       ].select(&:show?)
     end
   end

--- a/app/views/steps/closure/support_documents/edit.html.erb
+++ b/app/views/steps/closure/support_documents/edit.html.erb
@@ -23,7 +23,7 @@
       <div class="form-group util_mt-large">
         <%= f.label :having_problems_uploading, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
           <%= f.check_box :having_problems_uploading, 'aria-controls': 'unable_to_upload_panel' %>
-          <%= t('shared.file_upload.having_problems') %>
+          <%= t('.having_problems') %>
         <% end %>
 
         <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">

--- a/app/views/steps/details/letter_upload/edit.html.erb
+++ b/app/views/steps/details/letter_upload/edit.html.erb
@@ -1,0 +1,37 @@
+<% title t('.page_title') %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= step_header %>
+
+    <h1 class="heading-large"><%=t ".heading.#{@form_object.document_key}" %></h1>
+
+    <p class="lede"><%=t '.lead_text' %></p>
+
+    <p><%=t 'shared.file_upload.technical_info' %></p>
+
+    <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
+      <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'letter', ga_label: @form_object.document_key} do |f| %>
+
+        <%= document_upload_field(f, @form_object.document_key, label_text: t(".attach_document.#{@form_object.document_key}_html")) %>
+
+        <div class="form-group util_mt-large">
+          <%= f.label :having_problems_uploading, class: 'block-label selection-button-checkbox', 'data-target': 'unable_to_upload_panel' do %>
+            <%= f.check_box :having_problems_uploading, class: 'ga-checkbox', 'data-ga-label': 'having problems' %>
+            <%= t '.having_problems' %>
+          <% end %>
+
+          <div id="unable_to_upload_panel" class="panel js-hidden" aria-hidden="true">
+            <%= t 'shared.file_upload.explanation_html', contact_url: contact_page_path %>
+            <%=f.text_area :having_problems_uploading_explanation, size: '40x4', class: 'form-control form-control-3-4' %>
+          </div>
+        </div>
+
+        <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
+      <% end %>
+
+      <%= display_current_document(@form_object.document_key) %>
+    </div>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     tax_tribunal_independent: &tax_tribunal_independent "The tax tribunal is independent and doesn't have access to files from HMRC."
     attach_reasons_document: &attach_reasons_document "<strong>Attach reasons as a document</strong>"
     attach_reasons_blank_error: &attach_reasons_blank_error "You must enter reasons or attach a document"
+    blank_document: &blank_document "You must upload a file"
     blank_uploading_problems: &blank_uploading_problems "Please describe the problem"
     blank_first_name: &blank_first_name "Please enter your first name"
     blank_last_name: &blank_last_name "Please enter your last name"
@@ -202,8 +203,8 @@ en:
         edit:
           heading: Add documents to support your application (optional)
           lead_text: *tax_tribunal_independent
-          having_problems_uploading_html: I am having trouble uploading my documents
           page_title: Documents upload
+          having_problems: I am having trouble uploading my documents
       <<: *CYA_CONFIRMATION
       start:
         show:
@@ -345,6 +346,21 @@ en:
           review_conclusion_provided_html: "<strong>Review conclusion letter</strong><br>you
             will only have this if your case was reviewed"
           page_title: "Documents upload"
+      letter_upload:
+        edit:
+          page_title: Letter upload
+          lead_text: *tax_tribunal_independent
+          heading:
+            original_notice_letter: Upload the original notice or decision letter
+            review_conclusion_letter: Upload the review conclusion letter
+            late_review_refusal_letter: Upload the letter refusing your late review
+            late_appeal_refusal_letter: Upload the letter refusing your late appeal
+          attach_document:
+            original_notice_letter_html: "<strong>Attach original notice or decision letter</strong>"
+            review_conclusion_letter_html: "<strong>Attach review conclusion letter</strong>"
+            late_review_refusal_letter_html: "<strong>Attach letter refusing your late review</strong>"
+            late_appeal_refusal_letter_html: "<strong>Attach letter refusing your late appeal</strong>"
+          having_problems: I am having trouble uploading my letter
       outcome:
         edit:
           heading: Briefly say what outcome you would like
@@ -475,7 +491,7 @@ en:
         steps/closure/support_documents_form:
           attributes:
             having_problems_uploading_explanation:
-              blank: *blank_uploading_problems
+              blank: Please enter reasons why you can't upload documents
         steps/details/user_type_form:
           attributes:
             user_type:
@@ -546,6 +562,18 @@ en:
               no_documents: You must upload a file
             having_problems_uploading_explanation:
               blank: *blank_uploading_problems
+        steps/details/letter_upload_form:
+          attributes:
+            original_notice_letter_document:
+              blank: *blank_document
+            review_conclusion_letter_document:
+              blank: *blank_document
+            late_review_refusal_letter_document:
+              blank: *blank_document
+            late_appeal_refusal_letter_document:
+              blank: *blank_document
+            having_problems_uploading_explanation:
+              blank: Please enter reasons why you can't upload a letter
         steps/hardship/disputed_tax_paid_form:
           attributes:
             disputed_tax_paid:
@@ -736,7 +764,7 @@ en:
       steps_closure_additional_info_form:
         closure_additional_info: Enter reasons (optional)
       steps_closure_support_documents_form:
-        having_problems_uploading_explanation: Reasons you can't upload
+        having_problems_uploading_explanation: Enter reasons why you can't upload documents
       steps_details_user_type_form:
         user_type:
           taxpayer: 'Yes'
@@ -1005,6 +1033,9 @@ en:
       question: Desired outcome
       accessible_change_text: desired outcome
     documents_submitted:
+      question: Documents uploaded
+      accessible_change_text: documents uploaded
+    letters_submitted:
       question: Letters uploaded
       accessible_change_text: letters uploaded
     problems_uploading_documents:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
       edit_step :representative_details
       edit_step :grounds_for_appeal
       edit_step :outcome
+      edit_step :letter_upload
       edit_step :documents_checklist
       show_step :documents_upload_problems
       show_step :check_answers

--- a/spec/controllers/steps/details/letter_upload_controller_spec.rb
+++ b/spec/controllers/steps/details/letter_upload_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Details::LetterUploadController, type: :controller do
+  it_behaves_like 'an intermediate step controller', Steps::Details::LetterUploadForm, DetailsDecisionTree
+end

--- a/spec/forms/steps/details/letter_upload_form_spec.rb
+++ b/spec/forms/steps/details/letter_upload_form_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+include ActionDispatch::TestProcess
+
+RSpec.describe Steps::Details::LetterUploadForm do
+  let(:arguments) { {
+    tribunal_case: tribunal_case,
+    original_notice_letter_document: original_notice_letter_document,
+    having_problems_uploading: having_problems_uploading,
+    having_problems_uploading_explanation: having_problems_uploading_explanation
+  } }
+
+  let(:tribunal_case) { instance_double(TribunalCase, files_collection_ref: 'ABC123') }
+
+  let(:original_notice_letter_document) { nil }
+  let(:having_problems_uploading) { false }
+  let(:having_problems_uploading_explanation) { nil }
+
+  subject { described_class.new(arguments) }
+
+  before do
+    allow(tribunal_case).to receive(:documents).with(:original_notice_letter)
+    allow(tribunal_case).to receive(:having_problems_uploading=).with(having_problems_uploading)
+    # Used to retrieve already uploaded files and detect duplicates, but not part of these tests, so stubbing it
+    allow(Uploader).to receive(:list_files).and_return([])
+  end
+
+  describe '#save' do
+    context 'when having_problems_uploading is not selected' do
+      let(:having_problems_uploading) { false }
+      it { should_not validate_presence_of(:having_problems_uploading_explanation) }
+    end
+
+    context 'when having_problems_uploading is selected' do
+      let(:having_problems_uploading) { true }
+      it { should validate_presence_of(:having_problems_uploading_explanation) }
+    end
+
+    context 'when no document has been provided' do
+      let(:original_notice_letter_document) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the text field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:original_notice_letter_document]).to eq(['You must upload a file'])
+      end
+
+      context 'unless having_problems_uploading checkbox selected' do
+        let(:having_problems_uploading) { true }
+        let(:having_problems_uploading_explanation) { 'my explanation' }
+
+        it 'returns validations true' do
+          expect(subject).to be_valid
+        end
+      end
+    end
+
+    context 'when a document has been provided' do
+      context 'and it is not valid' do
+        let(:original_notice_letter_document) { fixture_file_upload('files/image.jpg', 'application/zip') }
+
+        it 'should retrieve the errors from the uploader' do
+          expect(subject.errors).to receive(:add).with(:original_notice_letter_document, :content_type).and_call_original
+          expect(subject).to_not be_valid
+        end
+      end
+
+      context 'and it is valid' do
+        let(:original_notice_letter_document) { fixture_file_upload('files/image.jpg', 'image/jpeg')  }
+
+        context 'document upload successful' do
+          it 'uploads the file' do
+            expect(Uploader).to receive(:add_file).with(hash_including(document_key: :original_notice_letter)).and_return({})
+
+            expect(tribunal_case).to receive(:update).with(
+              having_problems_uploading: having_problems_uploading,
+              having_problems_uploading_explanation: having_problems_uploading_explanation
+            ).and_return(true)
+
+            expect(subject.save).to be(true)
+          end
+        end
+
+        context 'document upload unsuccessful' do
+          it 'doesn\'t save the record' do
+            expect(tribunal_case).not_to receive(:update)
+            expect(subject).to receive(:upload_document_if_present).and_return(false)
+            expect(subject.save).to be(false)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR will introduce a new, simplified, letter upload to replace the current
documents checklist (dropzone uploader).

At the moment it is not wired up to the decision tree and thus is not visible to
the user, nor there are breaking changes with our current implementation, but
because the final PR might otherwise be too big, I decided to create at least 2
smaller PRs, being this one the first of those, to be easier to review.

The new form is very similar to the other steps we have where only one document
can be uploaded (i.e. `grounds for appeal`) with the difference it will maintain
the ability to check `having problems uploading` and go to the postal kick-out.
In summary, we remove the dropzone and replace it with a single file uploader,
and customise the view to talk about the specific letter needed to be uploaded.

https://www.pivotaltracker.com/story/show/148420071