### PR TITLE
Upgrade devise gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.5.3'
 
-gem 'devise', '4.4.1'
+gem 'devise', '~> 4.6.0'
 gem 'email_validator'
 gem 'glimr-api-client', '~> 0.3.2'
 gem 'govuk_elements_form_builder', '~> 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,10 +118,10 @@ GEM
     debug_inspector (0.0.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.4.1)
+    devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -317,9 +317,9 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     regexp_parser (1.3.0)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -448,7 +448,7 @@ DEPENDENCIES
   byebug
   capybara
   cucumber
-  devise (= 4.4.1)
+  devise (~> 4.6.0)
   dotenv-rails
   email_validator
   faker


### PR DESCRIPTION
This PR includes bug fixes and security patches for devise gem.

Also sorts out [CVE-2019-5421](https://github.com/plataformatec/devise/issues/4981)