### PR TITLE
RST-3296 missing noas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ LineLength:
   Max: 140
 
 MethodLength:
-  Max: 30
+  Max: 35
 
 AbcSize:
   Max: 35

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,11 @@ RUN bash -c "bundle exec rails assets:precompile RAILS_ENV=production SECRET_KEY
 RUN cp node_modules/govuk-frontend/govuk/assets/fonts/*  public/assets/govuk-frontend/govuk/assets/fonts
 RUN cp node_modules/govuk-frontend/govuk/assets/images/* public/assets/govuk-frontend/govuk/assets/images
 
-# adding daily export cron job
+## adding daily export cron job
 ADD daily-export /etc/cron.d/
+
+## adding backup noa cron job
+ADD backup_noas /etc/cron.d/
 
 # running app as a servive
 ENV PHUSION true

--- a/app/models/backup_noa.rb
+++ b/app/models/backup_noa.rb
@@ -1,0 +1,39 @@
+class BackupNoa < ApplicationRecord
+  def self.keep_noa(collection_ref:, folder:, filename:, data:)
+    if is_noa?(filename)
+      create(
+        collection_ref: collection_ref,
+        folder: folder,
+        filename: filename,
+        data: data
+      )
+      Rails.logger.info("[BACKUP_NOA] - saving NOA file #{filename}")
+    else
+      Rails.logger.info("[BACKUP_NOA] - skipping file #{filename} not a NOA")
+    end
+  end
+
+  def self.is_noa?(filename)
+    filename =~ /^TC_\d{4}_\d*_.*$/
+  end
+
+  def self.process
+    Rails.logger.info("[BACKUP_NOA] - process started")
+    find_each(&method(:re_upload))
+    Rails.logger.info("[BACKUP_NOA] - process finished")
+  end
+
+  def self.re_upload(backup)
+    Uploader.add_file(
+      collection_ref: backup.collection_ref,
+      document_key: backup.folder,
+      filename: backup.filename,
+      data: backup.data
+    )
+    backup.destroy
+    Rails.logger.info("[BACKUP_NOA] - file #{backup.filename} uploaded")
+  rescue Uploader::UploaderError
+    attempts = backup.attempts || 0
+    backup.update(attempts: attempts + 1)
+  end
+end

--- a/app/services/uploader.rb
+++ b/app/services/uploader.rb
@@ -46,7 +46,13 @@ class Uploader
       Rails.logger.tagged('add_file') {
         Rails.logger.warn('MojFileUploaderApiClient::RequestError': {error: e.inspect, backtrace: e.backtrace})
       }
-      raise UploaderError.new(e)
+      BackupNoa.keep_noa(
+        collection_ref: collection_ref,
+        folder: document_key.to_s,
+        filename: filename,
+        data: data
+      )
+      raise UploaderError.new(e) unless BackupNoa.is_noa?(filename)
     end
   end
 

--- a/backup_noas
+++ b/backup_noas
@@ -1,0 +1,1 @@
+0 2 */1 * * root /bin/bash -l -c 'cd /home/app && RAILS_ENV=production bundle exec rake backup_noas' > /proc/$(pgrep cron)/fd/1 2>&1

--- a/db/migrate/20210507132322_create_backup_noas.rb
+++ b/db/migrate/20210507132322_create_backup_noas.rb
@@ -1,0 +1,13 @@
+class CreateBackupNoas < ActiveRecord::Migration[6.0]
+  def change
+    create_table :backup_noas do |t|
+      t.string :collection_ref
+      t.string :folder
+      t.string :filename
+      t.text   :data
+      t.integer :attempts
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_140000) do
+ActiveRecord::Schema.define(version: 2021_05_07_132322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "backup_noas", force: :cascade do |t|
+    t.string "collection_ref"
+    t.string "folder"
+    t.string "filename"
+    t.text "data"
+    t.integer "attempts"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tribunal_cases", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/lib/tasks/backup_noas.rake
+++ b/lib/tasks/backup_noas.rake
@@ -1,0 +1,3 @@
+task :backup_noas => :environment do
+  BackupNoa.process
+end

--- a/spec/models/backup_noa_spec.rb
+++ b/spec/models/backup_noa_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe BackupNoa, type: :model do
+  let(:filename) { 'TC_2020_00934_HulkHogan.pdf' }
+  let(:collection_ref) { 'some-ref' }
+  let(:folder) { 'folder' }
+  let(:data) { 'some data in the file' }
+  let(:backup) do
+    double(
+      collection_ref: collection_ref,
+      folder: folder,
+      filename: filename,
+      data: data,
+      attempts: nil
+    )
+  end
+
+  before do
+    allow(Uploader).to receive(:add_file)
+    allow(backup).to receive(:destroy)
+    allow(backup).to receive(:update)
+  end
+
+  describe '.is_noa?' do
+    specify { expect(BackupNoa.is_noa?(filename)).to be_truthy }
+    specify { expect(BackupNoa.is_noa?('TC_2021_009340_Hulk_Hogan.pdf')).to be_truthy }
+    specify { expect(BackupNoa.is_noa?('TC/2021/00934_HulkHogan.pdf')).to be_falsey }
+    specify { expect(BackupNoa.is_noa?('some_other_filename.docx')).to be_falsey }
+  end
+
+  describe '.keep_noa' do
+    subject do
+      BackupNoa.keep_noa(
+        collection_ref: collection_ref,
+        folder: folder,
+        filename: filename,
+        data: data
+      )
+    end
+
+    context 'when it is a noa' do
+      it 'saves backup' do
+        expect(BackupNoa).to receive(:create).with(
+                               collection_ref: collection_ref,
+                               folder: folder,
+                               filename: filename,
+                               data: data
+                             )
+        subject
+      end
+    end
+
+    context 'when it is not a noa' do
+      let(:filename) { 'some_other_filename.docx' }
+
+      it 'does nothing' do
+        expect(BackupNoa).not_to receive(:create)
+        subject
+      end
+    end
+  end
+
+  describe '.re_upload' do
+    subject { BackupNoa.re_upload(backup) }
+
+    it 'invokes Uploader service' do
+      expect(Uploader).to receive(:add_file).with(
+                            collection_ref: collection_ref,
+                            document_key: folder,
+                            filename: filename,
+                            data: data
+                          )
+      subject
+    end
+
+    it 'delete specified backup after upload' do
+      expect(backup).to receive(:destroy)
+      subject
+    end
+
+    it 'increase attempts count when upload fails' do
+      allow(Uploader).to receive(:add_file).and_raise(Uploader::UploaderError, 'test')
+      expect(backup).to receive(:update).with(attempts: 1)
+      subject
+    end
+  end
+
+  describe '.process' do
+    it 'applies .re_upload to each backup' do
+      allow(BackupNoa).to receive(:find_each).and_yield([backup])
+      expect(BackupNoa).to receive(:re_upload)
+      BackupNoa.process
+    end
+  end
+end


### PR DESCRIPTION
**JIRA**
[RST-3296](https://tools.hmcts.net/jira/browse/RST-3296)

**Description**
Some Notice of Appeal files are missing at times

**How to reproduce the issue**
Just before submitting the NoA make the clamav service unavailable.
(It can be network connectivity issues, service momentarily overloaded ...)
It could also happened if the azure blobstorage is not accessible.

When the appeal is then submitted the following happens:
- the case is registered, via the glimr api call
- the case reference received is used to be in the filename of the noa
- the noa is uploaded.

In this scenario, the noa file fails to upload despite the retry mechanism (3 attempts) and the
user is presented an error page and the file.

**Workaround**
Store the noa for re-upload at a later time.