### PR TITLE
RST 1609 Google Tag Manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 ENV SENTRY_DSN                   replace_this_at_build_time
 ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
-ENV GA_TRACKING_ID               replace_this_at_build_time
+ENV GTM_TRACKING_ID              replace_this_at_build_time
 ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 ENV ZENDESK_USERNAME             replace_this_at_build_time
 ENV ZENDESK_TOKEN                replace_this_at_build_time

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -10,7 +10,7 @@ ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 ENV SENTRY_DSN                   replace_this_at_build_time
 ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
-ENV GA_TRACKING_ID               replace_this_at_build_time
+ENV GTM_TRACKING_ID               replace_this_at_build_time
 ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 ENV ZENDESK_USERNAME             replace_this_at_build_time
 ENV ZENDESK_TOKEN                replace_this_at_build_time

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -10,7 +10,7 @@ ENV MOJ_FILE_UPLOADER_ENDPOINT   replace_this_at_build_time
 ENV TAX_TRIBUNALS_DOWNLOADER_URL replace_this_at_build_time
 ENV SENTRY_DSN                   replace_this_at_build_time
 ENV GOVUK_NOTIFY_API_KEY         replace_this_at_build_time
-ENV GTM_TRACKING_ID               replace_this_at_build_time
+ENV GTM_TRACKING_ID              replace_this_at_build_time
 ENV TAX_TRIBUNAL_EMAIL           replace_this_at_build_time
 ENV ZENDESK_USERNAME             replace_this_at_build_time
 ENV ZENDESK_TOKEN                replace_this_at_build_time

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
   end
 
   def analytics_tracking_id
-    ENV['GA_TRACKING_ID']
+    ENV['GTM_TRACKING_ID']
   end
 
   def login_or_portfolio_path
@@ -63,16 +63,6 @@ module ApplicationHelper
 
   def service_homepage_url
     Rails.configuration.gds_service_homepage_url
-  end
-
-  def track_transaction(attributes)
-    return if current_tribunal_case.nil?
-
-    content_for :transaction_data, {
-      id: current_tribunal_case.id,
-      sku: current_tribunal_case.intent_case_type.to_s,
-      quantity: '1',
-    }.merge(attributes).to_json.html_safe
   end
 
   def title(page_title)

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,16 +1,12 @@
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '<%= analytics_tracking_id %>', 'auto');
-  ga('set', 'anonymizeIp', true);
-  ga('send', 'pageview');
-
-  <% if content_for?(:transaction_data) %>
-  ga('require', 'ecommerce');
-  ga('ecommerce:addItem', <%= yield(:transaction_data) %>);
-  ga('ecommerce:send');
-  <% end %>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer', '<%= analytics_tracking_id %>');
 </script>
+
+<noscript>
+  <iframe src="https://www.googletagmanager.com/ns.html?id=<%= analytics_tracking_id %>"
+height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>

--- a/app/views/layouts/analytics/_gtm_iframe.html.erb
+++ b/app/views/layouts/analytics/_gtm_iframe.html.erb
@@ -1,3 +1,5 @@
+<!-- Google Tag Manager (noscript) -->
 <noscript>
   <iframe src="https://www.googletagmanager.com/ns.html?id=<%= analytics_tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/app/views/layouts/analytics/_gtm_iframe.html.erb
+++ b/app/views/layouts/analytics/_gtm_iframe.html.erb
@@ -1,0 +1,3 @@
+<noscript>
+  <iframe src="https://www.googletagmanager.com/ns.html?id=<%= analytics_tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>

--- a/app/views/layouts/analytics/_gtm_script.html.erb
+++ b/app/views/layouts/analytics/_gtm_script.html.erb
@@ -5,8 +5,3 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer', '<%= analytics_tracking_id %>');
 </script>
-
-<noscript>
-  <iframe src="https://www.googletagmanager.com/ns.html?id=<%= analytics_tracking_id %>"
-height="0" width="0" style="display:none;visibility:hidden"></iframe>
-</noscript>

--- a/app/views/layouts/analytics/_gtm_script.html.erb
+++ b/app/views/layouts/analytics/_gtm_script.html.erb
@@ -1,3 +1,4 @@
+<!-- Google Tag Manager -->
 <script>
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -5,3 +6,4 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer', '<%= analytics_tracking_id %>');
 </script>
