### PR TITLE
Fix CSS positioning of uploaded documents

### DIFF
--- a/app/assets/stylesheets/local/positioning_hacks.scss
+++ b/app/assets/stylesheets/local/positioning_hacks.scss
@@ -9,10 +9,10 @@
 #document_upload_main_container.uploaded_doc_true {
   .uploaded_document_container {
     position: relative;
-    top: -50px;
+    top: -140px;
   }
 
-  p.actions {
+  p.actions, p.timeout-note {
     position: relative;
     top: 150px;
   }

--- a/app/views/steps/shared/_continue_or_save.html.erb
+++ b/app/views/steps/shared/_continue_or_save.html.erb
@@ -7,6 +7,6 @@
   <% end %>
 </p>
 
-<div class="timeout-note">
-  <p><%= t('.timeout_note', session_timeout: Rails.configuration.x.session.expires_in_minutes) %></p>
-</div>
+<p class="timeout-note">
+  <%= t('.timeout_note', session_timeout: Rails.configuration.x.session.expires_in_minutes) %>
+</p>


### PR DESCRIPTION
After the introduction of a timeout footnote, the previous positioning
was off and needed updating.

Before:
<img width="702" alt="screen shot 2017-09-20 at 12 43 16" src="https://user-images.githubusercontent.com/687910/30643266-15380296-9e06-11e7-8ee8-4bdd4337aed8.png">

After:
<img width="722" alt="screen shot 2017-09-20 at 13 15 01" src="https://user-images.githubusercontent.com/687910/30643271-1a8184d4-9e06-11e7-859c-1a6036845a5d.png">
