### PR TITLE
Add new case type Tax credits, with kickout page

### DIFF
--- a/app/controllers/steps/appeal/tax_credits_kickout_controller.rb
+++ b/app/controllers/steps/appeal/tax_credits_kickout_controller.rb
@@ -1,0 +1,6 @@
+module Steps::Appeal
+  class TaxCreditsKickoutController < Steps::AppealStepController
+    def show
+    end
+  end
+end

--- a/app/services/appeal_decision_tree.rb
+++ b/app/services/appeal_decision_tree.rb
@@ -19,6 +19,8 @@ class AppealDecisionTree < TaxTribs::DecisionTree
   def after_case_type_step
     if answer == Steps::Appeal::CaseTypeForm::SHOW_MORE
       edit(:case_type_show_more)
+    elsif tribunal_case.case_type == CaseType::TAX_CREDITS
+      show(:tax_credits_kickout)
     elsif tribunal_case.case_type.ask_challenged?
       edit('/steps/challenge/decision')
     else

--- a/app/value_objects/case_type.rb
+++ b/app/value_objects/case_type.rb
@@ -63,6 +63,7 @@ class CaseType < ValueObject
     STAMP_DUTIES                 = new(:stamp_duties,                 direct_tax_properties),
     STATUTORY_PAYMENTS           = new(:statutory_payments,           direct_tax_properties),
     STUDENT_LOANS                = new(:student_loans,                direct_tax_properties),
+    TAX_CREDITS                  = new(:tax_credits),                 # kickout
     TOBACCO_PRODUCTS_DUTY        = new(:tobacco_products_duty,        indirect_tax_properties),
     VAT                          = new(:vat,                          indirect_tax_properties),
     OTHER                        = new(:other,                        direct_tax: true, ask_hardship: true, appeal_or_application: :appeal)

--- a/app/views/steps/appeal/tax_credits_kickout/show.html.erb
+++ b/app/views/steps/appeal/tax_credits_kickout/show.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Must challenge HMRC', category: 'Kickouts' %>
+<% track_transaction name: 'Tax credits appeal', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -10,14 +10,10 @@
       <%=t '.lead_text' %>
     </p>
 
-    <p><%=t '.free_to_challenge_hmrc_heading_html' %></p>
-
-    <p>
-      <%=t '.free_to_challenge_hmrc_guidance_html' %>
-    </p>
+    <p><%=t '.appeal_text' %></p>
 
     <div class="form-group util_mt-large">
-      <a href="https://www.gov.uk/contact-hmrc" class="button"><%=t '.contact_hmrc_button' %></a>
+      <a href="https://www.gov.uk/social-security-child-support-tribunal" class="button"><%= t '.appeal_button' %></a>
     </div>
 
     <%= render partial: 'steps/shared/kickout_survey' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,13 @@ en:
           lead_text: Both figures must be shown on the same letter, either the original
             notice or review conclusion letter.
           page_title: Penalty and tax amounts
+      tax_credits_kickout:
+        show:
+          page_title: Tax credits
+          heading: You will need to appeal to a different tribunal
+          lead_text: There is a different way to appeal about tax credits, including Child Tax Credit and Working Tax Credit.
+          appeal_text: You will need to appeal to the Social Security and Child Support Tribunal.
+          appeal_button: Appeal a tax credit decision
       start:
         show:
           page_title: Start your appeal
@@ -702,6 +709,7 @@ en:
           statutory_payments_html: "<strong>Statutory payments</strong><br>for example
             statutory sick pay, maternity pay, paternity pay or adoption pay"
           student_loans_html: "<strong>Student loans</strong>"
+          tax_credits_html: "<strong>Tax credits</strong><br>including Child Tax Credit and Working Tax Credit"
           tobacco_products_duty_html: "<strong>Tobacco Products Duty</strong>"
           other_html: "<strong>None of the above</strong>"
       steps_appeal_dispute_type_form:
@@ -957,6 +965,7 @@ en:
         stamp_duties: Stamp duties
         statutory_payments: Statutory payments
         student_loans: Student loans
+        tax_credits: Tax credits
         tobacco_products_duty: Tobacco Products Duty
         vat: Value Added Tax (VAT)
     challenged_decision_direct:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       edit_step :penalty_amount
       edit_step :tax_amount
       edit_step :penalty_and_tax_amounts
+      show_step :tax_credits_kickout
     end
 
     namespace :challenge do

--- a/spec/controllers/steps/appeal/tax_credits_kickout_controller_spec.rb
+++ b/spec/controllers/steps/appeal/tax_credits_kickout_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Steps::Appeal::TaxCreditsKickoutController, type: :controller do
+  it_behaves_like 'an end point step controller'
+end

--- a/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
+++ b/spec/forms/steps/appeal/case_type_show_more_form_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Steps::Appeal::CaseTypeShowMoreForm do
         stamp_duties
         statutory_payments
         student_loans
+        tax_credits
         tobacco_products_duty
         other
       ))

--- a/spec/services/appeal_decision_tree/case_type_step_spec.rb
+++ b/spec/services/appeal_decision_tree/case_type_step_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe AppealDecisionTree, '#destination' do
   let(:tribunal_case) { instance_double(TribunalCase, case_type: case_type) }
+  let(:step_params)   { {case_type: 'anything'} }
   let(:next_step)     { nil }
   let(:case_type)     { nil }
 
@@ -13,15 +14,12 @@ RSpec.describe AppealDecisionTree, '#destination' do
   end
 
   context 'for a case asking asking `challenged question`' do
-    let(:step_params) { {case_type: 'anything'} }
-    let(:case_type)   { CaseType.new(:dummy, ask_challenged: true) }
+    let(:case_type) { CaseType.new(:dummy, ask_challenged: true) }
 
     it { is_expected.to have_destination('/steps/challenge/decision', :edit) }
   end
 
   context 'for a case not asking `challenged question`' do
-    let(:step_params) { {case_type: 'anything'} }
-
     context 'when the case type is one that should ask dispute type' do
       let(:case_type) { CaseType.new(:dummy, ask_challenged: false, ask_dispute_type: true) }
 
@@ -33,11 +31,15 @@ RSpec.describe AppealDecisionTree, '#destination' do
 
       it { is_expected.to have_destination('/steps/appeal/penalty_amount', :edit) }
     end
+  end
 
-    context 'when the case type is OTHER' do
-      let(:case_type) { CaseType::OTHER }
+  context 'when the case type is TAX_CREDITS' do
+    let(:case_type) { CaseType::TAX_CREDITS }
+    it { is_expected.to have_destination(:tax_credits_kickout, :show) }
+  end
 
-      it { is_expected.to have_destination('/steps/lateness/in_time', :edit) }
-    end
+  context 'when the case type is OTHER' do
+    let(:case_type) { CaseType::OTHER }
+    it { is_expected.to have_destination('/steps/lateness/in_time', :edit) }
   end
 end


### PR DESCRIPTION
Users have been adding tax credits under 'Other' but the judges have
confirmed these are not under the jurisdiction of the tax tribunal.

This PR add a new case radio option `Tax credits` which will direct
users to a kickout page explaining what they need to do.

https://www.pivotaltracker.com/story/show/150093581