### PR TITLE
Use created_at instead of updated_at

### DIFF
--- a/app/views/admin/other_case_types_report/index.html.erb
+++ b/app/views/admin/other_case_types_report/index.html.erb
@@ -24,7 +24,7 @@
   <tbody>
   <% @cases_with_other_type.each do |tribunal_case| %>
       <tr>
-        <td><%= l(tribunal_case.updated_at, format: :long) %></td>
+        <td><%= l(tribunal_case.created_at, format: :long) %></td>
         <td><%= tribunal_case.user_type.to_s %></td>
         <td><%= tribunal_case.intent_case_type.to_s %></td>
         <td><%= tribunal_case.case_type_other_value %></td>

--- a/app/views/admin/upload_problems_report/index.html.erb
+++ b/app/views/admin/upload_problems_report/index.html.erb
@@ -24,7 +24,7 @@
   <tbody>
     <% @cases_with_upload_problems.each do |tribunal_case| %>
       <tr>
-        <td><%= l(tribunal_case.updated_at, format: :long) %></td>
+        <td><%= l(tribunal_case.created_at, format: :long) %></td>
         <td><%= tribunal_case.user_type.to_s %></td>
         <td><%= tribunal_case.intent_case_type.to_s %></td>
         <td><%= tribunal_case.having_problems_uploading_explanation %></td>


### PR DESCRIPTION
For consistency with the controllers, and also because the `updated_at`
date can actually change if we send a case reminder email (as we update
the `case_status`).