### PR TITLE
Send representative details to GLiMR when present

### DIFF
--- a/app/models/tribunal_case.rb
+++ b/app/models/tribunal_case.rb
@@ -74,6 +74,10 @@ class TribunalCase < ApplicationRecord
     case_type.appeal_or_application
   end
 
+  def has_representative?
+    has_representative.eql?(HasRepresentative::YES)
+  end
+
   def started_by_taxpayer?
     user_type.eql?(UserType::TAXPAYER)
   end

--- a/spec/models/tribunal_case_spec.rb
+++ b/spec/models/tribunal_case_spec.rb
@@ -106,6 +106,20 @@ RSpec.describe TribunalCase, type: :model do
     end
   end
 
+  describe '#has_representative?' do
+    let(:attributes) { { has_representative: HasRepresentative.new(value) } }
+
+    context 'when value is `no`' do
+      let(:value) { :no }
+      it { expect(subject.has_representative?).to eq(false) }
+    end
+
+    context 'when value is `yes`' do
+      let(:value) { :yes }
+      it { expect(subject.has_representative?).to eq(true) }
+    end
+  end
+
   context 'when the user is the taxpayer' do
     let(:attributes) { { user_type: UserType.new(:taxpayer) } }
     describe '#started_by_taxpayer?' do


### PR DESCRIPTION
The representative details were not being sent to GLiMR, so this will
add those, if present, to the GLiMR call, in a similar way to the
taxpayer details.