### PR TITLE
RST-2867 Changes to upload paragraph text

### DIFF
--- a/app/helpers/document_upload_helper.rb
+++ b/app/helpers/document_upload_helper.rb
@@ -2,7 +2,7 @@
 # (as opposed to more than one) document.
 module DocumentUploadHelper
   # Display an upload field if no document has been uploaded for this `document_key` yet
-  def document_upload_field(form, document_key, label_text:)
+  def document_upload_field(form, document_key, label_text:, paragraph_text:)
     return if uploaded_document?(document_key)
 
     render(
@@ -10,7 +10,8 @@ module DocumentUploadHelper
       locals: {
         form:       form,
         field_name: document_field(document_key),
-        label_text: label_text
+        label_text: label_text,
+        paragraph_text: paragraph_text
       }
     )
   end

--- a/app/views/steps/closure/additional_info/edit.html.erb
+++ b/app/views/steps/closure/additional_info/edit.html.erb
@@ -11,7 +11,8 @@
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'closure', ga_label: 'additional info'} do |f| %>
         <%= f.govuk_text_area :closure_additional_info, rows: 15 %>
 
-        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html'),
+                                  paragraph_text: t('.upload_explanation_html')) %>
 
         <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
       <% end %>

--- a/app/views/steps/details/grounds_for_appeal/edit.html.erb
+++ b/app/views/steps/details/grounds_for_appeal/edit.html.erb
@@ -13,7 +13,8 @@
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'grounds', ga_label: 'grounds for appeal'} do |f| %>
         <%= f.govuk_text_area :grounds_for_appeal, rows: 15 %>
 
-        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html'),
+                                  paragraph_text: t('.upload_explanation_html')) %>
 
         <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
       <% end %>

--- a/app/views/steps/details/letter_upload/edit.html.erb
+++ b/app/views/steps/details/letter_upload/edit.html.erb
@@ -10,7 +10,8 @@
     <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'letter', ga_label: i18n_letter_type} do |f| %>
 
-        <%= document_upload_field(f, @form_object.document_key, label_text: t("shared.letter_upload.attach_document.#{i18n_letter_type}_html")) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t("shared.letter_upload.attach_document.#{i18n_letter_type}_html"),
+                                  paragraph_text: t('.upload_explanation_html')) %>
 
         <% unless uploaded_document?(@form_object.document_key) %>
           <%= f.govuk_check_boxes_fieldset :having_problems_uploading do %>

--- a/app/views/steps/details/representative_approval/edit.html.erb
+++ b/app/views/steps/details/representative_approval/edit.html.erb
@@ -24,7 +24,8 @@
 
     <div id="document_upload_main_container" class="uploaded_doc_<%= uploaded_document?(@form_object.document_key) %>">
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'representative approval', ga_label: 'representative approval'} do |f| %>
-        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html'),
+                                  paragraph_text: t('.upload_explanation_html')) %>
 
         <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
       <% end %>

--- a/app/views/steps/hardship/hardship_reason/edit.html.erb
+++ b/app/views/steps/hardship/hardship_reason/edit.html.erb
@@ -13,7 +13,8 @@
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'hardship', ga_label: 'hardship reasons'} do |f| %>
         <%= f.govuk_text_area :hardship_reason %>
 
-        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html'),
+                                  paragraph_text: t('.upload_explanation_html')) %>
 
         <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
       <% end %>

--- a/app/views/steps/lateness/lateness_reason/edit.html.erb
+++ b/app/views/steps/lateness/lateness_reason/edit.html.erb
@@ -17,7 +17,8 @@
       <%= step_form @form_object, html: {class: 'ga-fileUpload'}, data: {ga_category: 'lateness', ga_label: 'lateness reasons'} do |f| %>
         <%= f.govuk_text_area :lateness_reason, rows: 15 %>
 
-        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html')) %>
+        <%= document_upload_field(f, @form_object.document_key, label_text: t('.attach_document_html'),
+                                  paragraph_text: t('.upload_explanation_html')) %>
 
         <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
       <% end %>

--- a/app/views/steps/shared/document_upload/_document_upload_field.html.erb
+++ b/app/views/steps/shared/document_upload/_document_upload_field.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <p class="govuk-body">
-  <%=t '.upload_explanation_html' %>
+  <%= paragraph_text %>
 </p>
 
 <div class="govuk-grid-row uploader-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,8 +210,12 @@ en:
       additional_info:
         edit:
           heading: Why should the enquiry close? (optional)
