### PR TITLE
DRY some smoke tests steps and add sleep

### DIFF
--- a/smoke_tests/happypath/closure.feature
+++ b/smoke_tests/happypath/closure.feature
@@ -41,24 +41,18 @@ Feature: Closure Happy Path
 
     Given I drop "original_notice.docx"
     Then I should see "original_notice.docx"
-    And I should not see "format we don't accept"
-    And I should not see "Server responded with 0 code"
-    And I should not see "No files uploaded"
+    And I should not see dropzone errors
 
     Given I click the "Remove" link
     Then I should not see "original_notice.docx"
 
     Given I drop "original_notice.docx"
     Then I should see "original_notice.docx"
-    And I should not see "format we don't accept"
-    And I should not see "Server responded with 0 code"
-    And I should not see "No files uploaded"
+    And I should not see dropzone errors
 
     Given I drop "review_conclusion.docx"
     Then I should see "review_conclusion.docx"
-    And I should not see "format we don't accept"
-    And I should not see "Server responded with 0 code"
-    And I should not see "No files uploaded"
+    And I should not see dropzone errors
 
     # There is an intermittent S3 race condition where the last upload before
     # 'Check your answers' does not get stored in time to make it into the list

--- a/smoke_tests/support/dropzone_helpers.rb
+++ b/smoke_tests/support/dropzone_helpers.rb
@@ -1,7 +1,8 @@
 require 'securerandom'
 
 Then(/^I drop "(.*?)"$/) do |filename|
-	drop_in_dropzone("#{UPLOAD_EXAMPLES}/#{filename}")
+  drop_in_dropzone("#{UPLOAD_EXAMPLES}/#{filename}")
+  sleep(1)
 end
 
 def drop_in_dropzone(file_path)


### PR DESCRIPTION
This will DRY some of the closure steps, the same we did in the past with
the appeal smoke tests, and also will add a 1 second delay after dropping
a file in the dropzone to try to avoid the intermittent test failures (we
get 1 or 2 of these almost everyday).