### PR TITLE
Add new case type for SA late penalty

### DIFF
--- a/app/forms/steps/appeal/case_type_form.rb
+++ b/app/forms/steps/appeal/case_type_form.rb
@@ -7,6 +7,7 @@ module Steps::Appeal
     def self.choices
       [
         CaseType::INCOME_TAX,
+        CaseType::SELF_ASSESSMENT_LATE_PENALTY,
         CaseType::VAT,
         CaseType::CAPITAL_GAINS_TAX,
         CaseType::CORPORATION_TAX,

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -59,6 +59,7 @@ class CaseType < ValueObject
     POOL_BETTING_DUTY            = new(:pool_betting_duty,            indirect_tax_properties),
     REMOTE_GAMING_DUTY           = new(:remote_gaming_duty,           indirect_tax_properties),
     RESTORATION_CASE             = new(:restoration_case,             direct_tax: false, ask_challenged: true, appeal_or_application: :application),
+    SELF_ASSESSMENT_LATE_PENALTY = new(:self_assessment_late_penalty, direct_tax: true, ask_penalty: true, ask_challenged: true, appeal_or_application: :appeal),
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -641,6 +641,7 @@ en:
         case_type:
           income_tax_html: "<strong>Income Tax</strong><br>including tax paid through
             Pay As You Earn (PAYE) and Self Assessment"
+          self_assessment_late_penalty_html: "<strong>Penalty for late filing of self-assessment tax return</strong>"
           vat_html: "<strong>Value Added Tax (VAT)</strong>"
           capital_gains_tax_html: "<strong>Capital Gains Tax</strong>"
           corporation_tax_html: "<strong>Corporation Tax</strong>"
@@ -925,6 +926,7 @@ en:
         pool_betting_duty: Pool Betting Duty
         remote_gaming_duty: Remote Gaming Duty
         restoration_case: Restoration case
+        self_assessment_late_penalty: Penalty for late filing of self-assessment tax return
         stamp_duties: Stamp duties
         statutory_payments: Statutory payments
         student_loans: Student loans

--- a/spec/forms/steps/appeal/case_type_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_form_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Steps::Appeal::CaseTypeForm do
     it 'returns the relevant choices' do
       expect(described_class.choices).to eq(%w(
         income_tax
+        self_assessment_late_penalty
         vat
         capital_gains_tax
         corporation_tax


### PR DESCRIPTION
Based on analytics and discovery, we've decided to add to the list of
cases a new one to cater for `Self Assessment late filing penalty` as
a high volume of taxpayers were selecting the `none of the above` and
thus bypassing the challenge questions.

https://www.pivotaltracker.com/story/show/149166109

<img width="706" alt="screen shot 2017-08-02 at 15 13 15" src="https://user-images.githubusercontent.com/687910/28927418-5fd4fe90-7862-11e7-96a5-3cbd969e4a25.png">
