### PR TITLE
RST-1946 - Catching exception for service in status check

### DIFF
--- a/app/services/tax_tribs/status.rb
+++ b/app/services/tax_tribs/status.rb
@@ -36,6 +36,8 @@ module TaxTribs
         else
           'failed'
         end
+    rescue Errno::ECONNREFUSED
+      'failed'
     end
 
     def uploader_client
@@ -50,6 +52,8 @@ module TaxTribs
                            else
                              'failed'
                            end
+    rescue PG::ConnectionBad
+      'failed'
     end
 
     def glimr_status
@@ -59,6 +63,8 @@ module TaxTribs
             'ok'
           end
         rescue GlimrApiClient::Unavailable
+          'failed'
+        rescue NoMethodError
           'failed'
         end
     end

--- a/spec/services/tax_tribs/status_spec.rb
+++ b/spec/services/tax_tribs/status_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe TaxTribs::Status do
       end
 
       specify { expect(described_class.check).to eq(status) }
+      context 'Glimr client returns nil' do
+        before do
+          allow(GlimrApiClient::Available).to receive(:call).and_return(nil)
+        end
+
+        specify { expect(described_class.check).to eq(status) }
+      end
     end
 
     context 'database unavailable' do
@@ -86,6 +93,13 @@ RSpec.describe TaxTribs::Status do
       end
 
       specify { expect(described_class.check).to eq(status) }
+      context 'DB connection is down' do
+        before do
+          allow(ActiveRecord::Base).to receive(:connection).and_raise(PG::ConnectionBad)
+        end
+
+        specify { expect(described_class.check).to eq(status) }
+      end
     end
 
     context 'uploader unavailable' do
@@ -100,6 +114,14 @@ RSpec.describe TaxTribs::Status do
       end
 
       specify { expect(described_class.check).to eq(status) }
+      context 'MojFileUploaderApiClient is down' do
+        before do
+          allow(uploader_client).to receive(:call).and_raise(Errno::ECONNREFUSED)
+        end
+
+        specify { expect(described_class.check).to eq(status) }
+      end
+
     end
   end
 end


### PR DESCRIPTION
We had an issue when the glimr was failing and the whole status page was just return 500.