-          attach_document_html: "<strong>Attach reasons as a document (optional)</strong>"
+          attach_document_html: "<strong>Attach reasons as a single document (optional)</strong>"
           page_title: Additional information
+          upload_explanation_html: |
+            <p class="govuk-body">Your document will upload when you click 'Continue'.</p>
+            <p class="govuk-body">You will have an opportunity to upload supporting documents later in the process.</p>
+
       support_documents:
         edit:
           heading: Add documents to support your application (optional)
@@ -226,8 +230,6 @@ en:
       document_upload:
         current_document:
           previous_document_html: "<strong>Previously attached document:</strong><br>%{file_name}"
-        document_upload_field:
-          upload_explanation_html: "Your document will upload when you click 'Continue'."
       representative_explanation:
         heading: What is a representative and what can they do?
         content_html: |
@@ -320,6 +322,7 @@ en:
             <strong>Upload authorisation form</strong>
             <p class="govuk-body">You can send scanned images of the form or a good quality photo.</p>
           page_title: Representative approval
+          upload_explanation_html: "Your document will upload when you click 'Continue'."
       representative_type:
         edit:
           heading:
@@ -349,8 +352,11 @@ en:
             supports your case.
           footer_description_text: You will next have to upload any supporting documents
             including any correspondence with HMRC and evidence to support your case.
-          attach_document_html: *attach_reasons_document
+          attach_document_html: "<strong>Attach reasons as a single document</strong>"
           page_title: Grounds for appeal
+          upload_explanation_html: |
+            <p class="govuk-body">Your document will upload when you click 'Continue'.</p>
+            <p class="govuk-body">You will have an opportunity to upload the original notice, decision letter or review conclusion letter later in the process.</p>
       letter_upload:
         edit:
           page_title: Letter upload
@@ -449,6 +455,7 @@ en:
             paying the tax first.
           attach_document_html: *attach_reasons_document
           page_title: Hardship reason
+          upload_explanation_html: "Your document will upload when you click 'Continue'."
     lateness:
       in_time:
         edit:
@@ -471,6 +478,7 @@ en:
             whether your %{appeal_or_application} can go ahead if it is late.
           attach_document_html: *attach_reasons_document
           page_title: Lateness reason
+          upload_explanation_html: "Your document will upload when you click 'Continue'."
   activemodel:
     errors:
       models:
@@ -1287,6 +1295,7 @@ en:
         review_conclusion_letter_html: "<strong>Attach the review conclusion letter</strong>"
         late_review_refusal_letter_html: "<strong>Attach the letter refusing your late review</strong>"
         late_appeal_refusal_letter_html: "<strong>Attach the letter refusing your late appeal</strong>"
+      upload_explanation_html: "Your document will upload when you click 'Continue'."
     password_toggle:
       show_password: Show password
       hide_password: Hide password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,6 +361,7 @@ en:
         edit:
           page_title: Letter upload
           having_problems_uploading: I am having trouble uploading my letter
+          upload_explanation_html: Your document will upload when you click 'Continue'.
       outcome:
         edit:
           heading: Briefly say what outcome you would like

--- a/spec/helpers/document_upload_helper_spec.rb
+++ b/spec/helpers/document_upload_helper_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe DocumentUploadHelper do
   end
 
   describe '#document_upload_field' do
-    subject { helper.document_upload_field(form, :some_step, label_text: 'A file') }
+    subject { helper.document_upload_field(form, :some_step, label_text: 'A file',
+                                           paragraph_text: 'Some text') }
 
     context 'when there is no document uploaded' do
       let(:documents) { [] }
@@ -21,7 +22,8 @@ RSpec.describe DocumentUploadHelper do
           locals: {
             form:       form,
             field_name: :some_step_document,
-            label_text: 'A file'
+            label_text: 'A file',
+            paragraph_text: 'Some text'
           }
         )
         subject


### PR DESCRIPTION
JIRA link:
https://tools.hmcts.net/jira/browse/RST-2867

Description:
- Extra paragraph text added to the document upload field on the details/ground_for_appeal page and closure/additional_info pages.
- Document upload field headings changed to specify 'single document'.