### PR TITLE
Upgrade vulnerable gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       colored2 (~> 3.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.2)
+    crass (1.0.4)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -192,7 +192,8 @@ GEM
       activesupport (>= 4, < 5.1)
       railties (>= 4, < 5.1)
     logstash-event (1.2.02)
-    loofah (2.0.3)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -245,7 +246,7 @@ GEM
     nio4r (2.0.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    nokogumbo (1.4.11)
+    nokogumbo (1.5.0)
       nokogiri
     notifications-ruby-client (2.1.0)
       jwt (~> 1.5)
@@ -297,8 +298,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.0.3)
       actionpack (= 5.0.3)
       activesupport (= 5.0.3)
@@ -347,10 +348,10 @@ GEM
       rubocop (>= 0.42.0)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
-    sanitize (4.4.0)
+    sanitize (4.6.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
-      nokogumbo (~> 1.4.1)
+      nokogumbo (~> 1.4)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -490,4 +491,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Fixes for the following issues:

* CVE-2018-3740 - HTML INJECTION/XS
* CVE-2018-3741 - XSS VULNERABILITYS
* CVE-2018-8048 - XSS VULNERABILITY