### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ ENV NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID          replace_this_at_build_time
 
 RUN touch /etc/inittab
 
+# Prevent apt-get from failing to fetch updates for the removed jessie-updates suite
+RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list
+# Add alternative source which includes the removed debian-security suite
+RUN echo "deb http://security.debian.org/debian-security jessie/updates main" > /etc/apt/sources.list.d/jessie-alt-repo.list
+
 RUN apt-get update && apt-get install -y && apt-get install libcurl4-gnutls-dev -y
 
 EXPOSE $PUMA_PORT

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -28,6 +28,11 @@ ENV NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID          replace_this_at_build_time
 
 RUN touch /etc/inittab
 
+# Prevent apt-get from failing to fetch updates for the removed jessie-updates suite
+RUN echo "deb http://deb.debian.org/debian jessie main" > /etc/apt/sources.list
+# Add alternative source which includes the removed debian-security suite
+RUN echo "deb http://security.debian.org/debian-security jessie/updates main" > /etc/apt/sources.list.d/jessie-alt-repo.list
+
 RUN apt-get update && apt-get install -y && apt-get install libcurl4-gnutls-dev -y
 
 EXPOSE $PUMA_PORT


### PR DESCRIPTION
The debian team merged jessie-updates suite into master and archived it, causing `apt-get update` failures. This commit adds an alternative repo for the jessie-updates suite and removes it from the main sources.list