### PR TITLE
rst 1471 welsh paper forms notice

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,6 +57,7 @@
 @import 'local/positioning_hacks';
 @import 'local/timeout_modal';
 @import 'local/spinner';
+@import 'local/notices';
 
 // Dropzone vendor styling + local customization
 @import 'dropzone';

--- a/app/assets/stylesheets/local/notices.scss
+++ b/app/assets/stylesheets/local/notices.scss
@@ -1,0 +1,5 @@
+.info-notice {
+    border-left: 1em solid #dee0e2;
+    padding: 1em 0 1em 1em;
+    margin: 2em 0;
+}

--- a/app/assets/stylesheets/local/notices.scss
+++ b/app/assets/stylesheets/local/notices.scss
@@ -1,5 +1,5 @@
 .info-notice {
-    border-left: 1em solid #dee0e2;
-    padding: 1em 0 1em 1em;
-    margin: 2em 0;
+  border-left: 1em solid #dee0e2;
+  padding: 1em 0 1em 1em;
+  margin: 2em 0;
 }

--- a/app/assets/stylesheets/local/notices.scss
+++ b/app/assets/stylesheets/local/notices.scss
@@ -2,4 +2,9 @@
   border-left: 1em solid #dee0e2;
   padding: 1em 0 1em 1em;
   margin: 2em 0;
+
+  p {
+    margin-top: 0em ;
+    margin-bottom: 0em ;
+  }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1492,6 +1492,9 @@ en:
         date of the original notice or review conclusion letter.
       description_html: |
         <p>You may be able to appeal late by giving reasons. The judge will decide if your appeal can go ahead.</p>
+        <div role="note" aria-label="Information" class="info-notice">
+          <p>This service is not currently available in Welsh, please continue or alternatively <a href="https://www.gov.uk/government/publications/notice-of-appeal-ask-a-tax-judge-to-examine-a-dispute-form-t240">apply in Welsh (Cymraeg)</a> using the paper form.</p>
+        </div>
         <h2 class="heading-medium">What you will need</h2>
         <ul class="list list-bullet">
           <li><strong>a scan or photo</strong> of the original notice or review conclusion letter</li>
@@ -1506,6 +1509,9 @@ en:
       heading: Apply to close an enquiry
       lead_text: Ask the judge to end a tax enquiry with a closure, counteraction or no-counteraction notice.
       description_html: |
+        <div role="note" aria-label="Information" class="info-notice">
+          <p>This service is not currently available in Welsh, please continue or alternatively <a href="https://www.gov.uk/government/publications/form-t245-application-to-close-enquiry">apply in Welsh (Cymraeg)</a> using the paper form.</p>
+        </div>
         <h2 class="heading-medium">What you will need</h2>
         <ul class="list list-bullet">
           <li><strong>details of the enquiry</strong> including the HMRC reference number and tax years under enquiry</li>


### PR DESCRIPTION
This PR adds a notice in the digital forms for the users, about the service being currently available only in English. 

There are plans to introduce a Welsh version in 2019, so this is an interim solution.