### PR TITLE
Bump mail version due to security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     logstash-event (1.2.02)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.5)
+    mail (2.6.6)
       mime-types (>= 1.16, < 4)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)


### PR DESCRIPTION
This patches the SMTP injection via TO/FROM Addresses vulnerability [CVE-2015-9097](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9097)