### PR TITLE
Make the penalty and tax amount fields mandatory

### DIFF
--- a/app/forms/steps/appeal/penalty_amount_form.rb
+++ b/app/forms/steps/appeal/penalty_amount_form.rb
@@ -7,8 +7,16 @@ module Steps::Appeal
       PenaltyLevel.values.map(&:to_s)
     end
     validates_inclusion_of :penalty_level, in: choices
+    validates_presence_of :penalty_amount, if: :amount_required?
 
     private
+
+    def amount_required?
+      [
+        PenaltyLevel::PENALTY_LEVEL_2.to_s,
+        PenaltyLevel::PENALTY_LEVEL_3.to_s
+      ].include?(penalty_level)
+    end
 
     def penalty_level_value
       PenaltyLevel.new(penalty_level)

--- a/app/forms/steps/appeal/penalty_and_tax_amounts_form.rb
+++ b/app/forms/steps/appeal/penalty_and_tax_amounts_form.rb
@@ -3,6 +3,8 @@ module Steps::Appeal
     attribute :penalty_amount, String
     attribute :tax_amount, String
 
+    validates_presence_of :penalty_amount, :tax_amount
+
     private
 
     def persist!

--- a/app/forms/steps/appeal/tax_amount_form.rb
+++ b/app/forms/steps/appeal/tax_amount_form.rb
@@ -2,6 +2,8 @@ module Steps::Appeal
   class TaxAmountForm < BaseForm
     attribute :tax_amount, String
 
+    validates_presence_of :tax_amount
+
     private
 
     def persist!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -470,6 +470,18 @@ en:
           attributes:
             penalty_level:
               inclusion: Select a penalty or surcharge amount
+            penalty_amount:
+              blank: Enter the amount
+        steps/appeal/tax_amount_form:
+          attributes:
+            tax_amount:
+              blank: Enter the amount
+        steps/appeal/penalty_and_tax_amounts_form:
+          attributes:
+            tax_amount:
+              blank: Enter the tax amount
+            penalty_amount:
+              blank: Enter the penalty amount
         steps/challenge/decision_form:
           attributes:
             challenged_decision:
@@ -729,14 +741,14 @@ en:
           cancellation_of_registration_html: "<strong>Cancellation of registration</strong>"
           other_html: "<strong>None of the above</strong>"
       steps_appeal_penalty_amount_form:
-        penalty_amount: Enter the penalty or surcharge amount (optional)
+        penalty_amount: Enter the penalty or surcharge amount
         penalty_level:
           <<: *PENALTY_LEVELS
       steps_appeal_tax_amount_form:
-        tax_amount: Enter the amount of tax under dispute (optional)
+        tax_amount: Enter the amount of tax under dispute
       steps_appeal_penalty_and_tax_amounts_form:
-        tax_amount: Enter the amount of tax under dispute (optional)
-        penalty_amount: Enter the penalty or surcharge amount (optional)
+        tax_amount: Enter the amount of tax under dispute
+        penalty_amount: Enter the penalty or surcharge amount
       steps_challenge_decision_form:
         challenged_decision:
           <<: *YESNO

--- a/spec/forms/steps/appeal/penalty_amount_form_spec.rb
+++ b/spec/forms/steps/appeal/penalty_amount_form_spec.rb
@@ -57,15 +57,30 @@ RSpec.describe Steps::Appeal::PenaltyAmountForm do
         expect(subject.save).to be(true)
       end
 
-      context 'when penalty amount supplied' do
-        let(:penalty_amount) { 'about 12345' }
+      context 'when penalty amount is required' do
+        let(:penalty_level) { 'penalty_level_2' }
 
