### PR TITLE
Copy changes and removing duplication in CYA

### DIFF
--- a/app/presenters/check_answers/appeal_section_presenter.rb
+++ b/app/presenters/check_answers/appeal_section_presenter.rb
@@ -10,8 +10,7 @@ module CheckAnswers
         challenged_decision_answer,
         Answer.new(:challenged_decision_status, tribunal_case.challenged_decision_status, change_path: edit_steps_challenge_decision_status_path),
         dispute_type_answer,
-        Answer.new(:penalty_level, tribunal_case.penalty_level, change_path: edit_steps_appeal_penalty_amount_path),
-        Answer.new(:penalty_amount, tribunal_case.penalty_amount, raw: true),
+        penalty_level_or_amount_answer,
         Answer.new(:tax_amount, tribunal_case.tax_amount, raw: true)
       ].select(&:show?)
     end
@@ -31,6 +30,14 @@ module CheckAnswers
         Answer.new(:dispute_type, tribunal_case.dispute_type_other_value, raw: true, change_path: edit_steps_appeal_dispute_type_path)
       else
         Answer.new(:dispute_type, tribunal_case.dispute_type, change_path: edit_steps_appeal_dispute_type_path)
+      end
+    end
+
+    def penalty_level_or_amount_answer
+      if tribunal_case.penalty_amount.blank?
+        Answer.new(:penalty_level, tribunal_case.penalty_level)
+      else
+        Answer.new(:penalty_amount, tribunal_case.penalty_amount, raw: true)
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1082,7 +1082,7 @@ en:
       question: Letter uploaded
       accessible_change_text: letter uploaded
       quality_alert_html: |
-        <div class="quality-alert">Your %{appeal_or_application} will be returned
+        <div class="quality-alert">Your %{appeal_or_application} may be returned
         if we can't read the letter, and you risk missing the deadline.</div>
     problems_uploading_documents:
       question: Problems uploading documents
@@ -1177,7 +1177,7 @@ en:
         virus risks.
       technical_info_html: |
         We accept a <strong>good quality and legible</strong> scan or photograph.
-        Your %{appeal_or_application} will be returned if we can't read the letter,
+        Your %{appeal_or_application} may be returned if we can't read the letter,
         and you risk missing the deadline.
       dropzone_message_html: Drag and drop files here<br> <strong>or</strong><br><span
         class="faux-link" tabindex="-1">click to choose a file</span>

--- a/spec/presenters/check_answers/appeal_section_presenter_spec.rb
+++ b/spec/presenters/check_answers/appeal_section_presenter_spec.rb
@@ -11,7 +11,6 @@ module CheckAnswers
 
     before do
       allow(tribunal_case).to receive(:documents).and_return([])
-
       allow(Answer).to receive(:new).and_return(answer)
     end
 
@@ -23,7 +22,7 @@ module CheckAnswers
 
     describe '#answers' do
       it 'has the correct rows' do
-        expect(subject.answers.count).to eq(7)
+        expect(subject.answers.count).to eq(6)
 
         expect(subject.answers[0]).to eq(answer)
         expect(subject.answers[1]).to eq(answer)
@@ -31,14 +30,13 @@ module CheckAnswers
         expect(subject.answers[3]).to eq(answer)
         expect(subject.answers[4]).to eq(answer)
         expect(subject.answers[5]).to eq(answer)
-        expect(subject.answers[6]).to eq(answer)
       end
 
       context 'when the case type is other' do
         let(:case_type) { CaseType::OTHER }
 
         it 'has the correct rows' do
-          expect(subject.answers.count).to eq(7)
+          expect(subject.answers.count).to eq(6)
 
           expect(subject.answers[0]).to eq(answer)
           expect(subject.answers[1]).to eq(answer)
@@ -46,7 +44,6 @@ module CheckAnswers
           expect(subject.answers[3]).to eq(answer)
           expect(subject.answers[4]).to eq(answer)
           expect(subject.answers[5]).to eq(answer)
-          expect(subject.answers[6]).to eq(answer)
         end
       end
 
@@ -54,7 +51,7 @@ module CheckAnswers
         let(:dispute_type) { DisputeType::OTHER }
 
         it 'has the correct rows' do
-          expect(subject.answers.count).to eq(7)
+          expect(subject.answers.count).to eq(6)
 
           expect(subject.answers[0]).to eq(answer)
           expect(subject.answers[1]).to eq(answer)
@@ -62,7 +59,17 @@ module CheckAnswers
           expect(subject.answers[3]).to eq(answer)
           expect(subject.answers[4]).to eq(answer)
           expect(subject.answers[5]).to eq(answer)
-          expect(subject.answers[6]).to eq(answer)
+        end
+      end
+
+      context 'when the penalty amount is not blank' do
+        let(:dispute_type) { DisputeType::PENALTY }
+        let(:tribunal_case) {
+          TribunalCase.new(case_type: case_type, dispute_type: dispute_type, penalty_amount: '1234')
+        }
+
+        it 'has the correct rows' do
+          expect(subject.answers.count).to eq(6)
         end
       end
     end


### PR DESCRIPTION
Small copy change and removing a duplication when both the penalty level
and the amount were present.
Now only the amount will show in the check your answers page.