+<!-- End Google Tag Manager -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <% content_for(:cookie_message) do %><%=t '.cookie_message_html' %><% end %>
 
 <% content_for(:head) do %>
+  <%= render partial: 'layouts/analytics/gtm_script' if analytics_tracking_id.present? %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <!--[if lt IE 9]>
@@ -28,7 +29,8 @@
 <% end %>
 
 <% content_for(:body_start) do %>
-  <%= render partial: 'layouts/analytics' if analytics_tracking_id.present? %>
+  <%= render partial: 'layouts/analytics/gtm_iframe' if analytics_tracking_id.present? %>
+
 
   <%#
     it's easier to trigger the non-js dropzone solution than to style and tweak

--- a/app/views/steps/appeal/tax_credits_kickout/show.html.erb
+++ b/app/views/steps/appeal/tax_credits_kickout/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Tax credits appeal', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_ask_for_review/show.html.erb
+++ b/app/views/steps/challenge/must_ask_for_review/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Must ask for review', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_challenge_hmrc/show.html.erb
+++ b/app/views/steps/challenge/must_challenge_hmrc/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Must challenge HMRC', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_wait_for_challenge_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_challenge_decision/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Must wait for challenge decision', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
+++ b/app/views/steps/challenge/must_wait_for_review_decision/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Must wait for review decision', category: 'Kickouts' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/steps/closure/check_answers/resume.html.erb
+++ b/app/views/steps/closure/check_answers/resume.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Resume closure case', category: 'Save and Return' %>
 
 <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 

--- a/app/views/steps/closure/confirmation/show.html.erb
+++ b/app/views/steps/closure/confirmation/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Closure case submitted', category: 'Submissions' %>
 
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= t '.case_submitted' %></h1>

--- a/app/views/steps/details/check_answers/resume.html.erb
+++ b/app/views/steps/details/check_answers/resume.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Resume appeal case', category: 'Save and Return' %>
 
 <h1 class="heading-large"><%= translate_with_appeal_or_application '.heading' %></h1>
 

--- a/app/views/steps/details/confirmation/show.html.erb
+++ b/app/views/steps/details/confirmation/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Appeal case submitted', category: 'Submissions' %>
 
 <div class="govuk-box-highlight">
   <h1 class="bold-large"><%= t '.case_submitted' %></h1>

--- a/app/views/steps/details/documents_upload_problems/show.html.erb
+++ b/app/views/steps/details/documents_upload_problems/show.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Submit by post', category: 'Postal Submissions' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/users/logins/save_confirmation.html.erb
+++ b/app/views/users/logins/save_confirmation.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Case saved for existing account', category: 'Save and Return' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/users/registrations/save_confirmation.html.erb
+++ b/app/views/users/registrations/save_confirmation.html.erb
@@ -1,5 +1,4 @@
 <% title t('.page_title') %>
-<% track_transaction name: 'Case saved for new account', category: 'Save and Return' %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ApplicationHelper do
 
   describe '#analytics_tracking_id' do
     it 'retrieves the environment variable' do
-      expect(ENV).to receive(:[]).with('GA_TRACKING_ID')
+      expect(ENV).to receive(:[]).with('GTM_TRACKING_ID')
       helper.analytics_tracking_id
     end
   end
@@ -197,23 +197,6 @@ RSpec.describe ApplicationHelper do
     it 'should call #title with a blank value' do
       expect(helper).to receive(:title).with('')
       helper.fallback_title
-    end
-  end
-
-  describe '#track_transaction' do
-    let(:tribunal_case) { instance_double(TribunalCase, id: '12345') }
-
-    before do
-      allow(tribunal_case).to receive(:intent_case_type).and_return(CaseType::INCOME_TAX)
-      allow(helper).to receive(:current_tribunal_case).and_return(tribunal_case)
-    end
-
-    it 'sets the transaction attributes to track' do
-      helper.track_transaction(name: 'whatever')
-
-      expect(
-        helper.content_for(:transaction_data)
-      ).to eq("{\"id\":\"12345\",\"sku\":\"income_tax\",\"quantity\":\"1\",\"name\":\"whatever\"}")
     end
   end
 end


### PR DESCRIPTION
The goal of this PR is to replace Google Analytics and hardcoded GA events with Google Tag Manager to enable Web Analysts to add events as they please without depending on Devs.