### PR TITLE
Fix a few issues with filenames in the uploader

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -42,8 +42,11 @@ class DocumentsController < ApplicationController
     current_tribunal_case.files_collection_ref
   end
 
+  # The regexp as second argument to encode() will ensure all non-word characters are encoded,
+  # and not only those included in the REGEXP::UNSAFE which is the default behaviour.
+  # Specifically we are looking to encode problematic characters like '[' and ']'
   def filename
-    URI.encode(decoded_filename)
+    URI.encode(decoded_filename, /\W/)
   end
 
   def decoded_filename

--- a/app/models/document_upload.rb
+++ b/app/models/document_upload.rb
@@ -130,6 +130,7 @@ class DocumentUpload
   end
 
   def validate
+    add_error(:invalid_characters) unless file_name.ascii_only?
     add_error(:file_size) if file_size > MAX_FILE_SIZE.megabytes
     add_error(:content_type) unless content_type.downcase.in?(ALLOWED_CONTENT_TYPES)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1131,6 +1131,7 @@ en:
       blank: Please enter an answer
       file_size: File too big
       content_type: Unsupported file type
+      invalid_characters: Invalid file name
       response_error: Response error
       virus_detected: Virus detected
       already_confirmed: "was already confirmed, please try signing in"
@@ -1202,6 +1203,8 @@ en:
         less than %{max_size} megabytes (MB)"
       content_type: "%{file_name} is in a format we don't accept. You can upload JPG,
         PNG, GIF, PDF, Word or Excel files"
+      invalid_characters: "%{file_name} contains invalid characters. Please do not use
+        characters like £ or ¬ in the file name"
       virus_detected: "%{file_name} has a virus. You will need to resubmit a virus
         free copy"
       response_error: "%{file_name} failed to upload. Please try again"

--- a/spec/models/document_upload_spec.rb
+++ b/spec/models/document_upload_spec.rb
@@ -111,6 +111,18 @@ RSpec.describe DocumentUpload do
         expect(subject.errors).not_to be_empty
       end
     end
+
+    context 'when file is not valid due to non-ascii characters in the name' do
+      before do
+        allow(subject).to receive(:original_filename).and_return('invalid £ name.txt')
+      end
+
+      it 'should not be valid' do
+        expect(subject).to receive(:add_error).with(:invalid_characters).and_call_original
+        expect(subject.valid?).to eq(false)
+        expect(subject.errors).not_to be_empty
+      end
+    end
   end
 
   context '#file_name' do


### PR DESCRIPTION
Some problems were detected in the uploader, where some characters were
failing to upload or to be removed later on due to different encodings.

This PR ensures, in first place, we do not allow characters other than
valid ASCII in the filenames, and give a meaninful error to the user,
instead of uploading and silently modify their encoding and do not allow
the removal later on due to mismatches in the encodings.

Also, some characters like brackets are totally fine but by default
`URI.encode()` will not encode these characters, making our request to
delete a file containing square brackets fail. This has also been solved
by passing an extra argument to the encode() method to force encoding of
all non-word characters, which in turn will encode `[` and `]` properly.

https://www.pivotaltracker.com/story/show/149083759