### PR TITLE
RST-3371-add-missing-h1

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(resource) %>
 
-    <h2 class="govuk-heading-l"><%= translate_with_appeal_or_application '.heading' %></h2>
+    <h1 class="govuk-heading-l"><%= translate_with_appeal_or_application '.heading' %></h1>
 
     <%= t '.account_warning_html' %>
     <%= t 'users.shared.password_guidelines_html' %>

--- a/features/support/page_objects/save_appeal_page.rb
+++ b/features/support/page_objects/save_appeal_page.rb
@@ -2,8 +2,8 @@ class SaveAppealPage < BasePage
   set_url '/'+ ENV['TEST_LOCALE'] +'/users/sign_up'
 
   section :content, '#main-content' do
-    element :appeal_header, 'h2', text: I18n.t('users.registrations.new.appeal_test')
-    element :closure_header, 'h2', text: I18n.t('users.registrations.new.application_test')
+    element :appeal_header, 'h1', text: I18n.t('users.registrations.new.appeal_test')
+    element :closure_header, 'h1', text: I18n.t('users.registrations.new.application_test')
     elements :login_label, '.govuk-label'
     element :email_input, '#user-email-field'
     element :password_input, '#user-password-field'


### PR DESCRIPTION
**JIRA**
[RST-3371](https://tools.hmcts.net/jira/browse/RST-3371)

**Description**
The sign up page is missing a heading level 1.

The lack of a heading level one can make navigating and understanding the page context difficult for AT users.