-        it 'saves the record' do
-          expect(tribunal_case).to receive(:update).with(
-            penalty_level: PenaltyLevel::PENALTY_LEVEL_1,
-            penalty_amount: 'about 12345'
-          ).and_return(true)
-          expect(subject.save).to be(true)
+        context 'when penalty amount is not supplied' do
+          it 'returns false' do
+            expect(subject.save).to be(false)
+          end
+
+          it 'has a validation error on the field' do
+            expect(subject).to_not be_valid
+            expect(subject.errors[:penalty_amount]).to_not be_empty
+          end
+        end
+
+        context 'when penalty amount is supplied' do
+          let(:penalty_amount) {'about 12345'}
+
+          it 'saves the record' do
+            expect(tribunal_case).to receive(:update).with(
+              penalty_level: PenaltyLevel::PENALTY_LEVEL_2,
+              penalty_amount: 'about 12345'
+            ).and_return(true)
+            expect(subject.save).to be(true)
+          end
         end
       end
     end

--- a/spec/forms/steps/appeal/penalty_and_tax_amounts_form_spec.rb
+++ b/spec/forms/steps/appeal/penalty_and_tax_amounts_form_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Steps::Appeal::PenaltyAndTaxAmountsForm do
     tax_amount: tax_amount
   } }
   let(:tribunal_case)  { instance_double(TribunalCase, penalty_amount: nil, tax_amount: nil) }
-  let(:penalty_amount) { nil }
-  let(:tax_amount)     { nil }
+  let(:penalty_amount) { 'value 1' }
+  let(:tax_amount)     { 'value 2' }
 
   subject { described_class.new(arguments) }
 
@@ -21,20 +21,50 @@ RSpec.describe Steps::Appeal::PenaltyAndTaxAmountsForm do
       end
     end
 
-    context 'when penalty and tax amounts are not given' do
-      it 'saves the record' do
-        expect(tribunal_case).to receive(:update).with(
-          penalty_amount: nil,
-          tax_amount: nil
-        ).and_return(true)
-        expect(subject.save).to be(true)
+    context 'when penalty amount is not given' do
+      let(:penalty_amount) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:penalty_amount]).to_not be_empty
+        expect(subject.errors[:tax_amount]).to be_empty
+      end
+    end
+
+    context 'when tax amount is not given' do
+      let(:tax_amount) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:tax_amount]).to_not be_empty
+        expect(subject.errors[:penalty_amount]).to be_empty
+      end
+    end
+
+    context 'when penalty nor tax amounts are given' do
+      let(:penalty_amount) { nil }
+      let(:tax_amount) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the fields' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:penalty_amount]).to_not be_empty
+        expect(subject.errors[:tax_amount]).to_not be_empty
       end
     end
 
     context 'when penalty and tax amounts are given' do
-      let(:penalty_amount) { 'value 1' }
-      let(:tax_amount)     { 'value 2' }
-
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           penalty_amount: 'value 1',

--- a/spec/forms/steps/appeal/tax_amount_form_spec.rb
+++ b/spec/forms/steps/appeal/tax_amount_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Steps::Appeal::TaxAmountForm do
     tax_amount: tax_amount
   } }
   let(:tribunal_case) { instance_double(TribunalCase, tax_amount: nil) }
-  let(:tax_amount) { nil }
+  let(:tax_amount) { 'about 12345' }
 
   subject { described_class.new(arguments) }
 
@@ -20,17 +20,19 @@ RSpec.describe Steps::Appeal::TaxAmountForm do
     end
 
     context 'when tax_amount is not given' do
-      it 'returns true' do
-        expect(tribunal_case).to receive(:update).with(
-          tax_amount: nil
-        ).and_return(true)
-        expect(subject.save).to be(true)
+      let(:tax_amount) { nil }
+
+      it 'returns false' do
+        expect(subject.save).to be(false)
+      end
+
+      it 'has a validation error on the field' do
+        expect(subject).to_not be_valid
+        expect(subject.errors[:tax_amount]).to_not be_empty
       end
     end
 
     context 'when tax_amount is given' do
-      let(:tax_amount) { 'about 12345' }
-
       it 'saves the record' do
         expect(tribunal_case).to receive(:update).with(
           tax_amount: 'about 12345'


### PR DESCRIPTION
A requirement from the Tribunal to make the penalty and tax amount
fields mandatory, instead of optional.

https://www.pivotaltracker.com/story/show/151087519