### PR TITLE
Upgrade gems with security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
-    ffi (1.9.18)
+    ffi (1.9.25)
     gherkin (4.1.3)
     git (1.3.0)
     glimr-api-client (0.3.2)
@@ -491,4 +491,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
Apply security patches for the `ffi` gem. 

This upgrade fixes [CVE-2018-1000201](https://nvd.nist.gov/vuln/detail/CVE-2018-1000201)