### PR TITLE
Bump nokogiri version due to security issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'govuk_notify_rails', '~> 2.0.0'
 gem 'govuk_template'
 gem 'jquery-rails'
 gem 'mojfile-uploader-api-client', '~> 0.8'
+# explicit declaration to bump nokogiri version due to security issues in < 1.8.1
+gem 'nokogiri', '~> 1.8.1'
 gem 'pg', '~> 0.18'
 gem 'pry-rails'
 gem 'puma', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     ministryofjustice-danger (0.1.2)
       danger (~> 5)
       danger-commit_lint (~> 0)
@@ -243,8 +243,8 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     nio4r (2.0.0)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     nokogumbo (1.4.11)
       nokogiri
     notifications-ruby-client (2.1.0)
@@ -459,6 +459,7 @@ DEPENDENCIES
   ministryofjustice-danger
   mojfile-uploader-api-client (~> 0.8)
   mutant-rspec
+  nokogiri (~> 1.8.1)
   pg (~> 0.18)
   phantomjs
   poltergeist


### PR DESCRIPTION
There is a known critical severity security vulnerability
in nokogiri < 1.8.1