### PR TITLE
Rubocop fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+  require: rubocop-performance
+
   AllCops:
     Exclude:
       - 'lib/generators/step/templates/*.rb'
@@ -279,7 +281,7 @@
     Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
     Enabled: true
 
-  Performance/Sample:
+  Style/Sample:
     Description: >-
                     Use `sample` instead of `shuffle.first`,
                     `shuffle.last`, and `shuffle[Fixnum]`.
@@ -599,7 +601,7 @@
       Checks the indentation of the first non-blank non-comment line in a file.
     Enabled: false
 
-  Layout/FirstParameterIndentation:
+  Layout/IndentFirstArgument:
     Description: 'Checks the indentation of the first parameter in a method call.'
     Enabled: false
 
@@ -657,13 +659,13 @@
     StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
     Enabled: false
 
-  Layout/IndentArray:
+  Layout/IndentFirstArrayElement:
     Description: >-
                    Checks the indentation of the first element in an array
                    literal.
     Enabled: false
 
-  Layout/IndentHash:
+  Layout/IndentFirstHashElement:
     Description: 'Checks the indentation of the first key in a hash literal.'
     Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter', '~> 0.4.1'
   gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
   gem 'rubocop-rspec', require: false
   gem 'selenium-webdriver', '~> 3.142'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.3.0)
+      rubocop (>= 0.68.0)
     rubocop-rspec (1.41.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
@@ -510,6 +512,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter (~> 0.4.1)
   rubocop
+  rubocop-performance
   rubocop-rspec
   sanitize
   sassc-rails (~> 2.1.2)


### PR DESCRIPTION
- Gemfile and rubocop.yml changes to stop failing rubocop tests which probably result from updates in RST-2707.