### PR TITLE
RST-2918 details tag expansion MS Edge

### DIFF
--- a/app/assets/stylesheets/local/utilities.scss
+++ b/app/assets/stylesheets/local/utilities.scss
@@ -14,6 +14,10 @@
   clear: both;
 }
 
+.details__summary {
+  color: #1d70b8;
+  cursor: pointer;
+}
 
 /* clearfix */
 /* http://nicolasgallagher.com/micro-clearfix-hack/ */

--- a/app/views/steps/challenge/decision/edit.html.erb
+++ b/app/views/steps/challenge/decision/edit.html.erb
@@ -14,8 +14,8 @@
       <%= render partial: 'steps/shared/continue_or_save', locals: {f: f} %>
     <% end %>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary" aria-controls="details-content" aria-expanded="false">
+    <details class="govuk-details">
+      <summary class="details__summary" aria-controls="details-content" aria-expanded="false">
         <span class="govuk-details__summary-text">
           <%=t '.help_panel.heading' %>
         </span>

--- a/app/views/steps/details/representative_approval/edit.html.erb
+++ b/app/views/steps/details/representative_approval/edit.html.erb
@@ -12,7 +12,7 @@
     <p class="govuk-body"><%= t '.anytime_text' %></p>
 
     <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary" aria-controls="details-content" aria-expanded="false">
+      <summary class="details__summary" aria-controls="details-content" aria-expanded="false">
         <%= translate_for_user_type '.details_heading' %>
       </summary>
       <div class="govuk-details__text" aria-hidden="true">

--- a/app/views/steps/details/representative_approval/edit.html.erb
+++ b/app/views/steps/details/representative_approval/edit.html.erb
@@ -11,9 +11,11 @@
 
     <p class="govuk-body"><%= t '.anytime_text' %></p>
 
-    <details class="govuk-details" data-module="govuk-details">
+    <details class="govuk-details">
       <summary class="details__summary" aria-controls="details-content" aria-expanded="false">
-        <%= translate_for_user_type '.details_heading' %>
+        <span class="govuk-details__summary-text">
+          <%= translate_for_user_type '.details_heading' %>
+        </span>
       </summary>
       <div class="govuk-details__text" aria-hidden="true">
         <%= translate_for_user_type '.details_info_html' %>

--- a/app/views/steps/shared/_file_upload_requirements.html.erb
+++ b/app/views/steps/shared/_file_upload_requirements.html.erb
@@ -1,6 +1,8 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary" aria-controls="details-content" aria-expanded="false">
-    <%= t 'shared.file_upload.header' %>
+<details class="govuk-details">
+  <summary class="details__summary" aria-controls="details-content" aria-expanded="false">
+      <span class="govuk-details__summary-text">
+          <%= t 'shared.file_upload.header' %>
+      </span>
   </summary>
   <div class="govuk-details__text" aria-hidden="true">
     <%= t 'shared.file_upload.file_list_html' %>

--- a/app/views/steps/shared/_representative_explanation.html.erb
+++ b/app/views/steps/shared/_representative_explanation.html.erb
@@ -1,6 +1,8 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary" aria-controls="details-content" aria-expanded="false">
-    <%= t '.heading' %>
+<details class="govuk-details">
+  <summary class="details__summary" aria-controls="details-content" aria-expanded="false">
+      <span class="govuk-details__summary-text">
+          <%= t '.heading' %>
+      </span>
   </summary>
   <div class="govuk-details__text" aria-hidden="true">
     <%= translate_with_appeal_or_application('.content_html',


### PR DESCRIPTION
**Description**

On MS Edge details tag had a bad interaction with the details.polyfill.js
and the govuk-details__summary styling.

Removed the impactfull