### PR TITLE
Fix GLiMR code in appeals without penalty/dispute

### DIFF
--- a/app/services/tax_tribs/mapping_code_determiner.rb
+++ b/app/services/tax_tribs/mapping_code_determiner.rb
@@ -18,7 +18,7 @@ module TaxTribs::MappingCodeDeterminer
     elsif closure_case_type
       closure_case_type_mapping_code
     elsif case_type
-      case_type_mapping_code
+      appeal_case_type_mapping_code
     end
   end
 
@@ -47,13 +47,12 @@ module TaxTribs::MappingCodeDeterminer
     end
   end
 
-  def case_type_mapping_code
-    # TODO: Add further when-branches once we have additional case types
+  def appeal_case_type_mapping_code
     case case_type
-    when CaseType::OTHER
-      MappingCode::APPEAL_OTHER
-    else
+    when CaseType::RESTORATION_CASE
       MappingCode::APPN_OTHER
+    else
+      MappingCode::APPEAL_OTHER
     end
   end
 

--- a/spec/services/tax_tribs/glimr_new_case_spec.rb
+++ b/spec/services/tax_tribs/glimr_new_case_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe TaxTribs::GlimrNewCase do
     let(:glimr_params) do
       {
         jurisdictionId: 8,
-        onlineMappingCode: 'APPN_OTHER',
+        onlineMappingCode: 'APPEAL_OTHER',
         documentsURL: 'http://downloader.com/d29210a8-f2fe-4d6f-ac96-ea4f9fd66687',
         contactFirstName: 'Filomena',
         contactLastName: 'Keebler',

--- a/spec/services/tax_tribs/mapping_code_determiner_spec.rb
+++ b/spec/services/tax_tribs/mapping_code_determiner_spec.rb
@@ -108,16 +108,16 @@ RSpec.describe TaxTribs::MappingCodeDeterminer do
     it { expect{ subject.mapping_code }.to raise_error(StandardError) }
   end
 
-  context 'when the case type is about something else' do
-    let(:case_type) { CaseType::OTHER }
-
-    it { is_expected.to have_mapping_code(:appeal_other) }
-  end
-
-  context 'when there is a case type but it is an unhandled value' do
-    let(:case_type) { CaseType.new(:anything_else) }
+  context 'when the case type is restoration case' do
+    let(:case_type) { CaseType::RESTORATION_CASE }
 
     it { is_expected.to have_mapping_code(:appn_other) }
+  end
+
+  context 'when the case type is about something else' do
+    let(:case_type) { CaseType.new(:anything_else) }
+
+    it { is_expected.to have_mapping_code(:appeal_other) }
   end
 
   context 'when there is a closure case type' do


### PR DESCRIPTION
There was an edge case where an appeal without disputes nor penalties was
being sent to GLiMR with an incorrect `onlineMappingCode`.

In these cases the code must be `APPEAL_OTHER` except for a restoration
case, which must be `APPN_OTHER`.

https://www.pivotaltracker.com/story/show/150445421