### PR TITLE
Host our own version of the cookies policy page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,9 @@ class HomeController < ApplicationController
   def contact
   end
 
+  def cookies
+  end
+
   private
 
   # [task name (used for i18n), estimated minutes to complete this task, path/url to the task]

--- a/app/views/home/cookies.en.html.erb
+++ b/app/views/home/cookies.en.html.erb
@@ -1,0 +1,163 @@
+<% title 'Cookies' %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Cookies</h1>
+
+    <p>
+      Appeal to the tax tribunal puts small files (known as ‘cookies’) onto your computer to collect information about
+      how you browse the site.
+    </p>
+
+    <p>Cookies are used to:</p>
+
+    <ul class="list list-bullet">
+      <li>remember your progress</li>
+      <li>measure how you use the website so it can be updated and improved based on your needs</li>
+    </ul>
+
+    <p>Appeal to the tax tribunal cookies aren't used to identify you personally.</p>
+
+    <p>You'll normally see a message on the site before we store a cookie on your computer.</p>
+
+    <p>Find out more about <a rel="external" target="_blank" href="http://www.aboutcookies.org">how to manage cookies</a>.</p>
+
+    <h2 class="heading-medium">How cookies are used on Appeal to the tax tribunal</h2>
+
+    <p><strong>Our introductory message</strong></p>
+
+    <p>You may see a pop-up welcome message when you first visit Appeal to the tax tribunal. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
+
+    <table>
+      <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>seen_cookie_message</td>
+        <td>Saves a message to let us know that you've seen our cookie message</td>
+        <td>1 month</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <p><strong>Remembering your progress</strong></p>
+
+    <p>We will store a cookie to remember your case progress in this computer and to expire your session after 30 minutes of inactivity.</p>
+
+    <table>
+      <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>_tax-tribunals-datacapture_session</td>
+        <td>Saves your current progress in this computer and tracks inactivity periods</td>
+        <td>After 30 minutes of inactivity or when you close your browser</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <p><strong>Measuring website usage (Google Analytics)</strong></p>
+
+    <p>We use Google Analytics software to collect information about how you use Appeal to the tax tribunal. We do this
+      to help make sure the site is meeting the needs of its users and to help us make improvements, for example
+      <a rel="external" target="_blank" href="https://insidegovuk.blog.gov.uk/2015/03/26/new-tool-to-see-trending-searches/">improving site search</a>.</p>
+
+    <p>Google Analytics stores information about:</p>
+
+    <ul class="list list-bullet">
+      <li>the pages you visit on Appeal to the tax tribunal</li>
+      <li>how long you spend on each Appeal to the tax tribunal page </li>
+      <li>how you got to the site  </li>
+      <li>what you click on while you’re visiting the site</li>
+    </ul>
+
+    <p>We don't collect or store your personal information (for example your name or address) so this information can't
+      be used to identify who you are.</p>
+
+    <p>We don’t allow Google to use or share our analytics data.</p>
+
+    <p>Google Analytics sets the following cookies:</p>
+
+    <p>Universal Analytics</p>
+
+    <table>
+      <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>_ga</td>
+        <td>This helps us count how many people visit Appeal to the tax tribunal by tracking if you've visited before
+        </td>
+        <td>2 years</td>
+      </tr>
+      <tr>
+        <td>_gid</td>
+        <td>This helps us count how many people visit Appeal to the tax tribunal by tracking if you've visited before
+        </td>
+        <td>24 hours</td>
+      </tr>
+      <tr>
+        <td>_gat</td>
+        <td>Used to manage the rate at which page view requests are made</td>
+        <td>10 minutes</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <p>Google Analytics</p>
+
+    <table>
+      <thead>
+      <tr>
+        <th>Name</th>
+        <th>Purpose</th>
+        <th>Expires</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>_utma</td>
+        <td>Like _ga, this lets us know if you've visited before, so we can count how many of our visitors are new to
+          Appeal to the tax tribunal or to a certain page
+        </td>
+        <td>2 years</td>
+      </tr>
+      <tr>
+        <td>_utmb</td>
+        <td>This works with _utmc to calculate the average length of time you spend on Appeal to the tax tribunal</td>
+        <td>30 minutes</td>
+      </tr>
+      <tr>
+        <td>_utmc</td>
+        <td>This works with _utmb to calculate when you close your browser</td>
+        <td>when you close your browser</td>
+      </tr>
+      <tr>
+        <td>_utmz</td>
+        <td>This tells us how you reached Appeal to the tax tribunal (for example from another website or a search engine)
+        </td>
+        <td>6 months</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <p>You can
+      <a rel="external" target="_blank" href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies</a>.
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/_footer_links.html.erb
+++ b/app/views/layouts/_footer_links.html.erb
@@ -6,7 +6,7 @@
     <%= link_to t('.contact'), contact_page_path %>
   </li>
   <li>
-    <%= link_to t('.cookies'), 'https://www.gov.uk/help/cookies' %>
+    <%= link_to t('.cookies'), cookies_page_path %>
   </li>
   <li>
     <%= link_to t('.terms_and_conditions'), 'https://www.gov.uk/help/terms-conditions' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,7 @@
 <% content_for?(:page_title) ? yield(:page_title) : fallback_title %>
 
+<% content_for(:cookie_message) do %><%=t '.cookie_message_html' %><% end %>
+
 <% content_for(:head) do %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1261,6 +1261,9 @@ en:
       logout: Sign out
       change_password: Change password
       your_cases: Your saved cases
+    application:
+      cookie_message_html: |
+        <p>Appeal to the tax tribunal uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
   document_upload:
     errors:
       file_size: "%{file_name} is too big. You will need to resubmit a smaller version,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
   get :closure, to: 'closure_home#index'
 
   get :contact, to: 'home#contact', as: :contact_page
+  get :cookies, to: 'home#cookies', as: :cookies_page
 
   # catch-all route
   # :nocov:

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -50,4 +50,11 @@ RSpec.describe HomeController do
       expect(response).to render_template(:contact)
     end
   end
+
+  describe '#cookies' do
+    it 'renders the expected page' do
+      get :cookies
+      expect(response).to render_template(:cookies)
+    end
+  end
 end


### PR DESCRIPTION
According to the guidelines, the cookie policy must not be linked but
instead hosted and adapted to our own service.

Also the header cookie message must link to our hosted version.

https://www.pivotaltracker.com/story/show/151042485