### PR TITLE
Pin mutant gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'dotenv-rails'
   gem 'launchy'
-  gem 'mutant-rspec'
+  gem 'mutant-rspec', '< 0.9'
   gem 'pry-byebug'
   gem 'rspec-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -539,7 +539,7 @@ DEPENDENCIES
   logstash-event
   ministryofjustice-danger
   mojfile-uploader-api-client (~> 0.8)
-  mutant-rspec
+  mutant-rspec (< 0.9)
   nokogiri (~> 1.10.5)
   pg (~> 0.18)
   phantomjs


### PR DESCRIPTION
Mutant has changed license in v0.9 which makes things a bit more complicated. Pinning mutant to less than v0.9 for now.