### PR TITLE
Add a timeout explanatory note

### DIFF
--- a/app/assets/stylesheets/local/typography.scss
+++ b/app/assets/stylesheets/local/typography.scss
@@ -107,3 +107,10 @@ address {
 h2.notice {
   margin-bottom: 1em;
 }
+
+.timeout-note {
+  margin-top: 30px;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #454a4c;
+}

--- a/app/views/steps/shared/_continue_or_save.html.erb
+++ b/app/views/steps/shared/_continue_or_save.html.erb
@@ -6,3 +6,7 @@
     <%= link_to t('helpers.submit.save_and_come_back_later'), new_user_registration_path %>
   <% end %>
 </p>
+
+<div class="timeout-note">
+  <p><%= t('.timeout_note', session_timeout: Rails.configuration.x.session.expires_in_minutes) %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,6 +233,8 @@ en:
           <p>You can use a representative if you feel you need help or advice. A representative is able to receive correspondence from the tax tribunal and go to any hearings for you.</p>
           <p>You need to download and fill in an <a href="%{approval_form_href}" target="_blank" rel="noopener">authorisation form (%{approval_form_format_and_size})<span class="visuallyhidden"> (opens in new window)</span></a> if the person representing you isn't a practising barrister or solicitor.</p>
       kickout_feedback: Give your feedback. Help improve this service
+      continue_or_save:
+        timeout_note: Your session will time out after %{session_timeout} minutes of inactivity. Save your details if you want to come back later.
     details:
       user_type:
         edit:


### PR DESCRIPTION
Explanatory message about the session expiring after X minutes of
inactivity and how users can save their progress.

<img width="651" alt="screen shot 2017-09-19 at 16 35 43" src="https://user-images.githubusercontent.com/687910/30600958-a140004e-9d58-11e7-8079-cce49094bab6.png">


https://www.pivotaltracker.com/story/show/143051001