### PR TITLE
This behaviour is tested in the devise gem

### DIFF
--- a/spec/controllers/users/logins_controller_spec.rb
+++ b/spec/controllers/users/logins_controller_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe Users::LoginsController do
         expect(response).to redirect_to(users_login_save_confirmation_path)
       end
 
-      it 'records #last_sign_in_at' do
-        expect { do_post }.to change(user, :last_sign_in_at)
-      end
-
       context 'when the case already belongs to the user (we do not send an email)' do
         it 'does not store the signed in email address in the session' do
           do_post


### PR DESCRIPTION
The last_sign_in_at behaviour has also changed to be nil in [users' first session](https://github.com/plataformatec/devise/blob/v4.4.3/lib/devise/models/trackable.rb#L37).